### PR TITLE
fix: two z-index bugs — scanner volume bar over header, mobile dropdown behind button

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -1235,6 +1235,7 @@ onBeforeUnmount(() => {
   .custom-select--mobile {
     min-width: 110px;
     max-width: 150px;
+    position: relative;
   }
 
   .custom-select--mobile .select-trigger {
@@ -1244,6 +1245,7 @@ onBeforeUnmount(() => {
 
   .custom-select--mobile .select-dropdown {
     font-size: 12px;
+    z-index: 9999;
   }
 
   .mobile-stack {

--- a/client/src/components/widgets/GenericScannerTable.vue
+++ b/client/src/components/widgets/GenericScannerTable.vue
@@ -101,6 +101,7 @@ th {
   background: #2d2d2d;
   position: sticky;
   top: 0;
+  z-index: 1;
   padding: 10px 8px;
   font-size: 13px;
   font-weight: 600;
@@ -122,6 +123,7 @@ td {
   padding: 8px;
   font-size: 13px;
   border-bottom: 1px solid #2a2a2a;
+  position: relative;
 }
 
 tr:hover {


### PR DESCRIPTION
**Bug 1 — Volume bar over sticky column header**
`volume-bar` is `position:absolute` but `td` had no `position:relative`, so it leaked out of its cell into the table stacking context and rendered over the sticky `th`. Fix: `position:relative` on `td` + `z-index:1` on `th`.

**Bug 2 — Mobile layout dropdown appears behind WidgetMenu button**
`select-dropdown` had `z-index:100` but rendered behind the WidgetMenu in the mobile toolbar. Fix: `z-index:9999` override on mobile + `position:relative` on the wrapper for correct absolute anchor.