### PR TITLE
feat(mobile): responsive layout + NewsFeed source inline

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -1,10 +1,18 @@
 <template>
   <header class="dashboard-header">
-    <h1>Stock Scanner Dashboard</h1>
+    <h1 class="dashboard-title">Stock Scanner Dashboard</h1>
     <div v-if="appConfig" class="status success">Connected</div>
     <div v-else class="status error">Error</div>
 
-    <div v-if="appConfig" class="layout-controls">
+    <!-- Mobile toolbar: just widget add -->
+    <div v-if="appConfig && isMobile" class="layout-controls layout-controls--mobile">
+      <div class="widget-menu">
+        <WidgetMenu @add-widget="addWidget" />
+      </div>
+    </div>
+
+    <!-- Desktop toolbar: full controls -->
+    <div v-if="appConfig && !isMobile" class="layout-controls">
 
       <div class="widget-menu">
         <WidgetMenu @add-widget="addWidget" />
@@ -179,7 +187,30 @@
   </div>
 
   <div class="dashboard">
+    <!-- Mobile: simple vertical stack (< 640px) -->
+    <div v-if="isMobile" class="mobile-stack">
+      <div
+          v-for="item in layout"
+          :key="item.i"
+          class="mobile-widget"
+      >
+        <WidgetWrapper
+            :widget-id="item.i"
+            :widget-type="item.type"
+            :is-locked="true"
+            :col-widths="item.colWidths || {}"
+            :link-color="item.linkColor || null"
+            :is-mobile="true"
+            @close="removeWidget"
+            @update-col-widths="(w) => updateColWidths(item.i, w)"
+            @update-link-color="(c) => updateLinkColor(item.i, c)"
+        />
+      </div>
+    </div>
+
+    <!-- Desktop/tablet: grid layout -->
     <GridLayout
+        v-else
         v-model:layout="layout"
         :col-num="12"
         :row-height="30"
@@ -204,6 +235,7 @@
             :is-locked="isLocked"
             :col-widths="item.colWidths || {}"
             :link-color="item.linkColor || null"
+            :is-mobile="false"
             @close="removeWidget"
             @update-col-widths="(w) => updateColWidths(item.i, w)"
             @update-link-color="(c) => updateLinkColor(item.i, c)"
@@ -221,6 +253,11 @@ import WidgetMenu from './WidgetMenu.vue'
 import WidgetWrapper from './WidgetWrapper.vue'
 
 const appConfig = window.__APP_CONFIG__ || {};
+
+// Responsive: phone < 640px gets stacked layout; tablet/desktop keeps grid
+const MOBILE_BREAKPOINT = 640
+const isMobile = ref(window.innerWidth < MOBILE_BREAKPOINT)
+const onResize = () => { isMobile.value = window.innerWidth < MOBILE_BREAKPOINT }
 
 const STORAGE_KEY = 'dashboard-layouts'
 const DEFAULT_KEY = 'dashboard-default-layout'
@@ -716,12 +753,14 @@ const handleClickOutside = (e) => {
 
 // Lifecycle
 onMounted(() => {
+  window.addEventListener('resize', onResize)
   loadFromStorage()
   loadDefaultLayout()
   document.addEventListener('click', handleClickOutside)
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('resize', onResize)
   document.removeEventListener('click', handleClickOutside)
   if (autoSaveTimeout) clearTimeout(autoSaveTimeout)
   if (hoverTimeout) clearTimeout(hoverTimeout)
@@ -1147,5 +1186,31 @@ onBeforeUnmount(() => {
 
 .auth-required button:hover {
   background: #3d3d3d;
+}
+
+/* ── Mobile (< 640px) ── */
+@media (max-width: 639px) {
+  .dashboard-title { font-size: 15px; }
+
+  .layout-controls--mobile {
+    display: flex;
+    align-items: center;
+  }
+
+  .mobile-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 6px;
+  }
+
+  .mobile-widget {
+    width: 100%;
+    /* Fixed heights per widget type handled by inner widget */
+  }
+
+  .mobile-widget .widget-wrapper {
+    border-radius: 6px;
+  }
 }
 </style>

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="widget-wrapper">
+  <div :class="['widget-wrapper', isMobile ? 'widget-wrapper--mobile' : '']">
     <div
       class="widget-header"
       :style="linkColor ? { borderBottom: `1px solid ${linkColorHex}`, boxShadow: `0 1px 0 0 ${linkColorHex}` } : {}"
@@ -43,6 +43,7 @@
         :is-locked="isLocked"
         :col-widths="colWidths"
         :link-color="linkColor"
+        :is-mobile="isMobile"
         @update-col-widths="$emit('update-col-widths', $event)"
       />
     </div>
@@ -58,11 +59,12 @@ import NewsFeed from './widgets/NewsFeed.vue'
 import { LINK_COLORS, LINK_COLOR_MAP } from '@/composables/useWidgetBus.js'
 
 const props = defineProps({
-  widgetId:  { type: String,  required: true },
-  widgetType: { type: String, required: true },
-  isLocked:  { type: Boolean, default: true },
-  colWidths: { type: Object,  default: () => ({}) },
-  linkColor: { type: String,  default: null },
+  widgetId:   { type: String,  required: true },
+  widgetType: { type: String,  required: true },
+  isLocked:   { type: Boolean, default: true },
+  colWidths:  { type: Object,  default: () => ({}) },
+  linkColor:  { type: String,  default: null },
+  isMobile:   { type: Boolean, default: false },
 })
 defineEmits(['close', 'update-col-widths', 'update-link-color'])
 
@@ -207,5 +209,12 @@ const freshnessIcon = computed(() => {
 .widget-content {
   flex: 1;
   overflow: auto;
+}
+
+/* Mobile: fixed heights so widgets don't collapse */
+.widget-wrapper--mobile {
+  height: auto;
+  min-height: 320px;
+  max-height: 480px;
 }
 </style>

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -17,8 +17,35 @@
       </span>
     </div>
 
-    <!-- Table -->
-    <div class="news-table-wrap" ref="tableWrap">
+    <!-- Mobile: card list -->
+    <div v-if="isMobile" class="news-card-list">
+      <div
+        v-for="(item, idx) in filteredNews"
+        :key="idx"
+        class="news-card"
+        @click="openDetail(item)"
+      >
+        <div class="news-card-header">
+          <span class="news-card-time">{{ formatTime(item.publishDate) }}</span>
+          <span
+            v-for="co in usCompanies(item)"
+            :key="co.ticker"
+            :class="['ticker-tag', activeTicker === co.ticker ? 'ticker-tag--active' : '']"
+            @click.stop="toggleTickerFilter(co.ticker)"
+          >{{ co.ticker }}</span>
+        </div>
+        <div class="news-card-title">
+          <span :class="['sentiment-dot', sentimentClass(item.sentiment)]" :title="item.sentiment"></span>
+          {{ item.title }}<span v-if="item.source" class="headline-source"> — {{ shortSource(item.source) }}</span>
+        </div>
+      </div>
+      <div v-if="filteredNews.length === 0" class="news-empty">
+        {{ newsItems.length === 0 ? 'No articles yet.' : 'No articles match the current filter.' }}
+      </div>
+    </div>
+
+    <!-- Desktop: table -->
+    <div v-else class="news-table-wrap" ref="tableWrap">
       <table class="news-table" :style="tableStyle">
         <thead>
           <tr>
@@ -52,9 +79,8 @@
                 :class="['sentiment-dot', sentimentClass(item.sentiment)]"
                 :title="item.sentiment"
               ></span>
-              {{ item.title }}
+              {{ item.title }}<span v-if="item.source" class="headline-source"> — {{ shortSource(item.source) }}</span>
             </td>
-            <td class="col-source">{{ shortSource(item.source) }}</td>
             <td class="col-tickers">
               <span
                 v-for="co in usCompanies(item)"
@@ -66,13 +92,13 @@
             </td>
           </tr>
           <tr v-if="filteredNews.length === 0">
-            <td colspan="4" class="news-empty">
+            <td colspan="3" class="news-empty">
               {{ newsItems.length === 0 ? 'No articles yet.' : 'No articles match the current filter.' }}
             </td>
           </tr>
         </tbody>
       </table>
-    </div>
+    </div><!-- end desktop table (v-else) -->
 
     <!-- Detail modal -->
     <Teleport to="body">
@@ -151,6 +177,7 @@ const props = defineProps({
   isLocked:  { type: Boolean, default: true },
   colWidths: { type: Object,  default: () => ({}) },
   linkColor: { type: String,  default: null },
+  isMobile:  { type: Boolean, default: false },
 })
 const emit = defineEmits(['ticker-click', 'update-col-widths'])
 
@@ -161,13 +188,12 @@ const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
 const LS_HAS_TICKERS_KEY = 'newsfeed:hasTickersOnly'
 
 // Default widths (px)
-const DEFAULT_WIDTHS = { time: 90, title: 0, source: 110, tickers: 130 }
+const DEFAULT_WIDTHS = { time: 90, title: 0, tickers: 130 }
 // title=0 means "auto" — fills remaining space via table-layout:fixed percentage trick
 
 const columns = [
   { key: 'time',    label: 'Time'     },
   { key: 'title',   label: 'Headline' },
-  { key: 'source',  label: 'Source'   },
   { key: 'tickers', label: 'Tickers'  },
 ]
 
@@ -449,7 +475,6 @@ const filteredNews = computed(() => {
 
 .col-time   { color: #888; font-size: 12px; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .col-title  { color: #ddd; font-size: 13px; line-height: 1.4; }
-.col-source { color: #888; font-size: 12px; }
 .col-tickers { white-space: normal; vertical-align: top; }
 
 /* Sentiment dot */
@@ -467,6 +492,14 @@ const filteredNews = computed(() => {
 .sentiment-dot.positive { background: #22c55e; }
 .sentiment-dot.negative { background: #ef4444; }
 .sentiment-dot.neutral  { background: #555; }
+
+/* Inline source in headline */
+.headline-source {
+  color: #555;
+  font-size: 11px;
+  font-weight: 400;
+  margin-left: 2px;
+}
 
 /* Ticker tags */
 .ticker-tag {
@@ -598,4 +631,44 @@ const filteredNews = computed(() => {
 .modal-company { display: flex; align-items: center; gap: 8px; }
 .company-name     { font-size: 12px; color: #999; flex: 1; }
 .company-exchange { font-size: 10px; color: #555; }
+
+/* ── Mobile card layout ── */
+.news-card-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.news-card {
+  padding: 7px 8px;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.news-card:hover { background: #222; }
+
+.news-card-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.news-card-time {
+  font-size: 11px;
+  color: #666;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.news-card-title {
+  font-size: 13px;
+  color: #ddd;
+  line-height: 1.4;
+}
 </style>


### PR DESCRIPTION
## NewsFeed: source inlined into headline

Removed dedicated Source column. Renders as `{HEADLINE} — {source}` in muted smaller text. Frees ~110px of horizontal space on all screen sizes.

## Mobile responsive layout (< 640px)

**DashboardGrid:**
- `isMobile` ref reactive on window resize (< 640px threshold)
- Phone: vertical stack of widgets — no grid drag/resize, collapsed toolbar (widget-add only)
- Tablet/desktop (≥ 640px): unchanged

**NewsFeed on phone:**
- Card layout: time + tickers header row, full-width headline + source below
- No table columns, no resize handles needed

**WidgetWrapper:**
- Forwards `isMobile` to inner widget
- `widget-wrapper--mobile`: auto height, 320–480px range