### PR TITLE
fix(NewsFeedFast/V2): remove double scrollbar

### DIFF
--- a/client/src/components/widgets/NewsFeedFast.vue
+++ b/client/src/components/widgets/NewsFeedFast.vue
@@ -529,7 +529,7 @@ const filteredNews = computed(() => {
 /* ── Table ── */
 .news-table-wrap {
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .news-table {

--- a/client/src/components/widgets/NewsFeedV2.vue
+++ b/client/src/components/widgets/NewsFeedV2.vue
@@ -535,7 +535,7 @@ const filteredNews = computed(() => {
 /* ── Table ── */
 .news-table-wrap {
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .news-table {


### PR DESCRIPTION
Both virtual scroll widgets had a redundant outer scrollbar from `.news-table-wrap { overflow-y: auto }`. Changed to `overflow: hidden` — the inner `.vs-scroller` handles all scrolling.