### PR TITLE
feat(ci): add GitHub Actions workflow for frontend tests

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -1,0 +1,33 @@
+name: Frontend Tests
+
+on:
+  push:
+    branches: [ mainline ]
+  pull_request:
+    branches: [ mainline ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Vitest
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: client
+
+      - name: Run tests
+        run: npm test
+        working-directory: client


### PR DESCRIPTION
Adds `.github/workflows/test-frontend.yml` — runs Vitest on push to mainline and on all PRs targeting mainline. Node 22, `npm ci` in `client/`, cache keyed on `package-lock.json`.

Depends on #57 (already merged).

closes #62