### PR TITLE
fix(CompanyNews): remove flex from news-card-title

### DIFF
--- a/client/src/components/widgets/CompanyNews.vue
+++ b/client/src/components/widgets/CompanyNews.vue
@@ -546,7 +546,8 @@ const openDetail = (item) => { selected.value = item }
   display: inline-block;
   width: 6px; height: 6px;
   border-radius: 50%;
-  flex-shrink: 0;
+  margin-right: 5px;
+  vertical-align: middle;
 }
 .sentiment-dot.positive { background: #22c55e; }
 .sentiment-dot.negative { background: #ef4444; }
@@ -577,7 +578,7 @@ const openDetail = (item) => { selected.value = item }
   margin-bottom: 4px;
 }
 .news-card-time  { font-size: 11px; color: #666; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.news-card-title { font-size: 13px; color: #ddd; line-height: 1.4; display: flex; gap: 5px; align-items: center; }
+.news-card-title { font-size: 13px; color: #ddd; line-height: 1.4; }
 
 /* ── Empty ── */
 .news-empty {


### PR DESCRIPTION
`display: flex` on `.news-card-title` caused two bugs:
- Source became a separate flex item → right-aligned away from headline
- Multi-line headlines center-justified instead of top-aligned

Fix: remove `display: flex / gap / align-items`, matching NewsFeed exactly. Sentiment dot uses `inline-block + vertical-align: middle` to sit in the text flow.

Supersedes PR #113.