### PR TITLE
fix(scanners): column visibility toggles now work correctly

### DIFF
--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -51,11 +51,7 @@
               type="checkbox"
               :checked="!hiddenCols.includes(col.key)"
               :disabled="col.key === 'symbol'"
-              @change="e => {
-                if (e.target.checked) hiddenCols.value = hiddenCols.value.filter(k => k !== col.key)
-                else if (col.key !== 'symbol') hiddenCols.value = [...hiddenCols.value, col.key]
-              }"
-            />
+              @change="toggleCol(col.key, $event.target.checked)"
             {{ col.label }}
           </label>
         </div>
@@ -125,10 +121,21 @@ const handleClickOutside = (e) => {
 onMounted(() => document.addEventListener('click', handleClickOutside))
 onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
 
+const toggleCol = (key, visible) => {
+  if (key === 'symbol') return  // symbol is always visible
+  if (visible) {
+    hiddenCols.value = hiddenCols.value.filter(k => k !== key)
+  } else {
+    if (!hiddenCols.value.includes(key)) {
+      hiddenCols.value = [...hiddenCols.value, key]
+    }
+  }
+}
+
 
 // Persist filter settings to layout
 watch(
-  [() => hiddenCols.value,
+  [() => [...hiddenCols.value],
    () => volumeThreshold.value, () => relVolumeThreshold.value, () => minPriceThreshold.value, () => maxPriceThreshold.value, () => minChangePercent.value],
   () => {
     emit('update-settings', { hiddenCols: hiddenCols.value, volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value, minChangePercent: minChangePercent.value })

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -51,11 +51,7 @@
               type="checkbox"
               :checked="!hiddenCols.includes(col.key)"
               :disabled="col.key === 'symbol'"
-              @change="e => {
-                if (e.target.checked) hiddenCols.value = hiddenCols.value.filter(k => k !== col.key)
-                else if (col.key !== 'symbol') hiddenCols.value = [...hiddenCols.value, col.key]
-              }"
-            />
+              @change="toggleCol(col.key, $event.target.checked)"
             {{ col.label }}
           </label>
         </div>
@@ -124,10 +120,21 @@ const handleClickOutside = (e) => {
 onMounted(() => document.addEventListener('click', handleClickOutside))
 onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
 
+const toggleCol = (key, visible) => {
+  if (key === 'symbol') return  // symbol is always visible
+  if (visible) {
+    hiddenCols.value = hiddenCols.value.filter(k => k !== key)
+  } else {
+    if (!hiddenCols.value.includes(key)) {
+      hiddenCols.value = [...hiddenCols.value, key]
+    }
+  }
+}
+
 
 // Persist filter settings to layout
 watch(
-  [() => hiddenCols.value,
+  [() => [...hiddenCols.value],
    () => volumeThreshold.value, () => relVolumeThreshold.value, () => minPriceThreshold.value, () => maxPriceThreshold.value, () => minChangePercent.value],
   () => {
     emit('update-settings', { hiddenCols: hiddenCols.value, volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value, minChangePercent: minChangePercent.value })

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -53,11 +53,7 @@
               type="checkbox"
               :checked="!hiddenCols.includes(col.key)"
               :disabled="col.key === 'symbol'"
-              @change="e => {
-                if (e.target.checked) hiddenCols.value = hiddenCols.value.filter(k => k !== col.key)
-                else if (col.key !== 'symbol') hiddenCols.value = [...hiddenCols.value, col.key]
-              }"
-            />
+              @change="toggleCol(col.key, $event.target.checked)"
             {{ col.label }}
           </label>
         </div>
@@ -127,10 +123,21 @@ const handleClickOutside = (e) => {
 onMounted(() => document.addEventListener('click', handleClickOutside))
 onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
 
+const toggleCol = (key, visible) => {
+  if (key === 'symbol') return  // symbol is always visible
+  if (visible) {
+    hiddenCols.value = hiddenCols.value.filter(k => k !== key)
+  } else {
+    if (!hiddenCols.value.includes(key)) {
+      hiddenCols.value = [...hiddenCols.value, key]
+    }
+  }
+}
+
 
 // Persist filter settings to layout
 watch(
-  [() => hiddenCols.value,
+  [() => [...hiddenCols.value],
    () => volumeThreshold.value, () => relVolumeThreshold.value, () => showGappersOnly.value, () => minPriceThreshold.value, () => maxPriceThreshold.value],
   () => {
     emit('update-settings', { hiddenCols: hiddenCols.value, volumeThreshold: volumeThreshold.value, relVolumeThreshold: relVolumeThreshold.value, showGappersOnly: showGappersOnly.value, minPriceThreshold: minPriceThreshold.value, maxPriceThreshold: maxPriceThreshold.value })


### PR DESCRIPTION
Fixes two bugs in the column visibility feature shipped in PR #84:

**Bug 1 — Toggles did nothing:** Inline `@change` handler mixed auto-unwrapped template context with explicit `.value` access. Replaced with a named `toggleCol(key, visible)` method.

**Bug 2 — Settings not persisted:** Watch source `() => hiddenCols.value` captured the array reference — since we replace the array rather than mutate in place, Vue's shallow comparison saw no change. Fixed by spreading: `() => [...hiddenCols.value]`.

refs #83