### PR TITLE
fix(NewsFeedFast/V2): scope .col-title to data rows only

### DIFF
--- a/client/src/components/widgets/NewsFeedFast.vue
+++ b/client/src/components/widgets/NewsFeedFast.vue
@@ -613,7 +613,7 @@ const filteredNews = computed(() => {
   color: #a78bfa;
   pointer-events: none;
 }
-.col-title  { color: #ddd; font-size: 16px; line-height: 1.4; }
+.vs-td.col-title  { color: #ddd; font-size: 16px; line-height: 1.4; }
 
 /* Sentiment dot */
 .sentiment-dot {

--- a/client/src/components/widgets/NewsFeedV2.vue
+++ b/client/src/components/widgets/NewsFeedV2.vue
@@ -619,7 +619,7 @@ const filteredNews = computed(() => {
   color: #a78bfa;
   pointer-events: none;
 }
-.col-title  { color: #ddd; font-size: 16px; line-height: 1.4; }
+.vs-td.col-title  { color: #ddd; font-size: 16px; line-height: 1.4; }
 
 /* Sentiment dot */
 .sentiment-dot {


### PR DESCRIPTION
The `.col-title` CSS rule was applying to both header cells (`.vs-th`) and data cells (`.vs-td`), overriding the header styling set in PR #76.

**Symptom:** The 'HEADLINE' column header appeared white (`#ddd`) and oversized (`16px`) instead of gray (`#888`) and `12px` like the other headers.

**Fix:** Scope to `.vs-td.col-title` so data row styles don't bleed into the header row.