### PR TITLE
fix(GenericScannerTable): tighten row padding to match NewsFeedFast density

### DIFF
--- a/client/src/components/widgets/GenericScannerTable.vue
+++ b/client/src/components/widgets/GenericScannerTable.vue
@@ -102,7 +102,7 @@ th {
   position: sticky;
   top: 0;
   z-index: 1;
-  padding: 10px 8px;
+  padding: 4px 8px;
   font-size: 13px;
   font-weight: 600;
   text-align: left;
@@ -120,7 +120,7 @@ th.sorted {
 }
 
 td {
-  padding: 8px;
+  padding: 2px 8px;
   font-size: 13px;
   border-bottom: 1px solid #2a2a2a;
   position: relative;


### PR DESCRIPTION
Scanner widget rows had excessive vertical padding compared to `NewsFeedFast`:

| Element | Before | After |
|---------|--------|-------|
| `th` | `10px 8px` | `4px 8px` |
| `td` | `8px` (all sides) | `2px 8px` |

Matches `NewsFeedFast`'s `.news-row td { padding: 2px 8px }`, significantly reducing wasted vertical space across all three scanner widgets (TopGainers, TopGappers, TopVolume).