### PR TITLE
feat(Quote): add prev_day open/high/low to Previous Day section

### DIFF
--- a/client/src/components/widgets/Quote.vue
+++ b/client/src/components/widgets/Quote.vue
@@ -76,6 +76,9 @@
       <!-- Previous day -->
       <div class="quote-section-label">Previous Day</div>
       <div class="quote-grid">
+        <div class="quote-kv"><span class="quote-k">PD Open</span><span class="quote-v">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+        <div class="quote-kv"><span class="quote-k">PD High</span><span class="quote-v">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+        <div class="quote-kv"><span class="quote-k">PD Low</span><span class="quote-v">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
         <div class="quote-kv"><span class="quote-k">PD Close</span><span class="quote-v">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
         <div class="quote-kv"><span class="quote-k">PD Volume</span><span class="quote-v">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
         <div class="quote-kv"><span class="quote-k">PD VWAP</span><span class="quote-v">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>


### PR DESCRIPTION
Completes the Previous Day section of the Quote widget with the full OHLC picture.

**Before:** PD Close / PD Volume / PD VWAP
**After:** PD Open / PD High / PD Low / PD Close / PD Volume / PD VWAP

Fields sourced from `prev_day_open`, `prev_day_high`, `prev_day_low` in the `quote:{symbol}` payload, published by `LeaderboardAnalyzer` as of `kuhl-haus-mdp` v0.3.11 (kuhl-haus/kuhl-haus-mdp#55).

Gracefully renders as $0.00 when fields are absent — the existing `fmt()` helper handles null/undefined safely.

refs #97