### PR TITLE
fix: mobile edit mode now respects isLocked state

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -230,7 +230,7 @@
         <WidgetWrapper
             :widget-id="item.i"
             :widget-type="item.type"
-            :is-locked="true"
+            :is-locked="isLocked"
             :col-widths="item.colWidths || {}"
             :link-color="item.linkColor || null"
             :settings="item.settings || {}"


### PR DESCRIPTION
## Problem

Two edit-mode features were broken on mobile:
1. **Widget linking** — link color selector never appeared
2. **Widget title editing** — double-click to rename never fired

## Root Cause

In `DashboardGrid.vue`, the mobile stack's `WidgetWrapper` was hardcoded with `:is-locked="true"`:

```vue
<!-- Mobile (broken) -->
<WidgetWrapper :is-locked="true" ...>

<!-- Desktop (correct) -->
<WidgetWrapper :is-locked="isLocked" ...>
```

Both `WidgetWrapper` features are gated on `!isLocked`. With a hardcoded `true`, the ✏️ unlock button had no effect on mobile.

## Fix

Pass `:is-locked="isLocked"` consistently in the mobile stack, matching the desktop grid.