### PR TITLE
fix: always persist explicit widget state changes regardless of autosave

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -452,8 +452,8 @@ const loadDefaultLayout = () => {
 }
 
 // Auto-save
-const autoSaveLayout = () => {
-  if (!autosaveEnabled.value) return
+const autoSaveLayout = (forceSave = false) => {
+  if (!autosaveEnabled.value && !forceSave) return
   if (autoSaveTimeout) {
     clearTimeout(autoSaveTimeout)
   }
@@ -762,7 +762,7 @@ const updateLinkColor = (widgetId, linkColor) => {
   const item = layout.value.find(i => i.i === widgetId)
   if (item) {
     item.linkColor = linkColor || null
-    autoSaveLayout()
+    autoSaveLayout(true)
   }
 }
 
@@ -770,7 +770,7 @@ const updateColWidths = (widgetId, colWidths) => {
   const item = layout.value.find(i => i.i === widgetId)
   if (item) {
     item.colWidths = { ...colWidths }
-    autoSaveLayout()
+    autoSaveLayout(true)
   }
 }
 
@@ -778,7 +778,7 @@ const updateSettings = (widgetId, settings) => {
   const item = layout.value.find(i => i.i === widgetId)
   if (item) {
     item.settings = { ...settings }
-    autoSaveLayout()
+    autoSaveLayout(true)
   }
 }
 
@@ -786,7 +786,7 @@ const updateLabel = (widgetId, label) => {
   const item = layout.value.find(i => i.i === widgetId)
   if (item) {
     item.userLabel = label || ''
-    autoSaveLayout()
+    autoSaveLayout(true)
   }
 }
 


### PR DESCRIPTION
## Problem

Widget filter settings (and link color, col widths, labels) were not persisting when the autosave toggle (⏸/🔄) was disabled. The four explicit-mutation handlers all called `autoSaveLayout()`, which bails early when `autosaveEnabled` is false.

## Root Cause

`autoSaveLayout()` serves two purposes:
1. Passive layout mutations (drag, resize) — should respect the autosave toggle
2. Explicit user config changes (filters, link color, label) — should **always** persist

These were treated identically, so disabling autosave silently dropped explicit changes.

## Fix

Add a `forceSave = false` parameter to `autoSaveLayout()`. The four explicit-mutation handlers pass `true`:
- `updateLinkColor()`
- `updateColWidths()`
- `updateSettings()`
- `updateLabel()`

The layout deep watcher (drag/resize autosave) continues to pass nothing, so the toggle still controls passive saves.

refs #66