### PR TITLE
ci: bump Docker GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for tags
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Install build dependencies
         run: pip install -r requirements-build.txt
@@ -63,14 +63,14 @@ jobs:
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push MDP App Server Base Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./py4web.Dockerfile
@@ -83,7 +83,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push MDP App Server Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./app.Dockerfile


### PR DESCRIPTION
## Summary

Bump Docker-related GitHub Actions to versions that support Node.js 24, ahead of the **June 2, 2026** forced migration.

## Changes

| Action | Old | New |
|--------|-----|-----|
| `docker/setup-buildx-action` | `@v3` | `@v4` |
| `docker/login-action` | `@v3` | `@v4` |
| `docker/build-push-action` | `@v5` | `@v6` |

## Reference

- [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

Closes #13