### PR TITLE
feat(NewsFeed): include M/D date prefix in time column

### DIFF
--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -378,7 +378,11 @@ const sentimentClass = (s) => {
 const formatTime = (ts) => {
   if (!ts) return ''
   const d = new Date(ts)
-  return isNaN(d.getTime()) ? '' : d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  if (isNaN(d.getTime())) return ''
+  const month = d.getMonth() + 1          // no zero-padding needed, JS returns 1-12
+  const day   = d.getDate()               // no zero-padding needed, JS returns 1-31
+  const time  = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return `${month}/${day} ${time}`
 }
 
 const formatDateTime = (ts) => {


### PR DESCRIPTION
With the article cache spanning multiple days, the time-only column was ambiguous — users had to open the popup just to see the date.

**Change:** Time column format updated from `12:00 AM` to `4/1 12:00 AM` (M/D with no zero-padding).

Examples:
```
4/1 12:00 AM
3/31 11:59 PM
1/1 12:00 AM
12/31 11:59 PM
```

Also bumped the default time column width from 90px → 115px to fit the wider format.