### PR TITLE
feat(layout): persist per-widget control settings in layout (fixes shared localStorage bug)

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -233,10 +233,12 @@
             :is-locked="true"
             :col-widths="item.colWidths || {}"
             :link-color="item.linkColor || null"
+            :settings="item.settings || {}"
             :is-mobile="true"
             @close="removeWidget"
             @update-col-widths="(w) => updateColWidths(item.i, w)"
             @update-link-color="(c) => updateLinkColor(item.i, c)"
+            @update-settings="(s) => updateSettings(item.i, s)"
         />
       </div>
     </div>
@@ -268,10 +270,12 @@
             :is-locked="isLocked"
             :col-widths="item.colWidths || {}"
             :link-color="item.linkColor || null"
+            :settings="item.settings || {}"
             :is-mobile="false"
             @close="removeWidget"
             @update-col-widths="(w) => updateColWidths(item.i, w)"
             @update-link-color="(c) => updateLinkColor(item.i, c)"
+            @update-settings="(s) => updateSettings(item.i, s)"
         />
       </GridItem>
     </GridLayout>
@@ -762,6 +766,14 @@ const updateColWidths = (widgetId, colWidths) => {
   const item = layout.value.find(i => i.i === widgetId)
   if (item) {
     item.colWidths = { ...colWidths }
+    autoSaveLayout()
+  }
+}
+
+const updateSettings = (widgetId, settings) => {
+  const item = layout.value.find(i => i.i === widgetId)
+  if (item) {
+    item.settings = { ...settings }
     autoSaveLayout()
   }
 }

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -44,7 +44,9 @@
         :col-widths="colWidths"
         :link-color="linkColor"
         :is-mobile="isMobile"
+        :settings="settings"
         @update-col-widths="$emit('update-col-widths', $event)"
+        @update-settings="$emit('update-settings', $event)"
       />
     </div>
   </div>
@@ -67,8 +69,9 @@ const props = defineProps({
   colWidths:  { type: Object,  default: () => ({}) },
   linkColor:  { type: String,  default: null },
   isMobile:   { type: Boolean, default: false },
+  settings:   { type: Object,  default: () => ({}) },
 })
-defineEmits(['close', 'update-col-widths', 'update-link-color'])
+defineEmits(['close', 'update-col-widths', 'update-link-color', 'update-settings'])
 
 const widgetComponents = {
   'top-gainers': TopGainers,

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -201,8 +201,9 @@ const props = defineProps({
   colWidths: { type: Object,  default: () => ({}) },
   linkColor: { type: String,  default: null },
   isMobile:  { type: Boolean, default: false },
+  settings:  { type: Object,  default: () => ({}) },
 })
-const emit = defineEmits(['ticker-click', 'update-col-widths'])
+const emit = defineEmits(['ticker-click', 'update-col-widths', 'update-settings'])
 
 const { setActiveTicker, activeTickers } = useWidgetBus()
 
@@ -237,18 +238,22 @@ const activeTicker   = ref(null)
 const searchQuery    = ref('')
 const LS_MAX_ARTICLES_KEY = 'newsfeed:maxArticles'
 const MAX_ARTICLES_OPTIONS = [50, 100, 500, 1000, 2000, 4000, 8000, 10000]
-const maxArticles = ref(parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
+const maxArticles = ref(props.settings.maxArticles ?? parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
 watch(maxArticles, v => {
   localStorage.setItem(LS_MAX_ARTICLES_KEY, String(v))
+  emit('update-settings', { ...props.settings, maxArticles: v }
   cacheLimit.value = v
   newsItems.value = []
   getCache(v)
 })
-const hasTickersOnly = ref(localStorage.getItem(LS_HAS_TICKERS_KEY) === 'true')
+const hasTickersOnly = ref(props.settings.hasTickersOnly ?? localStorage.getItem(LS_HAS_TICKERS_KEY) === 'true')
 const tableWrap      = ref(null)
 
 // Persist R1 toggle
-watch(hasTickersOnly, (val) => localStorage.setItem(LS_HAS_TICKERS_KEY, val))
+watch(hasTickersOnly, (val) => {
+  localStorage.setItem(LS_HAS_TICKERS_KEY, val)
+  emit('update-settings', { ...props.settings, hasTickersOnly: val })
+})
 
 // Receive ticker from bus when another linked widget broadcasts
 watch(

--- a/client/src/components/widgets/NewsFeedFast.vue
+++ b/client/src/components/widgets/NewsFeedFast.vue
@@ -203,8 +203,9 @@ const props = defineProps({
   colWidths: { type: Object,  default: () => ({}) },
   linkColor: { type: String,  default: null },
   isMobile:  { type: Boolean, default: false },
+  settings:  { type: Object,  default: () => ({}) },
 })
-const emit = defineEmits(['ticker-click', 'update-col-widths'])
+const emit = defineEmits(['ticker-click', 'update-col-widths', 'update-settings'])
 
 const { setActiveTicker, activeTickers } = useWidgetBus()
 
@@ -239,18 +240,22 @@ const activeTicker   = ref(null)
 const searchQuery    = ref('')
 const LS_MAX_ARTICLES_KEY = 'newsfeed:maxArticles'
 const MAX_ARTICLES_OPTIONS = [50, 100, 500, 1000, 2000, 4000, 8000, 10000]
-const maxArticles = ref(parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
+const maxArticles = ref(props.settings.maxArticles ?? parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
 watch(maxArticles, v => {
   localStorage.setItem(LS_MAX_ARTICLES_KEY, String(v))
+  emit('update-settings', { ...props.settings, maxArticles: v })
   cacheLimit.value = v
   newsItems.value = []
   getCache(v)
 })
-const hasTickersOnly = ref(localStorage.getItem(LS_HAS_TICKERS_KEY) === 'true')
+const hasTickersOnly = ref(props.settings.hasTickersOnly ?? localStorage.getItem(LS_HAS_TICKERS_KEY) === 'true')
 const tableWrap      = ref(null)
 
 // Persist R1 toggle
-watch(hasTickersOnly, (val) => localStorage.setItem(LS_HAS_TICKERS_KEY, val))
+watch(hasTickersOnly, (val) => {
+  localStorage.setItem(LS_HAS_TICKERS_KEY, val)
+  emit('update-settings', { ...props.settings, hasTickersOnly: val })
+})
 
 // Receive ticker from bus when another linked widget broadcasts
 watch(

--- a/client/src/components/widgets/NewsFeedV2.vue
+++ b/client/src/components/widgets/NewsFeedV2.vue
@@ -209,8 +209,9 @@ const props = defineProps({
   colWidths: { type: Object,  default: () => ({}) },
   linkColor: { type: String,  default: null },
   isMobile:  { type: Boolean, default: false },
+  settings:  { type: Object,  default: () => ({}) },
 })
-const emit = defineEmits(['ticker-click', 'update-col-widths'])
+const emit = defineEmits(['ticker-click', 'update-col-widths', 'update-settings'])
 
 const { setActiveTicker, activeTickers } = useWidgetBus()
 
@@ -245,18 +246,22 @@ const activeTicker   = ref(null)
 const searchQuery    = ref('')
 const LS_MAX_ARTICLES_KEY = 'newsfeed:maxArticles'
 const MAX_ARTICLES_OPTIONS = [50, 100, 500, 1000, 2000, 4000, 8000, 10000]
-const maxArticles = ref(parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
+const maxArticles = ref(props.settings.maxArticles ?? parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
 watch(maxArticles, v => {
   localStorage.setItem(LS_MAX_ARTICLES_KEY, String(v))
+  emit('update-settings', { ...props.settings, maxArticles: v })
   cacheLimit.value = v
   newsItems.value = []
   getCache(v)
 })
-const hasTickersOnly = ref(localStorage.getItem(LS_HAS_TICKERS_KEY) === 'true')
+const hasTickersOnly = ref(props.settings.hasTickersOnly ?? localStorage.getItem(LS_HAS_TICKERS_KEY) === 'true')
 const tableWrap      = ref(null)
 
 // Persist R1 toggle
-watch(hasTickersOnly, (val) => localStorage.setItem(LS_HAS_TICKERS_KEY, val))
+watch(hasTickersOnly, (val) => {
+  localStorage.setItem(LS_HAS_TICKERS_KEY, val)
+  emit('update-settings', { ...props.settings, hasTickersOnly: val })
+})
 
 // Receive ticker from bus when another linked widget broadcasts
 watch(


### PR DESCRIPTION
Each layout item now carries a `settings` object (`maxArticles`, `hasTickersOnly`). Widgets initialize from `props.settings` (with localStorage fallback for backwards compat), emit `update-settings` on change, and `DashboardGrid` writes back to `layout[i].settings` + autosaves.

**Fixes:** Two instances of the same widget type fighting over the same `localStorage` key.

refs #66