### PR TITLE
fix(TopGappers): add missing watch to persist filter settings

### DIFF
--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -87,6 +87,14 @@ const minPriceThreshold = ref(props.settings.minPriceThreshold ?? 2)
 const maxPriceThreshold = ref(props.settings.maxPriceThreshold ?? 20)
 const minChangePercent = ref(props.settings.minChangePercent ?? 10)
 
+// Persist filter settings to layout
+watch(
+  [() => volumeThreshold.value, () => relVolumeThreshold.value, () => minPriceThreshold.value, () => maxPriceThreshold.value, () => minChangePercent.value],
+  () => {
+    emit('update-settings', { volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value, minChangePercent: minChangePercent.value })
+  }
+)
+
 // Initialize WebSocket client
 const { connect, lastDataAt, isConnected, reconnecting } = useWebSocketClient({
   wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',


### PR DESCRIPTION
## Problem

Filter settings in `TopGappers` were not triggering autosave, while `TopGainers` and `TopVolume` worked correctly.

## Root Cause

The script that added settings persistence to all three scanner widgets searched for this insertion point:

```js
const { lastDataAt, isConnected, reconnecting } = useWebSocketClient({
```

`TopGappers` destructures an additional `connect` export:

```js
const { connect, lastDataAt, isConnected, reconnecting } = useWebSocketClient({
```

The pattern didn't match, so the `watch` block was silently skipped. The `settings` prop and `emit` declaration were added correctly — only the watch was missing.

## Fix

Add the missing `watch` block to `TopGappers` matching the pattern in the other two scanner widgets.

refs #66