### PR TITLE
fix(CompanyNews): don't auto-connect until ticker is set

### DIFF
--- a/client/src/components/widgets/CompanyNews.vue
+++ b/client/src/components/widgets/CompanyNews.vue
@@ -276,7 +276,7 @@ const searchQuery = ref('')
 
 const currentFeed = ref('')
 
-const { feedName, cacheKey, isConnected, reconnecting, getCache, subscribe, unsubscribe, cacheLimit } = useWebSocketClient({
+const { feedName, cacheKey, isConnected, reconnecting, getCache, subscribe, unsubscribe, connect, cacheLimit } = useWebSocketClient({
   wsUrl:     appConfig.wsEndpoint || 'ws://localhost:4202/ws',
   authKey:   appConfig.apiKey || 'secret',
   feedName:  '',
@@ -291,7 +291,7 @@ const { feedName, cacheKey, isConnected, reconnecting, getCache, subscribe, unsu
     const combined = [...fresh, ...newsItems.value]
     newsItems.value = combined.slice(0, maxArticles.value)
   },
-  autoConnect: true,
+  autoConnect: false,  // connect manually when ticker is set
 })
 
 // Re-subscribe when ticker changes
@@ -307,8 +307,13 @@ watch(activeTicker, (newTicker, oldTicker) => {
     currentFeed.value = feed
     feedName.value = feed
     cacheKey.value = feed
-    subscribe()
-    getCache()
+    if (!isConnected.value) {
+      // First ticker set — connect now (autoConnect was false to avoid subscribing with empty feed)
+      connect()
+    } else {
+      subscribe()
+      getCache()
+    }
   }
 })
 


### PR DESCRIPTION
**Problem:** With `autoConnect: true` and an empty `feedName`, the WDS received an invalid subscribe request on connect, causing an immediate error/close and a persistent reconnect loop (🔵/🟣 pulsing icon).

**Fix:** `autoConnect: false` — `connect()` is called manually when the first ticker is set. Subsequent ticker changes use `subscribe`/`unsubscribe` as before. The existing `watch(isConnected)` handler fires after connect succeeds and issues `subscribe + getCache`.

Compare: `NewsFeed` initializes with a valid `feedName: 'news:feed:latest'`, so `autoConnect: true` works there. `CompanyNews` has no feed until the user picks a ticker.