### PR TITLE
feat(dashboard): widget linking Phase 2 + mobile responsive layout

### DIFF
--- a/client/src/components/widgets/GenericScannerTable.vue
+++ b/client/src/components/widgets/GenericScannerTable.vue
@@ -17,7 +17,9 @@
     <tr
         v-for="row in data"
         :key="row.symbol"
-        :class="rowClassFn?.(row)"
+        :class="[rowClassFn?.(row), activeTicker === row.symbol ? 'row-active' : '']"
+        style="cursor:pointer"
+        @click="$emit('row-click', row)"
     >
       <td v-for="col in columns" :key="col.key" :class="getCellClass(col, row)">
         <template v-if="col.render">
@@ -46,10 +48,11 @@ const props = defineProps({
   columns: { type: Array, required: true },
   sortKey: { type: String, default: '' },
   sortDir: { type: String, default: 'asc' },
-  rowClassFn: { type: Function, default: null }
+  rowClassFn: { type: Function, default: null },
+  activeTicker: { type: String, default: null },
 })
 
-defineEmits(['sort'])
+defineEmits(['sort', 'row-click'])
 
 const toNum = (val) => {
   const n = Number(val)
@@ -183,4 +186,6 @@ tr:hover {
 .twenty-percent-gainer { background: rgba(18, 44, 75, 0.9); }
 .fifty-percent-gainer { background: rgba(50, 4, 141, 0.9); }
 .hundred-percent-gainer { background: rgba(136, 4, 141, 0.9); }
+
+tr.row-active { outline: 1px solid rgba(255,255,255,0.25); background: rgba(255,255,255,0.06) !important; }
 </style>

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -33,7 +33,7 @@
               <span
                 v-if="!isLocked"
                 class="col-resize-handle"
-                @mousedown.stop="startResize($event, col.key)"
+                @mousedown.prevent="startResize($event, col.key)"
                 title="Drag to resize column"
               ></span>
             </th>
@@ -220,7 +220,6 @@ let resizeState = null
 
 const startResize = (e, colKey) => {
   if (props.isLocked) return
-  e.preventDefault()
   // title column is auto — we compute its current px width from DOM
   let startWidth
   if (colKey === 'title' && tableWrap.value) {

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -33,7 +33,7 @@
               <span
                 v-if="!isLocked"
                 class="col-resize-handle"
-                @mousedown.prevent="startResize($event, col.key)"
+                @mousedown.stop="startResize($event, col.key)"
                 title="Drag to resize column"
               ></span>
             </th>
@@ -220,6 +220,7 @@ let resizeState = null
 
 const startResize = (e, colKey) => {
   if (props.isLocked) return
+  e.preventDefault()
   // title column is auto — we compute its current px width from DOM
   let startWidth
   if (colKey === 'title' && tableWrap.value) {

--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -49,7 +49,9 @@
         :sort-key="sortKey"
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
+        :active-ticker="activeTicker"
         @sort="sortBy"
+        @row-click="onRowClick"
     />
   </div>
 </template>
@@ -58,9 +60,16 @@
 import { ref, reactive, computed } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+})
 
 const appConfig = window.__APP_CONFIG__ || {}
 const marketData = reactive([])
+const { activeTicker, onRowClick } = useScannerLink(computed(() => props.linkColor))
 
 const toNum = (val) => {
   const n = Number(val)

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -49,7 +49,9 @@
         :sort-key="sortKey"
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
+        :active-ticker="activeTicker"
         @sort="sortBy"
+        @row-click="onRowClick"
     />
   </div>
 </template>
@@ -58,9 +60,16 @@
 import { ref, reactive, computed } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+})
 
 const appConfig = window.__APP_CONFIG__ || {}
 const marketData = reactive([])
+const { activeTicker, onRowClick } = useScannerLink(computed(() => props.linkColor))
 
 const toNum = (val) => {
   const n = Number(val)

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -51,7 +51,9 @@
         :sort-key="sortKey"
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
+        :active-ticker="activeTicker"
         @sort="sortBy"
+        @row-click="onRowClick"
     />
   </div>
 </template>
@@ -60,9 +62,16 @@
 import { ref, reactive, computed } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+})
 
 const appConfig = window.__APP_CONFIG__ || {}
 const marketData = reactive([])
+const { activeTicker, onRowClick } = useScannerLink(computed(() => props.linkColor))
 
 const toNum = (val) => {
   const n = Number(val)

--- a/client/src/composables/useScannerLink.js
+++ b/client/src/composables/useScannerLink.js
@@ -1,0 +1,32 @@
+/**
+ * useScannerLink — scanner-side widget bus integration.
+ *
+ * Call in any Scanner widget to get:
+ *   - onRowClick(row): call when a row is clicked; broadcasts symbol to bus
+ *   - activeTicker: computed active ticker for this link color (for row highlight)
+ *
+ * @param {import('vue').Ref<string|null>} linkColorRef  - reactive linkColor prop
+ */
+import { computed } from 'vue'
+import { useWidgetBus } from './useWidgetBus.js'
+
+export function useScannerLink(linkColorRef) {
+  const { setActiveTicker, activeTickers } = useWidgetBus()
+
+  const activeTicker = computed(() => {
+    const color = linkColorRef.value
+    return color ? activeTickers[color] : null
+  })
+
+  const onRowClick = (row) => {
+    const color = linkColorRef.value
+    if (!color) return
+    const symbol = row.symbol || row.ticker || null
+    if (!symbol) return
+    // Toggle: clicking the active ticker clears it
+    const current = activeTickers[color]
+    setActiveTicker(color, current === symbol ? null : symbol)
+  }
+
+  return { activeTicker, onRowClick }
+}


### PR DESCRIPTION
## Phase 2: Scanner → Bus broadcast

Wires top-gainers, top-gappers, top-volume into the widget bus.

- Click a row in a Scanner widget → broadcasts ticker to all linked Content widgets on the same color channel
- Active row highlighted; click same row again to clear (toggle)
- New `useScannerLink` composable handles bus wiring for Scanner widgets

## NewsFeed: source inlined into headline

Removed dedicated Source column. Renders as `{HEADLINE} — {source}` in muted text. Frees ~110px for headline content.

## Mobile responsive layout (< 640px)

**DashboardGrid:**
- `isMobile` ref reactive on window resize
- Phone (< 640px): vertical stack of widgets, no grid drag/resize, collapsed toolbar (widget-add only)
- Tablet/desktop (≥ 640px): unchanged

**NewsFeed on phone:**
- Card layout: time + tickers on top row, full-width headline below
- No table columns, no resize handles
- Source inlined into headline card

**WidgetWrapper:**
- Forwards `isMobile` to inner widget
- `widget-wrapper--mobile` class: auto height, 320–480px range