### PR TITLE
fix(Quote): broadcast manual ticker to widget bus; fix mobile Go button

### DIFF
--- a/client/src/components/widgets/Quote.vue
+++ b/client/src/components/widgets/Quote.vue
@@ -11,7 +11,7 @@
         @keyup.enter="applyInput"
         @keyup.escape="inputTicker = ''"
       />
-      <button class="quote-go-btn" @click="applyInput" title="Load quote">Go</button>
+      <button class="quote-go-btn" @click="applyInput" @touchend.prevent="applyInput" title="Load quote">Go</button>
     </div>
 
     <!-- No ticker yet -->
@@ -96,7 +96,7 @@ const props = defineProps({
 defineEmits(['update-settings'])
 
 const appConfig = window.__APP_CONFIG__ || {}
-const { activeTickers } = useWidgetBus()
+const { activeTickers, setActiveTicker } = useWidgetBus()
 
 // Manual entry — not persisted, ephemeral
 const inputTicker = ref('')
@@ -111,9 +111,12 @@ const activeTicker = computed(() => busTicker.value || manualTicker.value || nul
 
 const applyInput = () => {
   const t = inputTicker.value.trim().toUpperCase()
-  if (t) {
-    manualTicker.value = t
-    inputTicker.value = ''
+  if (!t) return
+  manualTicker.value = t
+  inputTicker.value = ''
+  // Broadcast to widget bus so linked widgets (news feed, etc.) also update
+  if (props.linkColor) {
+    setActiveTicker(props.linkColor, t)
   }
 }
 


### PR DESCRIPTION
Fixes two bugs with manual ticker entry in the Quote widget.

## Bug 1 — Mobile Go button does nothing

`@click` is unreliable on iOS/mobile due to touch event timing. Added `@touchend.prevent="applyInput"` so the button fires on touch.

## Bug 2 — Linked widgets not updated on manual entry

`applyInput()` set the local `manualTicker` ref but never called `setActiveTicker()` on the widget bus. Linked news feed (and other linked widgets) never received the ticker.

Fix: call `setActiveTicker(props.linkColor, t)` in `applyInput()` when a link color is configured. Manual entry now behaves identically to clicking a scanner row for linked widgets.