### PR TITLE
fix(NewsFeed): deduplicate articles by link on ingest

### DIFF
--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -299,7 +299,11 @@ const { lastDataAt, isConnected, reconnecting } = useWebSocketClient({
   onData: (data) => {
     const incoming = (Array.isArray(data) ? data : [data]).filter(item => item && item.title)
     if (!incoming.length) return
-    newsItems.value = [...incoming, ...newsItems.value]
+    // Dedup by link — prevents duplicates from cache load + live pub/sub overlap
+    const seen = new Set(newsItems.value.map(a => a.link))
+    const fresh = incoming.filter(a => !seen.has(a.link))
+    if (!fresh.length) return
+    newsItems.value = [...fresh, ...newsItems.value]
   },
   autoConnect: true,
 })


### PR DESCRIPTION
Cache load (up to 1,000 articles on connect) + live pub/sub can deliver the same article twice. Filter incoming by `link` against existing items before prepending.