### PR TITLE
fix(NewsFeedFast/V2): remove double scrollbar + match original font sizes and row spacing

### DIFF
--- a/client/src/components/widgets/NewsFeedFast.vue
+++ b/client/src/components/widgets/NewsFeedFast.vue
@@ -828,7 +828,7 @@ const filteredNews = computed(() => {
 .vs-row {
   display: flex;
   align-items: center;
-  height: 40px;
+  height: 28px;
   border-bottom: 1px solid #1a1a1a;
   cursor: pointer;
 }
@@ -840,6 +840,7 @@ const filteredNews = computed(() => {
   white-space: nowrap;
   flex-shrink: 0;
   font-size: 12px;
+  line-height: 1.2;
 }
 
 .vs-td.col-title {

--- a/client/src/components/widgets/NewsFeedFast.vue
+++ b/client/src/components/widgets/NewsFeedFast.vue
@@ -529,7 +529,7 @@ const filteredNews = computed(() => {
 /* ── Table ── */
 .news-table-wrap {
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .news-table {

--- a/client/src/components/widgets/NewsFeedV2.vue
+++ b/client/src/components/widgets/NewsFeedV2.vue
@@ -834,8 +834,8 @@ const filteredNews = computed(() => {
 .vs-row {
   display: flex;
   align-items: flex-start;
-  min-height: 44px;
-  padding: 6px 0;
+  min-height: 28px;
+  padding: 2px 0;
   border-bottom: 1px solid #1a1a1a;
   cursor: pointer;
 }
@@ -862,7 +862,7 @@ const filteredNews = computed(() => {
 }
 
 .vs-headline {
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.4;
   white-space: normal;
   word-break: break-word;

--- a/client/src/components/widgets/NewsFeedV2.vue
+++ b/client/src/components/widgets/NewsFeedV2.vue
@@ -535,7 +535,7 @@ const filteredNews = computed(() => {
 /* ── Table ── */
 .news-table-wrap {
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .news-table {


### PR DESCRIPTION
- Remove outer scrollbar (`overflow: hidden` on `.news-table-wrap`)
- Headline font-size 14px → 16px (matches original NewsFeed)
- Row height tightened (40px → 28px Fast, 44px → 28px V2) — less wasted whitespace