### PR TITLE
feat(#83): resizable and hideable columns in scanner widgets

### DIFF
--- a/client/src/components/widgets/GenericScannerTable.vue
+++ b/client/src/components/widgets/GenericScannerTable.vue
@@ -3,13 +3,21 @@
     <thead>
     <tr>
       <th
-          v-for="col in columns"
+          v-for="col in visibleColumns"
           :key="col.key"
           @click="$emit('sort', col.key)"
           :class="{ sorted: sortKey === col.key }"
+          :style="colStyle(col)"
+          style="position: relative;"
       >
         <span v-html="col.label"></span>
         <span v-if="sortKey === col.key">{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+        <span
+          v-if="!isLocked"
+          class="col-resize-handle"
+          @mousedown.prevent="startResize($event, col.key)"
+          title="Drag to resize"
+        ></span>
       </th>
     </tr>
     </thead>
@@ -21,7 +29,7 @@
         style="cursor:pointer"
         @click="$emit('row-click', row)"
     >
-      <td v-for="col in columns" :key="col.key" :class="getCellClass(col, row)">
+      <td v-for="col in visibleColumns" :key="col.key" :class="getCellClass(col, row)">
         <template v-if="col.render">
           <component :is="col.render(row)" />
         </template>
@@ -51,19 +59,57 @@
 </template>
 
 <script setup>
-import { h } from 'vue'
+import { h, ref, watch, computed, onUnmounted } from 'vue'
 import { getFlameVariant, getFlameTooltip, newsTimestamps } from '@/composables/useWidgetBus.js'
 
 const props = defineProps({
-  data: { type: Array, required: true },
-  columns: { type: Array, required: true },
-  sortKey: { type: String, default: '' },
-  sortDir: { type: String, default: 'asc' },
+  data:       { type: Array,   required: true },
+  columns:    { type: Array,   required: true },
+  sortKey:    { type: String,  default: '' },
+  sortDir:    { type: String,  default: 'asc' },
   rowClassFn: { type: Function, default: null },
   activeTicker: { type: String, default: null },
+  isLocked:   { type: Boolean, default: true },
+  colWidths:  { type: Object,  default: () => ({}) },
+  hiddenCols: { type: Array,   default: () => [] },
 })
 
-defineEmits(['sort', 'row-click'])
+const emit = defineEmits(['sort', 'row-click', 'update-col-widths'])
+
+// ── Column widths & resize ────────────────────────────────────────────────────
+const localWidths = ref({ ...props.colWidths })
+watch(() => props.colWidths, (v) => { if (v) localWidths.value = { ...v } })
+
+const colStyle = (col) => {
+  const w = localWidths.value[col.key]
+  return w ? { width: `${w}px`, minWidth: `${w}px` } : {}
+}
+
+let resizeState = null
+const startResize = (e, colKey) => {
+  if (props.isLocked) return
+  const startWidth = localWidths.value[colKey] || e.target.closest('th')?.offsetWidth || 80
+  resizeState = { colKey, startX: e.clientX, startWidth }
+  const onMove = (me) => {
+    if (!resizeState) return
+    const newWidth = Math.max(40, resizeState.startWidth + me.clientX - resizeState.startX)
+    localWidths.value = { ...localWidths.value, [resizeState.colKey]: newWidth }
+  }
+  const onUp = () => {
+    resizeState = null
+    document.removeEventListener('mousemove', onMove)
+    document.removeEventListener('mouseup', onUp)
+    emit('update-col-widths', { ...localWidths.value })
+  }
+  document.addEventListener('mousemove', onMove)
+  document.addEventListener('mouseup', onUp)
+}
+onUnmounted(() => { resizeState = null })
+
+// Filter visible columns
+const visibleColumns = computed(() =>
+  props.columns.filter(col => !props.hiddenCols.includes(col.key))
+)
 
 // ── Flame freshness icons ──────────────────────────────────────────────────────
 const FLAME_SRCS = {
@@ -183,6 +229,22 @@ tr:hover {
   display: inline-block;
   vertical-align: middle;
   flex-shrink: 0;
+}
+
+/* ── Column resize handle ── */
+.col-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  user-select: none;
+  z-index: 1;
+}
+.col-resize-handle:hover,
+.col-resize-handle:active {
+  background: rgba(139, 92, 246, 0.5);
 }
 
 .close, .prev_day_close, .change, .prev_day_volume, .avg_volume {

--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -41,6 +41,25 @@
       <input id="gainRelVolumeThreshold" v-model.number="relVolumeThreshold" type="number" placeholder="Min Relative Volume" class="filter-input" />
       <label for="gainMinChangePercent">Change</label>
       <input id="gainMinChangePercent" v-model.number="minChangePercent" type="number" placeholder="Min Change %" class="filter-input" />
+      <!-- Column visibility gear menu -->
+      <div class="col-menu-wrap" ref="colMenuRef">
+        <button class="col-menu-btn" @click="showColMenu = !showColMenu" title="Show/hide columns">⚙️</button>
+        <div v-if="showColMenu" class="col-menu-popover">
+          <div class="col-menu-title">Columns</div>
+          <label v-for="col in columns" :key="col.key" class="col-menu-item">
+            <input
+              type="checkbox"
+              :checked="!hiddenCols.includes(col.key)"
+              :disabled="col.key === 'symbol'"
+              @change="e => {
+                if (e.target.checked) hiddenCols.value = hiddenCols.value.filter(k => k !== col.key)
+                else if (col.key !== 'symbol') hiddenCols.value = [...hiddenCols.value, col.key]
+              }"
+            />
+            {{ col.label }}
+          </label>
+        </div>
+      </div>
     </div>
 
     <GenericScannerTable
@@ -50,6 +69,10 @@
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
         :active-ticker="activeTicker"
+        :is-locked="isLocked"
+        :col-widths="colWidths"
+        :hidden-cols="hiddenCols"
+        @update-col-widths="$emit('update-col-widths', $event)"
         @sort="sortBy"
         @row-click="onRowClick"
     />
@@ -57,14 +80,15 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, watch } from 'vue'
+import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useScannerLink } from '@/composables/useScannerLink.js'
 
-const emit = defineEmits(['update-settings'])
+const emit = defineEmits(['update-settings', 'update-col-widths'])
 const props = defineProps({
   isLocked:  { type: Boolean, default: true },
+  colWidths:  { type: Object,  default: () => ({}) },
   linkColor: { type: String,  default: null },
   isMobile:  { type: Boolean, default: false },
   settings:  { type: Object,  default: () => ({}) },
@@ -88,11 +112,26 @@ const maxPriceThreshold = ref(props.settings.maxPriceThreshold ?? 20)
 const minChangePercent = ref(props.settings.minChangePercent ?? 10)
 
 
+// Column visibility
+const hiddenCols = ref(props.settings.hiddenCols ?? [])
+const showColMenu = ref(false)
+const colMenuRef = ref(null)
+
+const handleClickOutside = (e) => {
+  if (colMenuRef.value && !colMenuRef.value.contains(e.target)) {
+    showColMenu.value = false
+  }
+}
+onMounted(() => document.addEventListener('click', handleClickOutside))
+onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
+
+
 // Persist filter settings to layout
 watch(
-  [() => volumeThreshold.value, () => relVolumeThreshold.value, () => minPriceThreshold.value, () => maxPriceThreshold.value, () => minChangePercent.value],
+  [() => hiddenCols.value,
+   () => volumeThreshold.value, () => relVolumeThreshold.value, () => minPriceThreshold.value, () => maxPriceThreshold.value, () => minChangePercent.value],
   () => {
-    emit('update-settings', { volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value, minChangePercent: minChangePercent.value })
+    emit('update-settings', { hiddenCols: hiddenCols.value, volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value, minChangePercent: minChangePercent.value })
   }
 )
 const { lastDataAt, isConnected, reconnecting } = useWebSocketClient({
@@ -253,4 +292,54 @@ const getRowClass = (row) => {
   height: 100%;
   overflow: auto;
 }
+.col-menu-wrap {
+  position: relative;
+}
+
+.col-menu-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.col-menu-btn:hover { background: #2a2a2a; }
+
+.col-menu-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: #1e1e1e;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 8px;
+  min-width: 160px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+
+.col-menu-title {
+  font-size: 11px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.col-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #ccc;
+  padding: 3px 0;
+  cursor: pointer;
+  user-select: none;
+}
+.col-menu-item input { cursor: pointer; }
+.col-menu-item:has(input:disabled) { opacity: 0.4; cursor: default; }
 </style>

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -41,6 +41,25 @@
       <input id="gapRelVolumeThreshold" v-model.number="relVolumeThreshold" type="number" placeholder="Min Relative Volume" class="filter-input" />
       <label for="gapMinChangePercent">Change</label>
       <input id="gapMinChangePercent" v-model.number="minChangePercent" type="number" placeholder="Min Change %" class="filter-input" />
+      <!-- Column visibility gear menu -->
+      <div class="col-menu-wrap" ref="colMenuRef">
+        <button class="col-menu-btn" @click="showColMenu = !showColMenu" title="Show/hide columns">⚙️</button>
+        <div v-if="showColMenu" class="col-menu-popover">
+          <div class="col-menu-title">Columns</div>
+          <label v-for="col in columns" :key="col.key" class="col-menu-item">
+            <input
+              type="checkbox"
+              :checked="!hiddenCols.includes(col.key)"
+              :disabled="col.key === 'symbol'"
+              @change="e => {
+                if (e.target.checked) hiddenCols.value = hiddenCols.value.filter(k => k !== col.key)
+                else if (col.key !== 'symbol') hiddenCols.value = [...hiddenCols.value, col.key]
+              }"
+            />
+            {{ col.label }}
+          </label>
+        </div>
+      </div>
     </div>
 
     <GenericScannerTable
@@ -50,6 +69,10 @@
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
         :active-ticker="activeTicker"
+        :is-locked="isLocked"
+        :col-widths="colWidths"
+        :hidden-cols="hiddenCols"
+        @update-col-widths="$emit('update-col-widths', $event)"
         @sort="sortBy"
         @row-click="onRowClick"
     />
@@ -57,14 +80,15 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, watch } from 'vue'
+import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useScannerLink } from '@/composables/useScannerLink.js'
 
-const emit = defineEmits(['update-settings'])
+const emit = defineEmits(['update-settings', 'update-col-widths'])
 const props = defineProps({
   isLocked:  { type: Boolean, default: true },
+  colWidths:  { type: Object,  default: () => ({}) },
   linkColor: { type: String,  default: null },
   isMobile:  { type: Boolean, default: false },
   settings:  { type: Object,  default: () => ({}) },
@@ -87,11 +111,26 @@ const minPriceThreshold = ref(props.settings.minPriceThreshold ?? 2)
 const maxPriceThreshold = ref(props.settings.maxPriceThreshold ?? 20)
 const minChangePercent = ref(props.settings.minChangePercent ?? 10)
 
+// Column visibility
+const hiddenCols = ref(props.settings.hiddenCols ?? [])
+const showColMenu = ref(false)
+const colMenuRef = ref(null)
+
+const handleClickOutside = (e) => {
+  if (colMenuRef.value && !colMenuRef.value.contains(e.target)) {
+    showColMenu.value = false
+  }
+}
+onMounted(() => document.addEventListener('click', handleClickOutside))
+onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
+
+
 // Persist filter settings to layout
 watch(
-  [() => volumeThreshold.value, () => relVolumeThreshold.value, () => minPriceThreshold.value, () => maxPriceThreshold.value, () => minChangePercent.value],
+  [() => hiddenCols.value,
+   () => volumeThreshold.value, () => relVolumeThreshold.value, () => minPriceThreshold.value, () => maxPriceThreshold.value, () => minChangePercent.value],
   () => {
-    emit('update-settings', { volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value, minChangePercent: minChangePercent.value })
+    emit('update-settings', { hiddenCols: hiddenCols.value, volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value, minChangePercent: minChangePercent.value })
   }
 )
 
@@ -254,4 +293,54 @@ const getRowClass = (row) => {
   height: 100%;
   overflow: auto;
 }
+.col-menu-wrap {
+  position: relative;
+}
+
+.col-menu-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.col-menu-btn:hover { background: #2a2a2a; }
+
+.col-menu-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: #1e1e1e;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 8px;
+  min-width: 160px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+
+.col-menu-title {
+  font-size: 11px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.col-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #ccc;
+  padding: 3px 0;
+  cursor: pointer;
+  user-select: none;
+}
+.col-menu-item input { cursor: pointer; }
+.col-menu-item:has(input:disabled) { opacity: 0.4; cursor: default; }
 </style>

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -43,6 +43,25 @@
         <input type="checkbox" v-model="showGappersOnly" />
         Gappers Only
       </label>
+      <!-- Column visibility gear menu -->
+      <div class="col-menu-wrap" ref="colMenuRef">
+        <button class="col-menu-btn" @click="showColMenu = !showColMenu" title="Show/hide columns">⚙️</button>
+        <div v-if="showColMenu" class="col-menu-popover">
+          <div class="col-menu-title">Columns</div>
+          <label v-for="col in columns" :key="col.key" class="col-menu-item">
+            <input
+              type="checkbox"
+              :checked="!hiddenCols.includes(col.key)"
+              :disabled="col.key === 'symbol'"
+              @change="e => {
+                if (e.target.checked) hiddenCols.value = hiddenCols.value.filter(k => k !== col.key)
+                else if (col.key !== 'symbol') hiddenCols.value = [...hiddenCols.value, col.key]
+              }"
+            />
+            {{ col.label }}
+          </label>
+        </div>
+      </div>
     </div>
 
     <GenericScannerTable
@@ -52,6 +71,10 @@
         :sort-dir="sortDir"
         :row-class-fn="getRowClass"
         :active-ticker="activeTicker"
+        :is-locked="isLocked"
+        :col-widths="colWidths"
+        :hidden-cols="hiddenCols"
+        @update-col-widths="$emit('update-col-widths', $event)"
         @sort="sortBy"
         @row-click="onRowClick"
     />
@@ -59,14 +82,15 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, watch } from 'vue'
+import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import GenericScannerTable from './GenericScannerTable.vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useScannerLink } from '@/composables/useScannerLink.js'
 
-const emit = defineEmits(['update-settings'])
+const emit = defineEmits(['update-settings', 'update-col-widths'])
 const props = defineProps({
   isLocked:  { type: Boolean, default: true },
+  colWidths:  { type: Object,  default: () => ({}) },
   linkColor: { type: String,  default: null },
   isMobile:  { type: Boolean, default: false },
   settings:  { type: Object,  default: () => ({}) },
@@ -90,11 +114,26 @@ const minPriceThreshold = ref(props.settings.minPriceThreshold ?? 2)
 const maxPriceThreshold = ref(props.settings.maxPriceThreshold ?? 20)
 
 
+// Column visibility
+const hiddenCols = ref(props.settings.hiddenCols ?? [])
+const showColMenu = ref(false)
+const colMenuRef = ref(null)
+
+const handleClickOutside = (e) => {
+  if (colMenuRef.value && !colMenuRef.value.contains(e.target)) {
+    showColMenu.value = false
+  }
+}
+onMounted(() => document.addEventListener('click', handleClickOutside))
+onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
+
+
 // Persist filter settings to layout
 watch(
-  [() => volumeThreshold.value, () => relVolumeThreshold.value, () => showGappersOnly.value, () => minPriceThreshold.value, () => maxPriceThreshold.value],
+  [() => hiddenCols.value,
+   () => volumeThreshold.value, () => relVolumeThreshold.value, () => showGappersOnly.value, () => minPriceThreshold.value, () => maxPriceThreshold.value],
   () => {
-    emit('update-settings', { volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, showGappersOnly: showGappersOnly.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value })
+    emit('update-settings', { hiddenCols: hiddenCols.value, volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, showGappersOnly: showGappersOnly.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value })
   }
 )
 const { lastDataAt, isConnected, reconnecting } = useWebSocketClient({
@@ -268,4 +307,54 @@ const getRowClass = (row) => {
   height: 100%;
   overflow: auto;
 }
+.col-menu-wrap {
+  position: relative;
+}
+
+.col-menu-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.col-menu-btn:hover { background: #2a2a2a; }
+
+.col-menu-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: #1e1e1e;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 8px;
+  min-width: 160px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+
+.col-menu-title {
+  font-size: 11px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.col-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #ccc;
+  padding: 3px 0;
+  cursor: pointer;
+  user-select: none;
+}
+.col-menu-item input { cursor: pointer; }
+.col-menu-item:has(input:disabled) { opacity: 0.4; cursor: default; }
 </style>


### PR DESCRIPTION
Implements column resize and column visibility for TopGainers, TopGappers, and TopVolume.

## Column Resize

- Drag handle on `<th>` right edge — only visible when unlocked (edit mode)
- Width persists to layout via existing `update-col-widths` → `DashboardGrid` mechanism

## Column Visibility

- Gear icon ⚙️ in the scanner controls bar opens a compact column checklist
- Symbol column is always visible (disabled checkbox)
- Hidden columns removed from both header and data rows via `visibleColumns` computed
- Visibility persists to layout via `settings.hiddenCols` → `update-settings`
- Click-outside closes the popover

## Technical notes

- `GenericScannerTable` gains `colWidths`, `hiddenCols`, `isLocked` props and `update-col-widths` emit
- Scanner widgets gain `colWidths` prop (was already passed down from `DashboardGrid` → `WidgetWrapper` → widget but unused)
- Default: all columns visible, no widths set — zero behavioral change for existing layouts

refs #83