### PR TITLE
fix: temporarily disable Short Interest section in EnhancedQuote widget

### DIFF
--- a/client/src/components/widgets/EnhancedQuote.vue
+++ b/client/src/components/widgets/EnhancedQuote.vue
@@ -89,7 +89,8 @@
         <div class="eq-kv"><span class="eq-k">VWAP</span><span class="eq-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
       </div>
 
-      <!-- Short Interest -->
+      <!-- Short Interest — temporarily disabled (refs #85) -->
+      <!-- TODO: re-enable once short interest/volume enrichment is stable
       <div class="eq-section-label">Short Interest</div>
       <div v-if="allShortNull" class="eq-short-loading">Short interest data loading...</div>
       <div v-else class="eq-grid">
@@ -97,6 +98,7 @@
         <div class="eq-kv"><span class="eq-k">Days to Cover</span><span class="eq-v">{{ fmt(quoteData.days_to_cover, 1) }}</span></div>
         <div class="eq-kv"><span class="eq-k">Short Vol Ratio</span><span class="eq-v">{{ fmt(quoteData.short_volume_ratio, 1) }}%</span></div>
       </div>
+      -->
 
       <!-- Volume -->
       <div class="eq-section-label">Volume</div>


### PR DESCRIPTION
Short interest and volume enrichment is disabled in MDS until issue #85 is fully resolved. Hides the section rather than showing a permanent null/loading state.

TODO comment in place to re-enable once stabilized.

refs #85