### PR TITLE
feat(#78): news freshness flame indicators on scanner rows

### DIFF
--- a/client/src/components/widgets/GenericScannerTable.vue
+++ b/client/src/components/widgets/GenericScannerTable.vue
@@ -32,7 +32,17 @@
           </div>
         </template>
         <template v-else>
-          {{ formatCell(col, row) }}
+          <span>{{ formatCell(col, row) }}</span>
+          <img
+            v-if="col.key === 'symbol' && getFlame(row.symbol)"
+            :src="getFlame(row.symbol).src"
+            :title="getFlame(row.symbol).tooltip"
+            width="14" height="14"
+            class="flame-icon"
+            @touchstart.passive="onFlameTouchStart($event, row.symbol)"
+            @touchend.passive="onFlameTouchEnd"
+            @touchmove.passive="onFlameTouchEnd"
+          />
         </template>
       </td>
     </tr>
@@ -42,6 +52,7 @@
 
 <script setup>
 import { h } from 'vue'
+import { getFlameVariant, getFlameTooltip, newsTimestamps } from '@/composables/useWidgetBus.js'
 
 const props = defineProps({
   data: { type: Array, required: true },
@@ -53,6 +64,36 @@ const props = defineProps({
 })
 
 defineEmits(['sort', 'row-click'])
+
+// ── Flame freshness icons ──────────────────────────────────────────────────────
+const FLAME_SRCS = {
+  red:    new URL('@/assets/icons/flame-red.svg',    import.meta.url).href,
+  orange: new URL('@/assets/icons/flame-orange.svg', import.meta.url).href,
+  yellow: new URL('@/assets/icons/flame-yellow.svg', import.meta.url).href,
+  white:  new URL('@/assets/icons/flame-white.svg',  import.meta.url).href,
+  blue:   new URL('@/assets/icons/flame-blue.svg',   import.meta.url).href,
+  dark:   new URL('@/assets/icons/flame-dark.svg',   import.meta.url).href,
+}
+
+// Reactive: re-evaluates when newsTimestamps changes
+const getFlame = (ticker) => {
+  void newsTimestamps[ticker]  // reactive dependency
+  const variant = getFlameVariant(ticker)
+  if (!variant) return null
+  return { src: FLAME_SRCS[variant], tooltip: getFlameTooltip(ticker) }
+}
+
+// Mobile long-press tooltip (500ms, matches widget rename pattern)
+let flameLongPressTimer = null
+const onFlameTouchStart = (e, ticker) => {
+  flameLongPressTimer = setTimeout(() => {
+    const tooltip = getFlameTooltip(ticker)
+    if (tooltip) alert(tooltip)  // simple fallback; upgrade to popover in follow-up
+  }, 500)
+}
+const onFlameTouchEnd = () => {
+  if (flameLongPressTimer) { clearTimeout(flameLongPressTimer); flameLongPressTimer = null }
+}
 
 const toNum = (val) => {
   const n = Number(val)
@@ -133,6 +174,15 @@ tr:hover {
 .symbol {
   font-weight: 600;
   color: #fff;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.flame-icon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
 }
 
 .close, .prev_day_close, .change, .prev_day_volume, .avg_volume {

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -191,7 +191,7 @@
  * @emits update-col-widths   - Column widths changed, payload: { time, title, source, tickers }
  */
 import { ref, computed, watch, onUnmounted } from 'vue'
-import { useWidgetBus } from '@/composables/useWidgetBus.js'
+import { useWidgetBus, setNewsTimestamp } from '@/composables/useWidgetBus.js'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 
 const props = defineProps({
@@ -343,6 +343,15 @@ const { lastDataAt, isConnected, reconnecting, getCache, cacheLimit } = useWebSo
     const seen = new Set(newsItems.value.map(a => a.link))
     const fresh = incoming.filter(a => !seen.has(a.link))
     if (!fresh.length) return
+    // Update news freshness timestamps for scanner widgets
+    for (const article of fresh) {
+      const ts = article.publishDate ? new Date(article.publishDate).getTime() : Date.now()
+      if (isFinite(ts)) {
+        for (const co of article.companies ?? []) {
+          if (co.ticker) setNewsTimestamp(co.ticker, ts)
+        }
+      }
+    }
     const combined = [...fresh, ...newsItems.value]
     newsItems.value = combined.slice(0, maxArticles.value)
   },

--- a/client/src/components/widgets/NewsFeedFast.vue
+++ b/client/src/components/widgets/NewsFeedFast.vue
@@ -192,7 +192,7 @@
  * @emits update-col-widths   - Column widths changed, payload: { time, title, source, tickers }
  */
 import { ref, computed, watch, onUnmounted } from 'vue'
-import { useWidgetBus } from '@/composables/useWidgetBus.js'
+import { useWidgetBus, setNewsTimestamp } from '@/composables/useWidgetBus.js'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 
@@ -345,6 +345,15 @@ const { lastDataAt, isConnected, reconnecting, getCache, cacheLimit } = useWebSo
     const seen = new Set(newsItems.value.map(a => a.link))
     const fresh = incoming.filter(a => !seen.has(a.link))
     if (!fresh.length) return
+    // Update news freshness timestamps for scanner widgets
+    for (const article of fresh) {
+      const ts = article.publishDate ? new Date(article.publishDate).getTime() : Date.now()
+      if (isFinite(ts)) {
+        for (const co of article.companies ?? []) {
+          if (co.ticker) setNewsTimestamp(co.ticker, ts)
+        }
+      }
+    }
     const combined = [...fresh, ...newsItems.value]
     newsItems.value = combined.slice(0, maxArticles.value)
   },

--- a/client/src/components/widgets/NewsFeedV2.vue
+++ b/client/src/components/widgets/NewsFeedV2.vue
@@ -198,7 +198,7 @@
  * @emits update-col-widths   - Column widths changed, payload: { time, title, source, tickers }
  */
 import { ref, computed, watch, onUnmounted } from 'vue'
-import { useWidgetBus } from '@/composables/useWidgetBus.js'
+import { useWidgetBus, setNewsTimestamp } from '@/composables/useWidgetBus.js'
 import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 
@@ -351,6 +351,15 @@ const { lastDataAt, isConnected, reconnecting, getCache, cacheLimit } = useWebSo
     const seen = new Set(newsItems.value.map(a => a.link))
     const fresh = incoming.filter(a => !seen.has(a.link))
     if (!fresh.length) return
+    // Update news freshness timestamps for scanner widgets
+    for (const article of fresh) {
+      const ts = article.publishDate ? new Date(article.publishDate).getTime() : Date.now()
+      if (isFinite(ts)) {
+        for (const co of article.companies ?? []) {
+          if (co.ticker) setNewsTimestamp(co.ticker, ts)
+        }
+      }
+    }
     const combined = [...fresh, ...newsItems.value]
     newsItems.value = combined.slice(0, maxArticles.value)
   },

--- a/client/src/composables/useWidgetBus.js
+++ b/client/src/composables/useWidgetBus.js
@@ -11,7 +11,7 @@
  *   import { useWidgetBus } from '@/composables/useWidgetBus.js'
  *   const { setActiveTicker, getActiveTicker, activeTickers, LINK_COLORS } = useWidgetBus()
  */
-import { reactive, computed } from 'vue'
+import { reactive } from 'vue'
 
 // 9-color palette — high contrast, distinct at a glance
 export const LINK_COLORS = [
@@ -28,6 +28,65 @@ export const LINK_COLORS = [
 
 export const LINK_COLOR_MAP = Object.fromEntries(LINK_COLORS.map(c => [c.name, c.hex]))
 
+// ── News freshness state ─────────────────────────────────────────────────────
+// Map of ticker → timestamp (ms) of most recent article mentioning that ticker.
+// Updated by news feed widgets; consumed by scanner widgets.
+const newsTimestamps = reactive({})
+
+const FLAME_THRESHOLDS = [
+  { variant: 'red',    maxH: 1   },
+  { variant: 'orange', maxH: 3   },
+  { variant: 'yellow', maxH: 12  },
+  { variant: 'white',  maxH: 24  },
+  { variant: 'blue',   maxH: 72  },
+  { variant: 'dark',   maxH: Infinity },
+]
+
+const FLAME_LABELS = {
+  red:    'Hot news',
+  orange: 'Recent news',
+  yellow: 'News today',
+  white:  'Multi-session news',
+  blue:   'Older news',
+  dark:   'Stale news',
+}
+
+function formatAge(ms) {
+  const s = Math.floor(ms / 1000)
+  if (s < 60)   return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60)   return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24)   return `${h}h ago`
+  const d = Math.floor(h / 24)
+  return `${d}d ago`
+}
+
+export function getFlameVariant(ticker) {
+  const ts = newsTimestamps[ticker]
+  if (!ts) return null
+  const h = (Date.now() - ts) / 3_600_000
+  return FLAME_THRESHOLDS.find(t => h < t.maxH)?.variant ?? 'dark'
+}
+
+export function getFlameTooltip(ticker) {
+  const ts = newsTimestamps[ticker]
+  if (!ts) return null
+  const variant = getFlameVariant(ticker)
+  return `${FLAME_LABELS[variant]} — ${formatAge(Date.now() - ts)}`
+}
+
+export function setNewsTimestamp(ticker, timestamp) {
+  if (!ticker) return
+  // Only update if newer than existing
+  if (!newsTimestamps[ticker] || timestamp > newsTimestamps[ticker]) {
+    newsTimestamps[ticker] = timestamp
+  }
+}
+
+export { newsTimestamps }
+
+// ── Active ticker state ───────────────────────────────────────────────────────
 // Shared reactive state — single instance across all components (module singleton)
 const activeTickers = reactive(
   Object.fromEntries(LINK_COLORS.map(c => [c.name, null]))


### PR DESCRIPTION
Implements the 6-tier flame freshness indicator on scanner widgets.

## How it works

News feed widgets (NewsFeed, NewsFeedFast, NewsFeedV2) call `setNewsTimestamp(ticker, timestamp)` for each ticker in every incoming article. This updates a module-singleton reactive map in `useWidgetBus`.

`GenericScannerTable` reads that map and renders the appropriate flame icon inline in the symbol cell:
- **Desktop:** `title` tooltip on hover — *"Hot news — 23 min ago"*
- **Mobile:** 500ms long-press triggers the same info (matches widget rename UX)

## Tiers

| Flame | Age | Catalyst? |
|-------|-----|-----------|
| 🔴 Red | < 1h | ✅ |
| 🟠 Orange | 1–3h | ✅ |
| 🟡 Yellow | 3–12h | ✅ |
| ⬜ White | 12–24h | ✅ |
| 🔵 Blue | 1–3d | ❌ |
| ⚫ Dark | > 3d | ❌ |
| *(none)* | No news | — |

## Files changed
- `useWidgetBus.js` — `newsTimestamps` map + `setNewsTimestamp` / `getFlameVariant` / `getFlameTooltip` / `formatAge` exports
- `GenericScannerTable.vue` — flame icon rendering + long-press mobile tooltip
- `NewsFeed.vue` / `NewsFeedFast.vue` / `NewsFeedV2.vue` — wire `onData` → `setNewsTimestamp`

closes #78