### PR TITLE
fix: filter out WDS auth/subscribe ack messages in NewsFeed

### DIFF
--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -147,7 +147,9 @@ const { lastDataAt, isConnected, reconnecting } = useWebSocketClient({
   feedName: props.feedName,
   cacheKey: props.cacheKey,
   onData: (data) => {
-    const incoming = Array.isArray(data) ? data : [data]
+    const incoming = (Array.isArray(data) ? data : [data])
+      .filter(item => item && item.title)  // skip auth/subscribe ack messages
+    if (!incoming.length) return
     newsItems.value = [...incoming, ...newsItems.value].slice(0, MAX_BUFFER)
   },
   autoConnect: true,


### PR DESCRIPTION
Auth and subscribe acknowledgment messages from WDS were being passed to onData and rendered as blank rows. Filter them out by requiring `item.title` before adding to the news buffer.