### PR TITLE
feat(dashboard): widget linking Phase 2 — scanner broadcast

### DIFF
--- a/client/src/components/widgets/GenericScannerTable.vue
+++ b/client/src/components/widgets/GenericScannerTable.vue
@@ -17,7 +17,9 @@
     <tr
         v-for="row in data"
         :key="row.symbol"
-        :class="rowClassFn?.(row)"
+        :class="[rowClassFn?.(row), activeTicker === row.symbol ? 'row-active' : '']"
+        style="cursor:pointer"
+        @click="$emit('row-click', row)"
     >
       <td v-for="col in columns" :key="col.key" :class="getCellClass(col, row)">
         <template v-if="col.render">
@@ -46,10 +48,11 @@ const props = defineProps({
   columns: { type: Array, required: true },
   sortKey: { type: String, default: '' },
   sortDir: { type: String, default: 'asc' },
-  rowClassFn: { type: Function, default: null }
+  rowClassFn: { type: Function, default: null },
+  activeTicker: { type: String, default: null },
 })
 
-defineEmits(['sort'])
+defineEmits(['sort', 'row-click'])
 
 const toNum = (val) => {
   const n = Number(val)
@@ -183,4 +186,6 @@ tr:hover {
 .twenty-percent-gainer { background: rgba(18, 44, 75, 0.9); }
 .fifty-percent-gainer { background: rgba(50, 4, 141, 0.9); }
 .hundred-percent-gainer { background: rgba(136, 4, 141, 0.9); }
+
+tr.row-active { outline: 1px solid rgba(255,255,255,0.25); background: rgba(255,255,255,0.06) !important; }
 </style>

--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -49,7 +49,9 @@
         :sort-key="sortKey"
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
+        :active-ticker="activeTicker"
         @sort="sortBy"
+        @row-click="onRowClick"
     />
   </div>
 </template>
@@ -58,9 +60,16 @@
 import { ref, reactive, computed } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+})
 
 const appConfig = window.__APP_CONFIG__ || {}
 const marketData = reactive([])
+const { activeTicker, onRowClick } = useScannerLink(computed(() => props.linkColor))
 
 const toNum = (val) => {
   const n = Number(val)

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -49,7 +49,9 @@
         :sort-key="sortKey"
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
+        :active-ticker="activeTicker"
         @sort="sortBy"
+        @row-click="onRowClick"
     />
   </div>
 </template>
@@ -58,9 +60,16 @@
 import { ref, reactive, computed } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+})
 
 const appConfig = window.__APP_CONFIG__ || {}
 const marketData = reactive([])
+const { activeTicker, onRowClick } = useScannerLink(computed(() => props.linkColor))
 
 const toNum = (val) => {
   const n = Number(val)

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -51,7 +51,9 @@
         :sort-key="sortKey"
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
+        :active-ticker="activeTicker"
         @sort="sortBy"
+        @row-click="onRowClick"
     />
   </div>
 </template>
@@ -60,9 +62,16 @@
 import { ref, reactive, computed } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+})
 
 const appConfig = window.__APP_CONFIG__ || {}
 const marketData = reactive([])
+const { activeTicker, onRowClick } = useScannerLink(computed(() => props.linkColor))
 
 const toNum = (val) => {
   const n = Number(val)

--- a/client/src/composables/useScannerLink.js
+++ b/client/src/composables/useScannerLink.js
@@ -1,0 +1,32 @@
+/**
+ * useScannerLink — scanner-side widget bus integration.
+ *
+ * Call in any Scanner widget to get:
+ *   - onRowClick(row): call when a row is clicked; broadcasts symbol to bus
+ *   - activeTicker: computed active ticker for this link color (for row highlight)
+ *
+ * @param {import('vue').Ref<string|null>} linkColorRef  - reactive linkColor prop
+ */
+import { computed } from 'vue'
+import { useWidgetBus } from './useWidgetBus.js'
+
+export function useScannerLink(linkColorRef) {
+  const { setActiveTicker, activeTickers } = useWidgetBus()
+
+  const activeTicker = computed(() => {
+    const color = linkColorRef.value
+    return color ? activeTickers[color] : null
+  })
+
+  const onRowClick = (row) => {
+    const color = linkColorRef.value
+    if (!color) return
+    const symbol = row.symbol || row.ticker || null
+    if (!symbol) return
+    // Toggle: clicking the active ticker clears it
+    const current = activeTickers[color]
+    setActiveTicker(color, current === symbol ? null : symbol)
+  }
+
+  return { activeTicker, onRowClick }
+}


### PR DESCRIPTION
Wires the three scanner widgets (top-gainers, top-gappers, top-volume) into the widget bus established in Phase 1 (PR #29).

## How it works

1. Assign the same link color to a Scanner widget and a NewsFeed widget (unlock dashboard → color swatches in header)
2. Click any row in the Scanner → ticker broadcasts to the bus on that color channel
3. NewsFeed auto-filters to that ticker
4. Click the same row again → clears the filter (toggle)

## New: `useScannerLink` composable

Thin wrapper over `useWidgetBus` for the Scanner side:
- `onRowClick(row)` — broadcasts `row.symbol` to bus (toggle-clears if already active)
- `activeTicker` — computed from bus; used to highlight the active row in the table

## GenericScannerTable

- Accepts `activeTicker` prop; applies `row-active` highlight class to matching row
- Emits `row-click` on tr click

## Scanner widgets

All three accept `linkColor` + `isLocked` props (already forwarded by WidgetWrapper since Phase 1).