### PR TITLE
feat: wire EnhancedQuote widget to REST company enrichment endpoint

### DIFF
--- a/client/src/components/widgets/EnhancedQuote.vue
+++ b/client/src/components/widgets/EnhancedQuote.vue
@@ -50,19 +50,20 @@
         </span>
       </div>
 
-      <!-- Company -->
+      <!-- Company — populated via REST /api/market_data/company/{symbol} -->
       <div class="eq-section-label">Company</div>
-      <div v-if="allCompanyNull" class="eq-company-loading">Company data loading...</div>
+      <div v-if="companyLoading" class="eq-company-loading">Company data loading...</div>
+      <div v-else-if="allCompanyNull" class="eq-company-loading">Company data unavailable</div>
       <div v-else class="eq-grid eq-grid--full">
-        <div class="eq-kv"><span class="eq-k">Name</span><span class="eq-v">{{ quoteData.name || '—' }}</span></div>
-        <div class="eq-kv"><span class="eq-k">Exchange</span><span class="eq-v">{{ quoteData.primary_exchange || '—' }}</span></div>
-        <div class="eq-kv"><span class="eq-k">Sector</span><span class="eq-v">{{ quoteData.sic_description || '—' }}</span></div>
-        <div class="eq-kv"><span class="eq-k">Market Cap</span><span class="eq-v">{{ quoteData.market_cap != null ? '$' + fmtVol(quoteData.market_cap) : '—' }}</span></div>
-        <div class="eq-kv"><span class="eq-k">Employees</span><span class="eq-v">{{ quoteData.total_employees != null ? fmtVol(quoteData.total_employees) : '—' }}</span></div>
-        <div class="eq-kv"><span class="eq-k">Listed</span><span class="eq-v">{{ quoteData.list_date || '—' }}</span></div>
-        <div v-if="quoteData.homepage_url" class="eq-kv eq-kv--full">
+        <div class="eq-kv"><span class="eq-k">Name</span><span class="eq-v">{{ companyData.name || '—' }}</span></div>
+        <div class="eq-kv"><span class="eq-k">Exchange</span><span class="eq-v">{{ companyData.primary_exchange || '—' }}</span></div>
+        <div class="eq-kv"><span class="eq-k">Sector</span><span class="eq-v">{{ companyData.sic_description || '—' }}</span></div>
+        <div class="eq-kv"><span class="eq-k">Market Cap</span><span class="eq-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
+        <div class="eq-kv"><span class="eq-k">Employees</span><span class="eq-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
+        <div class="eq-kv"><span class="eq-k">Listed</span><span class="eq-v">{{ companyData.list_date || '—' }}</span></div>
+        <div v-if="companyData.homepage_url" class="eq-kv eq-kv--full">
           <span class="eq-k">Website</span>
-          <a :href="quoteData.homepage_url" target="_blank" rel="noopener noreferrer" class="eq-link">{{ truncateUrl(quoteData.homepage_url) }}</a>
+          <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eq-link">{{ truncateUrl(companyData.homepage_url) }}</a>
         </div>
         <div v-else class="eq-kv"><span class="eq-k">Website</span><span class="eq-v">—</span></div>
       </div>
@@ -219,6 +220,28 @@ watch(busTicker, (t) => {
 const quoteData = ref(null)
 const lastDataAt = ref(null)
 
+// Company enrichment — fetched via REST on ticker change
+const companyData = ref({})
+const companyLoading = ref(false)
+
+const fetchCompany = async (symbol) => {
+  if (!symbol) return
+  companyLoading.value = true
+  companyData.value = {}
+  try {
+    const resp = await fetch(`/api/market_data/company/${symbol}`)
+    if (resp.ok) {
+      const json = await resp.json()
+      companyData.value = json.data || {}
+    }
+  } catch (e) {
+    // Network error — leave companyData empty, UI shows unavailable
+    console.warn(`[EnhancedQuote] company fetch failed for ${symbol}:`, e)
+  } finally {
+    companyLoading.value = false
+  }
+}
+
 // WebSocket client — always-on connection, swap feed on ticker change
 const currentFeed = ref('')
 
@@ -244,7 +267,9 @@ watch(activeTicker, (newTicker) => {
     currentFeed.value = ''
   }
   quoteData.value = null
+  companyData.value = {}
   if (newTicker) {
+    fetchCompany(newTicker)
     const feed = `daily_range:${newTicker}`
     feedName.value = feed
     cacheKey.value = feed
@@ -321,14 +346,15 @@ const allShortNull = computed(() => {
 
 // Company: null if all company fields are null
 const allCompanyNull = computed(() => {
-  if (!quoteData.value) return true
-  return quoteData.value.name == null &&
-         quoteData.value.primary_exchange == null &&
-         quoteData.value.sic_description == null &&
-         quoteData.value.market_cap == null &&
-         quoteData.value.total_employees == null &&
-         quoteData.value.list_date == null &&
-         quoteData.value.homepage_url == null
+  const d = companyData.value
+  if (!d) return true
+  return d.name == null &&
+         d.primary_exchange == null &&
+         d.sic_description == null &&
+         d.market_cap == null &&
+         d.total_employees == null &&
+         d.list_date == null &&
+         d.homepage_url == null
 })
 
 const truncateUrl = (url) => {
@@ -336,7 +362,7 @@ const truncateUrl = (url) => {
   return url.replace(/^https?:\/\//, '').replace(/\/$/, '').slice(0, 30)
 }
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading })
 </script>
 
 <style scoped>

--- a/client/src/components/widgets/__tests__/EnhancedQuote.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuote.spec.js
@@ -55,6 +55,11 @@ function mountWidget(props = {}) {
 describe('EnhancedQuote', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Mock fetch for company enrichment endpoint
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ symbol: 'TSLA', data: {}, available: false }),
+    })
   })
 
   it('renders without crashing', () => {
@@ -166,30 +171,59 @@ describe('EnhancedQuote', () => {
     expect(shortSection.exists()).toBe(false)
   })
 
-  it('hides company section when all company fields are null', async () => {
+  it('shows unavailable state when fetch returns empty data', async () => {
+    // Mock fetch returning empty company data
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ symbol: 'TSLA', data: {}, available: false }),
+    })
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
     await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = {
-      symbol: 'TSLA',
-      close: 250.00,
-      change: 5.00,
-      pct_change: 2.04,
-      pct_change_since_open: 1.5,
-      change_since_open: 3.75,
-      end_timestamp: Date.now(),
-      name: null,
-      primary_exchange: null,
-      sic_description: null,
-      market_cap: null,
-      total_employees: null,
-      list_date: null,
-      homepage_url: null,
+      symbol: 'TSLA', close: 250.00, change: 5.00,
+      pct_change: 2.04, pct_change_since_open: 1.5,
+      change_since_open: 3.75, end_timestamp: Date.now(),
     }
+    // Wait for fetchCompany to complete
+    await new Promise(r => setTimeout(r, 0))
     await wrapper.vm.$nextTick()
-    const companyLoading = wrapper.find('.eq-company-loading')
-    expect(companyLoading.exists()).toBe(true)
-    expect(companyLoading.text()).toContain('Company data loading')
+    const msg = wrapper.find('.eq-company-loading')
+    expect(msg.exists()).toBe(true)
+    expect(msg.text()).toContain('unavailable')
+  })
+
+  it('shows company data when fetch returns populated data', async () => {
+    // Mock fetch returning real company data
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        symbol: 'AAPL',
+        data: {
+          name: 'Apple Inc.',
+          primary_exchange: 'XNAS',
+          sic_description: 'Electronic Computers',
+          market_cap: 2500000000000,
+          total_employees: 164000,
+          list_date: '1980-12-12',
+          homepage_url: 'https://apple.com',
+        },
+      }),
+    })
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'AAPL'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = {
+      symbol: 'AAPL', close: 170.00, change: 1.00,
+      pct_change: 0.59, pct_change_since_open: 0.3,
+      change_since_open: 0.5, end_timestamp: Date.now(),
+    }
+    // Wait for fetchCompany to complete
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+    const body = wrapper.find('.eq-body')
+    expect(body.text()).toContain('Apple Inc.')
+    expect(body.text()).toContain('Electronic Computers')
   })
 
   it('hides splits section when splits array is empty', async () => {


### PR DESCRIPTION
On ticker change, fires `GET /api/market_data/company/{symbol}` to populate the Company section. Company data no longer comes from the WS feed (DailyRangeAnalyzer only publishes HOD/LOD).

- `companyData` ref populated via `fetchCompany()` on `activeTicker` change
- Loading state while fetch is in flight  
- 'Unavailable' state when API returns no data
- 10 tests