### PR TITLE
feat(dashboard): widget linking framework — Phase 1 (closes #28)

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -203,8 +203,10 @@
             :widget-type="item.type"
             :is-locked="isLocked"
             :col-widths="item.colWidths || {}"
+            :link-color="item.linkColor || null"
             @close="removeWidget"
             @update-col-widths="(w) => updateColWidths(item.i, w)"
+            @update-link-color="(c) => updateLinkColor(item.i, c)"
         />
       </GridItem>
     </GridLayout>
@@ -676,6 +678,14 @@ const addWidget = (widgetType) => {
     i: `widget-${widgetCounter++}`,
     type: widgetType
   })
+}
+
+const updateLinkColor = (widgetId, linkColor) => {
+  const item = layout.value.find(i => i.i === widgetId)
+  if (item) {
+    item.linkColor = linkColor || null
+    autoSaveLayout()
+  }
 }
 
 const updateColWidths = (widgetId, colWidths) => {

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -1,7 +1,38 @@
 <template>
   <div class="widget-wrapper">
-    <div class="widget-header">
+    <div
+      class="widget-header"
+      :style="linkColor ? { borderBottom: `1px solid ${linkColorHex}`, boxShadow: `0 1px 0 0 ${linkColorHex}` } : {}"
+    >
       <span class="widget-title">{{ widgetType }}</span>
+
+      <!-- Link color selector — only when unlocked -->
+      <div v-if="!isLocked" class="link-color-selector">
+        <!-- Unlink option -->
+        <button
+          :class="['color-swatch', 'color-swatch--none', !linkColor ? 'color-swatch--active' : '']"
+          title="No link (unlinked)"
+          @click="$emit('update-link-color', null)"
+        >∅</button>
+        <!-- Color swatches -->
+        <button
+          v-for="c in LINK_COLORS"
+          :key="c.name"
+          :class="['color-swatch', linkColor === c.name ? 'color-swatch--active' : '']"
+          :style="{ background: c.hex }"
+          :title="`Link: ${c.name}`"
+          @click="$emit('update-link-color', c.name)"
+        ></button>
+      </div>
+
+      <!-- Link color dot — always visible when linked -->
+      <span
+        v-else-if="linkColor"
+        class="link-dot"
+        :style="{ background: linkColorHex }"
+        :title="`Linked: ${linkColor}`"
+      ></span>
+
       <span class="freshness-icon">{{ freshnessIcon }}</span>
       <button @click="$emit('close', widgetId)" class="close-btn">✕</button>
     </div>
@@ -11,6 +42,7 @@
         ref="activeWidget"
         :is-locked="isLocked"
         :col-widths="colWidths"
+        :link-color="linkColor"
         @update-col-widths="$emit('update-col-widths', $event)"
       />
     </div>
@@ -23,19 +55,29 @@ import TopVolume from './widgets/TopVolume.vue'
 import TopGappers from './widgets/TopGappers.vue'
 import TopGainers from './widgets/TopGainers.vue'
 import NewsFeed from './widgets/NewsFeed.vue'
+import { LINK_COLORS, LINK_COLOR_MAP } from '@/composables/useWidgetBus.js'
 
-const props = defineProps(['widgetId', 'widgetType', 'isLocked', 'colWidths'])
-defineEmits(['close', 'update-col-widths'])
+const props = defineProps({
+  widgetId:  { type: String,  required: true },
+  widgetType: { type: String, required: true },
+  isLocked:  { type: Boolean, default: true },
+  colWidths: { type: Object,  default: () => ({}) },
+  linkColor: { type: String,  default: null },
+})
+defineEmits(['close', 'update-col-widths', 'update-link-color'])
 
 const widgetComponents = {
   'top-gainers': TopGainers,
-  'top-volume': TopVolume,
+  'top-volume':  TopVolume,
   'top-gappers': TopGappers,
-  'news-feed': NewsFeed,
+  'news-feed':   NewsFeed,
 }
 
 const widgetComponent = computed(() => widgetComponents[props.widgetType])
 
+const linkColorHex = computed(() => props.linkColor ? LINK_COLOR_MAP[props.linkColor] : null)
+
+// Freshness tracking
 const activeWidget = ref(null)
 const now = ref(Date.now())
 const intervalId = setInterval(() => { now.value = Date.now() }, 1000)
@@ -45,26 +87,19 @@ const oscillating = ref(true)
 const oscillateId = setInterval(() => { oscillating.value = !oscillating.value }, 250)
 onUnmounted(() => { clearInterval(oscillateId) })
 
-const lastDataAt = computed(() => activeWidget.value?.lastDataAt ?? null)
-const isConnected = computed(() => activeWidget.value?.isConnected ?? true)
-const reconnecting = computed(() => activeWidget.value?.reconnecting ?? false)
-
-const elapsedMs = computed(() => {
-  if (lastDataAt.value === null) return null
-  return now.value - lastDataAt.value
-})
+const lastDataAt    = computed(() => activeWidget.value?.lastDataAt ?? null)
+const isConnected   = computed(() => activeWidget.value?.isConnected ?? true)
+const reconnecting  = computed(() => activeWidget.value?.reconnecting ?? false)
+const elapsedMs     = computed(() => lastDataAt.value === null ? null : now.value - lastDataAt.value)
 
 const freshnessIcon = computed(() => {
   if (!isConnected.value && !reconnecting.value) return '❌'
-  if (reconnecting.value || lastDataAt.value === null) {
-    return oscillating.value ? '🔵' : '🟣'
-  }
+  if (reconnecting.value || lastDataAt.value === null) return oscillating.value ? '🔵' : '🟣'
   const s = elapsedMs.value / 1000
   if (s < 5) return '🟢'
   if (s < 60) return '🟡'
   return '🔴'
 })
-
 </script>
 
 <style scoped>
@@ -87,7 +122,9 @@ const freshnessIcon = computed(() => {
   background: #2d2d2d;
   border-bottom: 1px solid #333;
   cursor: move;
-  gap: 8px;
+  gap: 6px;
+  /* Smooth transition when link color applied */
+  transition: border-bottom-color 0.15s, box-shadow 0.15s;
 }
 
 .widget-title {
@@ -95,12 +132,59 @@ const freshnessIcon = computed(() => {
   font-weight: 600;
   color: #fff;
   flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
+/* ── Link color selector ── */
+.link-color-selector {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
 
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+.color-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.15);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: transform 0.1s, border-color 0.1s;
+  font-size: 9px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.color-swatch:hover { transform: scale(1.3); border-color: rgba(255,255,255,0.5); }
+.color-swatch--active { border: 2px solid #fff; transform: scale(1.2); }
+
+.color-swatch--none {
+  background: #333;
+  color: #666;
+  font-size: 10px;
+}
+.color-swatch--none.color-swatch--active { color: #aaa; }
+
+/* ── Link dot (locked mode) ── */
+.link-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+/* ── Freshness + close ── */
+.freshness-icon {
+  font-size: 14px;
+  line-height: 1;
+  user-select: none;
+  flex-shrink: 0;
 }
 
 .close-btn {
@@ -116,21 +200,12 @@ const freshnessIcon = computed(() => {
   align-items: center;
   justify-content: center;
   border-radius: 3px;
+  flex-shrink: 0;
 }
-
-.close-btn:hover {
-  background: #3d3d3d;
-  color: #fff;
-}
+.close-btn:hover { background: #3d3d3d; color: #fff; }
 
 .widget-content {
   flex: 1;
   overflow: auto;
-}
-
-.freshness-icon {
-  font-size: 14px;
-  line-height: 1;
-  user-select: none;
 }
 </style>

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -142,6 +142,7 @@
  * @emits update-col-widths   - Column widths changed, payload: { time, title, source, tickers }
  */
 import { ref, computed, watch, onUnmounted } from 'vue'
+import { useWidgetBus } from '@/composables/useWidgetBus.js'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 
 const props = defineProps({
@@ -149,8 +150,11 @@ const props = defineProps({
   cacheKey:  { type: String,  default: 'news:feed:latest' },
   isLocked:  { type: Boolean, default: true },
   colWidths: { type: Object,  default: () => ({}) },
+  linkColor: { type: String,  default: null },
 })
 const emit = defineEmits(['ticker-click', 'update-col-widths'])
+
+const { setActiveTicker, activeTickers } = useWidgetBus()
 
 const appConfig   = window.__APP_CONFIG__ || {}
 const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
@@ -175,6 +179,16 @@ const tableWrap      = ref(null)
 
 // Persist R1 toggle
 watch(hasTickersOnly, (val) => localStorage.setItem(LS_HAS_TICKERS_KEY, val))
+
+// Receive ticker from bus when another linked widget broadcasts
+watch(
+  () => props.linkColor ? activeTickers[props.linkColor] : undefined,
+  (incoming) => {
+    if (props.linkColor && incoming !== undefined) {
+      activeTicker.value = incoming
+    }
+  }
+)
 
 // ── Column width management ────────────────────────────────────────────────────
 
@@ -286,7 +300,12 @@ const formatDateTime = (ts) => {
 const openDetail = (item) => { selected.value = item }
 
 const toggleTickerFilter = (ticker) => {
-  activeTicker.value = activeTicker.value === ticker ? null : ticker
+  const next = activeTicker.value === ticker ? null : ticker
+  activeTicker.value = next
+  // Broadcast to linked widgets if this widget has a link color
+  if (props.linkColor) {
+    setActiveTicker(props.linkColor, next)
+  }
 }
 
 // ── Filtered view ──────────────────────────────────────────────────────────────

--- a/client/src/composables/useWidgetBus.js
+++ b/client/src/composables/useWidgetBus.js
@@ -1,0 +1,53 @@
+/**
+ * useWidgetBus — lightweight cross-widget event bus for ticker linking.
+ *
+ * Widgets are grouped by a shared link color. When a Scanner or Alert widget
+ * calls setActiveTicker(color, ticker), all Content widgets watching that
+ * color receive the update via getActiveTicker(color) or the activeTickers map.
+ *
+ * Active ticker state is intentionally ephemeral — it resets on page reload.
+ *
+ * Usage:
+ *   import { useWidgetBus } from '@/composables/useWidgetBus.js'
+ *   const { setActiveTicker, getActiveTicker, activeTickers, LINK_COLORS } = useWidgetBus()
+ */
+import { reactive, computed } from 'vue'
+
+// 9-color palette — high contrast, distinct at a glance
+export const LINK_COLORS = [
+  { name: 'red',    hex: '#ef4444' },
+  { name: 'orange', hex: '#f97316' },
+  { name: 'yellow', hex: '#eab308' },
+  { name: 'green',  hex: '#22c55e' },
+  { name: 'blue',   hex: '#3b82f6' },
+  { name: 'violet', hex: '#8b5cf6' },
+  { name: 'pink',   hex: '#ec4899' },
+  { name: 'cyan',   hex: '#06b6d4' },
+  { name: 'white',  hex: '#e5e7eb' },
+]
+
+export const LINK_COLOR_MAP = Object.fromEntries(LINK_COLORS.map(c => [c.name, c.hex]))
+
+// Shared reactive state — single instance across all components (module singleton)
+const activeTickers = reactive(
+  Object.fromEntries(LINK_COLORS.map(c => [c.name, null]))
+)
+
+export function useWidgetBus() {
+  const setActiveTicker = (color, ticker) => {
+    if (color && color in activeTickers) {
+      activeTickers[color] = ticker || null
+    }
+  }
+
+  const getActiveTicker = (color) => {
+    if (!color || !(color in activeTickers)) return null
+    return activeTickers[color]
+  }
+
+  const clearActiveTicker = (color) => {
+    if (color && color in activeTickers) activeTickers[color] = null
+  }
+
+  return { activeTickers, setActiveTicker, getActiveTicker, clearActiveTicker, LINK_COLORS, LINK_COLOR_MAP }
+}


### PR DESCRIPTION
## What's in this PR

Phase 1 of the widget linking framework. Widgets can now be assigned a shared link color — when a ticker is clicked on one widget, all Content widgets on the same color update automatically.

---

## New: `useWidgetBus` composable

Module-singleton reactive store. 9-color palette, each slot holds the currently active ticker (or null).

```js
const { setActiveTicker, getActiveTicker, activeTickers, LINK_COLORS } = useWidgetBus()
setActiveTicker('blue', 'AAPL')   // broadcast
getActiveTicker('blue')            // → 'AAPL'
```

Ephemeral — resets on reload.

## WidgetWrapper

- **Unlocked (✏️):** 9-swatch color picker appears in header. ∅ = unlink.
- **Locked (🔒):** small colored dot shown if linked; clean if unlinked.
- **Header border:** 1px bottom border in the link color when linked.
- Color stored in layout item (`linkColor`), persists through save/load.

## NewsFeed

- Accepts `linkColor` prop.
- Ticker badge click → broadcasts to bus (if linked).
- Watches bus → auto-applies ticker filter when another widget broadcasts.
- Bi-directional: works as both source and receiver on the same color.

## DashboardGrid

- `updateLinkColor()` stores `linkColor` on layout item + autoSaves.

---

## What's next (Phase 2)

Wire top-gainers / top-gappers / top-volume to call `setActiveTicker` on ticker row click.