### PR TITLE
feat: add automatic WebSocket reconnection with exponential backoff

### DIFF
--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -34,6 +34,8 @@ const intervalId = setInterval(() => { now.value = Date.now() }, 1000)
 onUnmounted(() => clearInterval(intervalId))
 
 const lastDataAt = computed(() => activeWidget.value?.lastDataAt ?? null)
+const isConnected = computed(() => activeWidget.value?.isConnected ?? true)
+const reconnecting = computed(() => activeWidget.value?.reconnecting ?? false)
 
 const elapsedMs = computed(() => {
   if (lastDataAt.value === null) return null
@@ -41,6 +43,8 @@ const elapsedMs = computed(() => {
 })
 
 const freshnessLabel = computed(() => {
+  if (reconnecting.value) return 'Reconnecting...'
+  if (!isConnected.value) return 'Disconnected'
   if (lastDataAt.value === null) return 'Waiting...'
   const s = Math.floor(elapsedMs.value / 1000)
   if (s < 60) return `${s}s ago`
@@ -50,6 +54,7 @@ const freshnessLabel = computed(() => {
 })
 
 const freshnessClass = computed(() => {
+  if (!isConnected.value || reconnecting.value) return 'disconnected'
   if (lastDataAt.value === null) return 'stale'
   const s = elapsedMs.value / 1000
   if (s < 30) return 'fresh'
@@ -130,4 +135,5 @@ const freshnessClass = computed(() => {
 .fresh { color: #4caf50; }
 .aging { color: #ff9800; }
 .stale { color: #f44336; }
+.disconnected { color: #ff9800; }
 </style>

--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -75,7 +75,7 @@ const minPriceThreshold = ref(2)
 const maxPriceThreshold = ref(20)
 const minChangePercent = ref(10)
 
-const { lastDataAt } = useWebSocketClient({
+const { lastDataAt, isConnected, reconnecting } = useWebSocketClient({
   wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',
   authKey: appConfig.apiKey || 'secret',
   feedName: 'scanners:top_gainers',
@@ -84,7 +84,7 @@ const { lastDataAt } = useWebSocketClient({
   autoConnect: true
 })
 
-defineExpose({ lastDataAt })
+defineExpose({ lastDataAt, isConnected, reconnecting })
 
 const getRelVolClass = (relVol) => {
   if (relVol >= 5) return 'extreme'

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -76,7 +76,7 @@ const maxPriceThreshold = ref(20)
 const minChangePercent = ref(10)
 
 // Initialize WebSocket client
-const { connect, lastDataAt } = useWebSocketClient({
+const { connect, lastDataAt, isConnected, reconnecting } = useWebSocketClient({
   wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',
   authKey: appConfig.apiKey || 'secret',
   feedName: 'scanners:top_gappers',
@@ -85,7 +85,7 @@ const { connect, lastDataAt } = useWebSocketClient({
   autoConnect: true
 })
 
-defineExpose({ lastDataAt })
+defineExpose({ lastDataAt, isConnected, reconnecting })
 
 const getRelVolClass = (relVol) => {
   if (relVol >= 5) return 'extreme'

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -77,7 +77,7 @@ const showGappersOnly = ref(false)
 const minPriceThreshold = ref(2)
 const maxPriceThreshold = ref(20)
 
-const { lastDataAt } = useWebSocketClient({
+const { lastDataAt, isConnected, reconnecting } = useWebSocketClient({
   wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',
   authKey: appConfig.apiKey || 'secret',
   feedName: 'scanners:top_volume',
@@ -86,7 +86,7 @@ const { lastDataAt } = useWebSocketClient({
   autoConnect: true
 })
 
-defineExpose({ lastDataAt })
+defineExpose({ lastDataAt, isConnected, reconnecting })
 
 const getRelVolClass = (relVol) => {
   if (relVol >= 5) return 'extreme'

--- a/client/src/composables/useWebSocketClient.js
+++ b/client/src/composables/useWebSocketClient.js
@@ -7,8 +7,13 @@ export function useWebSocketClient(config = {}) {
     feedName: initialFeedName = '',
     cacheKey: initialCacheKey = '',
     onData = null,
-    autoConnect = false
+    autoReconnect = true,
+    reconnectBaseMs = 1000,
+    reconnectMaxMs = 30000,
+    reconnectMaxAttempts = 0
   } = config
+
+  let autoConnect = config.autoConnect ?? false
 
   const ws = ref(null)
   const isConnected = ref(false)
@@ -17,6 +22,9 @@ export function useWebSocketClient(config = {}) {
   const authKey = ref(initialAuthKey)
   const feedName = ref(initialFeedName)
   const cacheKey = ref(initialCacheKey)
+  const reconnecting = ref(false)
+  const reconnectAttempts = ref(0)
+  let reconnectTimer = null
 
   function logMessage(content, type = 'message') {
     const time = new Date().toTimeString().split(' ')[0]
@@ -73,6 +81,22 @@ export function useWebSocketClient(config = {}) {
     sendMessage({ action: 'get', cache: key })
   }
 
+  function scheduleReconnect() {
+    if (!autoReconnect) return
+    if (reconnectMaxAttempts > 0 && reconnectAttempts.value >= reconnectMaxAttempts) {
+      logMessage('✗ Max reconnect attempts reached', 'error')
+      return
+    }
+    const delay = Math.min(reconnectBaseMs * 2 ** reconnectAttempts.value, reconnectMaxMs)
+    reconnectAttempts.value++
+    reconnecting.value = true
+    logMessage(`↻ Reconnecting in ${delay}ms (attempt ${reconnectAttempts.value})...`, 'info')
+    reconnectTimer = setTimeout(() => {
+      reconnecting.value = false
+      connect()
+    }, delay)
+  }
+
   function connect() {
     const url = wsUrl.value.trim()
     if (!url) {
@@ -88,6 +112,8 @@ export function useWebSocketClient(config = {}) {
       ws.value.onopen = () => {
         logMessage('✓ WebSocket connected', 'info')
         isConnected.value = true
+        reconnectAttempts.value = 0
+        reconnecting.value = false
       }
 
       ws.value.onmessage = (event) => {
@@ -115,6 +141,9 @@ export function useWebSocketClient(config = {}) {
         logMessage(`⊗ WebSocket closed (code: ${event.code})`, 'info')
         isConnected.value = false
         ws.value = null
+        if (autoConnect) {
+          scheduleReconnect()
+        }
       }
     } catch (error) {
       logMessage(`✗ Connection failed: ${error.message}`, 'error')
@@ -123,6 +152,12 @@ export function useWebSocketClient(config = {}) {
 
   function disconnect() {
     if (ws.value) {
+      autoConnect = false
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      reconnecting.value = false
       logMessage('Disconnecting...', 'info')
       ws.value.close()
     }
@@ -143,6 +178,7 @@ export function useWebSocketClient(config = {}) {
 
   // Cleanup on unmount
   onUnmounted(() => {
+    if (reconnectTimer) clearTimeout(reconnectTimer)
     if (feedName.value) {
       unsubscribe()
     }
@@ -162,6 +198,8 @@ export function useWebSocketClient(config = {}) {
     authKey,
     feedName,
     cacheKey,
+    reconnecting,
+    reconnectAttempts,
     connect,
     disconnect,
     sendMessage,


### PR DESCRIPTION
Closes #5

## Summary

Adds automatic reconnection with exponential backoff to `useWebSocketClient`. Dropped connections recover transparently without losing widget state (filters, thresholds, etc.). Reconnect fires **only on `onclose`** — never on data staleness — preserving correct off-hours behavior where the WebSocket stays connected but feeds are quiet.

## Changes

- **`useWebSocketClient.js`** — `scheduleReconnect()` with exponential backoff; resets on successful open; `disconnect()` suppresses reconnect; `autoConnect` changed to `let` for mutability; timer cleared on unmount
- **`TopVolume.vue`, `TopGainers.vue`, `TopGappers.vue`** — expose `isConnected` and `reconnecting`
- **`WidgetWrapper.vue`** — `freshnessLabel`/`freshnessClass` extended with "Reconnecting..." and "Disconnected" states (amber)

## Backoff Schedule

| Attempt | Delay |
|---------|-------|
| 1 | 1s |
| 2 | 2s |
| 3 | 4s |
| 4 | 8s |
| 5 | 16s |
| 6+ | 30s (capped) |

## Off-Hours Behavior

Market closed → WebSocket stays connected, feeds are quiet → `isConnected = true`, `lastDataAt` goes stale → indicator shows red "Xs ago". No reconnect fires. ✅

Connection drop → `onclose` fires → `scheduleReconnect()` → indicator shows amber "Reconnecting...". ✅

Co-authored-by: Tom Pounders <git@oldschool.engineer>