### PR TITLE
feat: add data freshness indicator to widget header

### DIFF
--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -2,16 +2,17 @@
   <div class="widget-wrapper">
     <div class="widget-header">
       <span class="widget-title">{{ widgetType }}</span>
+      <span class="freshness-indicator" :class="freshnessClass">{{ freshnessLabel }}</span>
       <button @click="$emit('close', widgetId)" class="close-btn">✕</button>
     </div>
     <div class="widget-content">
-      <component :is="widgetComponent"/>
+      <component :is="widgetComponent" ref="activeWidget"/>
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import TopVolume from './widgets/TopVolume.vue'
 import TopGappers from './widgets/TopGappers.vue'
 import TopGainers from './widgets/TopGainers.vue'
@@ -25,8 +26,36 @@ const widgetComponents = {
   'top-gappers': TopGappers
 }
 
-
 const widgetComponent = computed(() => widgetComponents[props.widgetType])
+
+const activeWidget = ref(null)
+const now = ref(Date.now())
+const intervalId = setInterval(() => { now.value = Date.now() }, 1000)
+onUnmounted(() => clearInterval(intervalId))
+
+const lastDataAt = computed(() => activeWidget.value?.lastDataAt ?? null)
+
+const elapsedMs = computed(() => {
+  if (lastDataAt.value === null) return null
+  return now.value - lastDataAt.value
+})
+
+const freshnessLabel = computed(() => {
+  if (lastDataAt.value === null) return 'Waiting...'
+  const s = Math.floor(elapsedMs.value / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  return `${m}m ${rem}s ago`
+})
+
+const freshnessClass = computed(() => {
+  if (lastDataAt.value === null) return 'stale'
+  const s = elapsedMs.value / 1000
+  if (s < 30) return 'fresh'
+  if (s <= 120) return 'aging'
+  return 'stale'
+})
 
 </script>
 
@@ -90,4 +119,15 @@ const widgetComponent = computed(() => widgetComponents[props.widgetType])
   flex: 1;
   overflow: auto;
 }
+
+.freshness-indicator {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-variant-numeric: tabular-nums;
+}
+
+.fresh { color: #4caf50; }
+.aging { color: #ff9800; }
+.stale { color: #f44336; }
 </style>

--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -75,7 +75,7 @@ const minPriceThreshold = ref(2)
 const maxPriceThreshold = ref(20)
 const minChangePercent = ref(10)
 
-useWebSocketClient({
+const { lastDataAt } = useWebSocketClient({
   wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',
   authKey: appConfig.apiKey || 'secret',
   feedName: 'scanners:top_gainers',
@@ -83,6 +83,8 @@ useWebSocketClient({
   onData: (data) => Object.assign(marketData, data),
   autoConnect: true
 })
+
+defineExpose({ lastDataAt })
 
 const getRelVolClass = (relVol) => {
   if (relVol >= 5) return 'extreme'

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -76,7 +76,7 @@ const maxPriceThreshold = ref(20)
 const minChangePercent = ref(10)
 
 // Initialize WebSocket client
-const { connect } = useWebSocketClient({
+const { connect, lastDataAt } = useWebSocketClient({
   wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',
   authKey: appConfig.apiKey || 'secret',
   feedName: 'scanners:top_gappers',
@@ -84,6 +84,8 @@ const { connect } = useWebSocketClient({
   onData: (data) => Object.assign(marketData, data),
   autoConnect: true
 })
+
+defineExpose({ lastDataAt })
 
 const getRelVolClass = (relVol) => {
   if (relVol >= 5) return 'extreme'

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -77,7 +77,7 @@ const showGappersOnly = ref(false)
 const minPriceThreshold = ref(2)
 const maxPriceThreshold = ref(20)
 
-useWebSocketClient({
+const { lastDataAt } = useWebSocketClient({
   wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',
   authKey: appConfig.apiKey || 'secret',
   feedName: 'scanners:top_volume',
@@ -85,6 +85,8 @@ useWebSocketClient({
   onData: (data) => Object.assign(marketData, data),
   autoConnect: true
 })
+
+defineExpose({ lastDataAt })
 
 const getRelVolClass = (relVol) => {
   if (relVol >= 5) return 'extreme'

--- a/client/src/composables/useWebSocketClient.js
+++ b/client/src/composables/useWebSocketClient.js
@@ -12,6 +12,7 @@ export function useWebSocketClient(config = {}) {
 
   const ws = ref(null)
   const isConnected = ref(false)
+  const lastDataAt = ref(null)
   const wsUrl = ref(initialWsUrl)
   const authKey = ref(initialAuthKey)
   const feedName = ref(initialFeedName)
@@ -93,8 +94,10 @@ export function useWebSocketClient(config = {}) {
         try {
           const data = JSON.parse(event.data)
           if (data.data) {
+            lastDataAt.value = Date.now()
             onData?.(data.data)
           } else if (data) {
+            lastDataAt.value = Date.now()
             onData?.(data)
           } else {
             logMessage(`⬇ ${JSON.stringify(event)}`, 'info')
@@ -154,6 +157,7 @@ export function useWebSocketClient(config = {}) {
   return {
     ws,
     isConnected,
+    lastDataAt,
     wsUrl,
     authKey,
     feedName,


### PR DESCRIPTION
Closes #3

## Summary

Adds a live-updating freshness indicator to each widget header showing how long ago data was last received via WebSocket. Color-coded: green (<30s), amber (30–120s), red (>120s / no data yet).

## Changes

- **`useWebSocketClient.js`** — Added `lastDataAt = ref(null)`, set to `Date.now()` on each valid data message; included in return value
- **`TopVolume.vue`, `TopGainers.vue`, `TopGappers.vue`** — Destructure `lastDataAt` from composable; `defineExpose({ lastDataAt })`
- **`WidgetWrapper.vue`** — Template ref on dynamic component; 1s ticker; computed freshness label + class; indicator span in header with CSS color states

## Staleness Thresholds

| State | Elapsed | Color |
|-------|---------|-------|
| Fresh | < 30s | 🟢 `#4caf50` |
| Aging | 30–120s | 🟡 `#ff9800` |
| Stale | > 120s | 🔴 `#f44336` |
| No data | — | 🔴 "Waiting..." |

Co-authored-by: Tom Pounders <git@oldschool.engineer>