### PR TITLE
fix(scanners): sync all filter state when settings prop changes (layout load race condition)

### DIFF
--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -113,10 +113,16 @@ const minChangePercent = ref(props.settings.minChangePercent ?? 10)
 const hiddenCols = ref(props.settings.hiddenCols ?? [])
 const showColMenu = ref(false)
 
-// Sync hiddenCols when settings change (e.g. layout load after browser refresh)
-watch(() => props.settings.hiddenCols, (v) => {
-  hiddenCols.value = v ?? []
+// Sync all filter state when settings prop changes (layout load after refresh)
+watch(() => props.settings, (s) => {
+  volumeThreshold.value    = s.volumeThreshold    ?? '100'
+  relVolumeThreshold.value = s.relVolumeThreshold ?? '5'
+  minPriceThreshold.value  = s.minPriceThreshold  ?? 2
+  maxPriceThreshold.value  = s.maxPriceThreshold  ?? 20
+  minChangePercent.value   = s.minChangePercent   ?? 10
+  hiddenCols.value         = s.hiddenCols         ?? []
 })
+
 const colMenuRef = ref(null)
 
 const handleClickOutside = (e) => {

--- a/client/src/components/widgets/TopGainers.vue
+++ b/client/src/components/widgets/TopGainers.vue
@@ -112,6 +112,11 @@ const minChangePercent = ref(props.settings.minChangePercent ?? 10)
 // Column visibility
 const hiddenCols = ref(props.settings.hiddenCols ?? [])
 const showColMenu = ref(false)
+
+// Sync hiddenCols when settings change (e.g. layout load after browser refresh)
+watch(() => props.settings.hiddenCols, (v) => {
+  hiddenCols.value = v ?? []
+})
 const colMenuRef = ref(null)
 
 const handleClickOutside = (e) => {

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -111,6 +111,11 @@ const minChangePercent = ref(props.settings.minChangePercent ?? 10)
 // Column visibility
 const hiddenCols = ref(props.settings.hiddenCols ?? [])
 const showColMenu = ref(false)
+
+// Sync hiddenCols when settings change (e.g. layout load after browser refresh)
+watch(() => props.settings.hiddenCols, (v) => {
+  hiddenCols.value = v ?? []
+})
 const colMenuRef = ref(null)
 
 const handleClickOutside = (e) => {

--- a/client/src/components/widgets/TopGappers.vue
+++ b/client/src/components/widgets/TopGappers.vue
@@ -112,10 +112,16 @@ const minChangePercent = ref(props.settings.minChangePercent ?? 10)
 const hiddenCols = ref(props.settings.hiddenCols ?? [])
 const showColMenu = ref(false)
 
-// Sync hiddenCols when settings change (e.g. layout load after browser refresh)
-watch(() => props.settings.hiddenCols, (v) => {
-  hiddenCols.value = v ?? []
+// Sync all filter state when settings prop changes (layout load after refresh)
+watch(() => props.settings, (s) => {
+  volumeThreshold.value    = s.volumeThreshold    ?? '100'
+  relVolumeThreshold.value = s.relVolumeThreshold ?? '5'
+  minPriceThreshold.value  = s.minPriceThreshold  ?? 2
+  maxPriceThreshold.value  = s.maxPriceThreshold  ?? 20
+  minChangePercent.value   = s.minChangePercent   ?? 10
+  hiddenCols.value         = s.hiddenCols         ?? []
 })
+
 const colMenuRef = ref(null)
 
 const handleClickOutside = (e) => {

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -114,6 +114,11 @@ const maxPriceThreshold = ref(props.settings.maxPriceThreshold ?? 20)
 // Column visibility
 const hiddenCols = ref(props.settings.hiddenCols ?? [])
 const showColMenu = ref(false)
+
+// Sync hiddenCols when settings change (e.g. layout load after browser refresh)
+watch(() => props.settings.hiddenCols, (v) => {
+  hiddenCols.value = v ?? []
+})
 const colMenuRef = ref(null)
 
 const handleClickOutside = (e) => {

--- a/client/src/components/widgets/TopVolume.vue
+++ b/client/src/components/widgets/TopVolume.vue
@@ -115,10 +115,16 @@ const maxPriceThreshold = ref(props.settings.maxPriceThreshold ?? 20)
 const hiddenCols = ref(props.settings.hiddenCols ?? [])
 const showColMenu = ref(false)
 
-// Sync hiddenCols when settings change (e.g. layout load after browser refresh)
-watch(() => props.settings.hiddenCols, (v) => {
-  hiddenCols.value = v ?? []
+// Sync all filter state when settings prop changes (layout load after refresh)
+watch(() => props.settings, (s) => {
+  volumeThreshold.value    = s.volumeThreshold    ?? '100'
+  relVolumeThreshold.value = s.relVolumeThreshold ?? '5'
+  showGappersOnly.value    = s.showGappersOnly    ?? false
+  minPriceThreshold.value  = s.minPriceThreshold  ?? 2
+  maxPriceThreshold.value  = s.maxPriceThreshold  ?? 20
+  hiddenCols.value         = s.hiddenCols         ?? []
 })
+
 const colMenuRef = ref(null)
 
 const handleClickOutside = (e) => {


### PR DESCRIPTION
## Problem

After a browser refresh, scanner filter settings (volume threshold, price range, change%, hidden columns) required loading the layout twice before taking effect. The same bug affected all filter refs, not just hidden columns.

## Root Cause

Vue reuses component instances when layout items share the same `i` key. All filter refs were initialized from `props.settings` at mount time only. When `loadLayout()` replaces the layout data, `props.settings` updates but the local refs didn't react to it.

## Fix

One `watch(() => props.settings, ...)` per widget syncs all refs when the settings prop changes:

```js
watch(() => props.settings, (s) => {
  volumeThreshold.value    = s.volumeThreshold    ?? '100'
  relVolumeThreshold.value = s.relVolumeThreshold ?? '5'
  minPriceThreshold.value  = s.minPriceThreshold  ?? 2
  maxPriceThreshold.value  = s.maxPriceThreshold  ?? 20
  minChangePercent.value   = s.minChangePercent   ?? 10
  hiddenCols.value         = s.hiddenCols         ?? []
})
```

Single watch per widget. Covers all filter refs. No watch proliferation.