### PR TITLE
fix: align NewsFeedFast/V2 header style with NewsFeed

### DIFF
--- a/client/src/components/widgets/NewsFeedFast.vue
+++ b/client/src/components/widgets/NewsFeedFast.vue
@@ -808,17 +808,18 @@ const filteredNews = computed(() => {
   position: sticky;
   top: 0;
   z-index: 2;
-  background: #0d0d0d;
-  border-bottom: 1px solid #222;
-  font-size: 11px;
-  color: #666;
+  background: #1a1a1a;
+  border-bottom: 1px solid #333;
+  font-size: 12px;
+  font-weight: 600;
+  color: #888;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   user-select: none;
 }
 
 .vs-th {
-  padding: 6px 8px;
+  padding: 3px 8px;
   overflow: hidden;
   white-space: nowrap;
   flex-shrink: 0;

--- a/client/src/components/widgets/NewsFeedV2.vue
+++ b/client/src/components/widgets/NewsFeedV2.vue
@@ -814,17 +814,18 @@ const filteredNews = computed(() => {
   position: sticky;
   top: 0;
   z-index: 2;
-  background: #0d0d0d;
-  border-bottom: 1px solid #222;
-  font-size: 11px;
-  color: #666;
+  background: #1a1a1a;
+  border-bottom: 1px solid #333;
+  font-size: 12px;
+  font-weight: 600;
+  color: #888;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   user-select: none;
 }
 
 .vs-th {
-  padding: 6px 8px;
+  padding: 3px 8px;
   overflow: hidden;
   white-space: nowrap;
   flex-shrink: 0;


### PR DESCRIPTION
The virtual scroller header (`.vs-header`/`.vs-th`) in `NewsFeedFast` and `NewsFeedV2` was styled independently from the original `NewsFeed` table header (`thead th`), resulting in a visually inconsistent look.

Aligns all properties to match `NewsFeed`: background, color, font size/weight, border, padding, and letter-spacing.