### PR TITLE
feat(NewsFeed): send limit to WDS on initial cache fetch (closes #47 step 3)

### DIFF
--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -238,7 +238,12 @@ const searchQuery    = ref('')
 const LS_MAX_ARTICLES_KEY = 'newsfeed:maxArticles'
 const MAX_ARTICLES_OPTIONS = [50, 100, 500, 1000, 2000]
 const maxArticles = ref(parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
-watch(maxArticles, v => localStorage.setItem(LS_MAX_ARTICLES_KEY, String(v)))
+watch(maxArticles, v => {
+  localStorage.setItem(LS_MAX_ARTICLES_KEY, String(v))
+  cacheLimit.value = v
+  newsItems.value = []
+  getCache(v)
+})
 const hasTickersOnly = ref(localStorage.getItem(LS_HAS_TICKERS_KEY) === 'true')
 const tableWrap      = ref(null)
 
@@ -320,11 +325,12 @@ onUnmounted(() => {
 
 // ── WebSocket ──────────────────────────────────────────────────────────────────
 
-const { lastDataAt, isConnected, reconnecting } = useWebSocketClient({
+const { lastDataAt, isConnected, reconnecting, getCache, cacheLimit } = useWebSocketClient({
   wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',
   authKey: appConfig.apiKey || 'secret',
   feedName: props.feedName,
   cacheKey: props.cacheKey,
+  cacheLimit: maxArticles.value,
   onData: (data) => {
     const incoming = (Array.isArray(data) ? data : [data]).filter(item => item && item.title)
     if (!incoming.length) return

--- a/client/src/composables/useWebSocketClient.js
+++ b/client/src/composables/useWebSocketClient.js
@@ -6,6 +6,7 @@ export function useWebSocketClient(config = {}) {
     authKey: initialAuthKey = 'secret',
     feedName: initialFeedName = '',
     cacheKey: initialCacheKey = '',
+    cacheLimit: initialCacheLimit = 0,
     onData = null,
     autoReconnect = true,
     reconnectBaseMs = 1000,
@@ -22,6 +23,7 @@ export function useWebSocketClient(config = {}) {
   const authKey = ref(initialAuthKey)
   const feedName = ref(initialFeedName)
   const cacheKey = ref(initialCacheKey)
+  const cacheLimit = ref(initialCacheLimit)
   const reconnecting = ref(false)
   const reconnectAttempts = ref(0)
   let reconnectTimer = null
@@ -72,13 +74,15 @@ export function useWebSocketClient(config = {}) {
     sendMessage({ action: 'unsubscribe', feed })
   }
 
-  function getCache() {
+  function getCache(limit = 0) {
     const key = cacheKey.value.trim()
     if (!key) {
       logMessage('✗ ERROR: Cache key is required', 'error')
       return
     }
-    sendMessage({ action: 'get', cache: key })
+    const msg = { action: 'get', cache: key }
+    if (limit > 0) msg.limit = limit
+    sendMessage(msg)
   }
 
   function scheduleReconnect() {
@@ -168,7 +172,7 @@ export function useWebSocketClient(config = {}) {
     if (connected && socket && socket.readyState === WebSocket.OPEN) {
       sendAuth()
       if (cacheKey.value) {
-        getCache()
+        getCache(cacheLimit.value)
       }
       if (feedName.value) {
         subscribe()
@@ -206,6 +210,7 @@ export function useWebSocketClient(config = {}) {
     sendAuth,
     subscribe,
     unsubscribe,
-    getCache
+    getCache,
+    cacheLimit
   }
 }


### PR DESCRIPTION
Passes `maxArticles` as `cacheLimit` to `useWebSocketClient`, which sends `{ action: 'get', cache: '...', limit: N }` on connect. WDS fetches only N items from Redis — limiting wire transfer to the configured display size.

Changing `maxArticles` in the dropdown clears the buffer and re-fetches at the new limit.

Part 3 of 3 for kuhl-haus/kuhl-haus-mdp#47.