### PR TITLE
fix(NewsFeed): missing closing paren on emit call (build fix)

### DIFF
--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -241,7 +241,7 @@ const MAX_ARTICLES_OPTIONS = [50, 100, 500, 1000, 2000, 4000, 8000, 10000]
 const maxArticles = ref(props.settings.maxArticles ?? parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
 watch(maxArticles, v => {
   localStorage.setItem(LS_MAX_ARTICLES_KEY, String(v))
-  emit('update-settings', { ...props.settings, maxArticles: v }
+  emit('update-settings', { ...props.settings, maxArticles: v })
   cacheLimit.value = v
   newsItems.value = []
   getCache(v)


### PR DESCRIPTION
Fixes syntax error introduced in PR #67. `emit('update-settings', { ...props.settings, maxArticles: v }` was missing its closing `)`, breaking the Vite build.\n\nrefs #66