### PR TITLE
fix: restore missing /> on checkbox input in scanner column menu

### DIFF
--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -52,6 +52,7 @@
               :checked="!hiddenCols.includes(col.key)"
               :disabled="col.key === 'symbol'"
               @change="toggleCol(col.key, $event.target.checked)"
+            />
             {{ col.label }}
           </label>
         </div>

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -52,6 +52,7 @@
               :checked="!hiddenCols.includes(col.key)"
               :disabled="col.key === 'symbol'"
               @change="toggleCol(col.key, $event.target.checked)"
+            />
             {{ col.label }}
           </label>
         </div>

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -54,6 +54,7 @@
               :checked="!hiddenCols.includes(col.key)"
               :disabled="col.key === 'symbol'"
               @change="toggleCol(col.key, $event.target.checked)"
+            />
             {{ col.label }}
           </label>
         </div>


### PR DESCRIPTION
PR #85 merged with a template syntax error: the `<input>` self-closing tag was missing its `/>` and had duplicate `:checked`/`:disabled` attributes, causing the Vite build to fail with `Illegal '/' in tags` at compile time. This patch restores the correct template.