### PR TITLE
feat(testing): add useConfig and useScannerLink composable tests

### DIFF
--- a/client/src/composables/__tests__/useConfig.spec.js
+++ b/client/src/composables/__tests__/useConfig.spec.js
@@ -1,0 +1,124 @@
+/**
+ * Tests for useConfig composable.
+ *
+ * useConfig is a module singleton — config/loading/error are module-level refs.
+ * Each test resets state by calling fetchConfig() with a fresh mock and
+ * directly resetting the refs via the returned references.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Reset module between tests to clear singleton state
+beforeEach(async () => {
+  vi.resetModules()
+})
+
+describe('useConfig', () => {
+
+  it('test_useConfig_with_successful_fetch_expect_config_returned', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ api_key: 'test-api-key', ws_endpoint: 'ws://localhost:4202/ws' }),
+    })
+
+    const { useConfig } = await import('../useConfig.js')
+    const { fetchConfig } = useConfig()
+
+    const result = await fetchConfig()
+
+    expect(result).toEqual({
+      apiKey: 'test-api-key',
+      wsEndpoint: 'ws://localhost:4202/ws',
+    })
+  })
+
+  it('test_useConfig_with_successful_fetch_expect_config_ref_populated', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ api_key: 'test-api-key', ws_endpoint: 'ws://localhost:4202/ws' }),
+    })
+
+    const { useConfig } = await import('../useConfig.js')
+    const { fetchConfig, config } = useConfig()
+
+    await fetchConfig()
+
+    expect(config.value?.apiKey).toBe('test-api-key')
+    expect(config.value?.wsEndpoint).toBe('ws://localhost:4202/ws')
+  })
+
+  it('test_useConfig_with_failed_fetch_expect_null_returned', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    })
+
+    const { useConfig } = await import('../useConfig.js')
+    const { fetchConfig } = useConfig()
+
+    const result = await fetchConfig()
+
+    expect(result).toBeNull()
+  })
+
+  it('test_useConfig_with_failed_fetch_expect_error_set', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    })
+
+    const { useConfig } = await import('../useConfig.js')
+    const { fetchConfig, error } = useConfig()
+
+    await fetchConfig()
+
+    expect(error.value).toContain('401')
+  })
+
+  it('test_useConfig_with_network_error_expect_null_returned', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+
+    const { useConfig } = await import('../useConfig.js')
+    const { fetchConfig } = useConfig()
+
+    const result = await fetchConfig()
+
+    expect(result).toBeNull()
+  })
+
+  it('test_useConfig_isAuthenticated_with_config_expect_true', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ api_key: 'test-api-key', ws_endpoint: 'ws://localhost:4202/ws' }),
+    })
+
+    const { useConfig } = await import('../useConfig.js')
+    const { fetchConfig, isAuthenticated } = useConfig()
+
+    await fetchConfig()
+
+    expect(isAuthenticated()).toBe(true)
+  })
+
+  it('test_useConfig_isAuthenticated_without_config_expect_false', async () => {
+    const { useConfig } = await import('../useConfig.js')
+    const { isAuthenticated } = useConfig()
+
+    expect(isAuthenticated()).toBe(false)
+  })
+
+  it('test_useConfig_loading_is_false_after_fetch_completes', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ api_key: 'key', ws_endpoint: 'ws://localhost' }),
+    })
+
+    const { useConfig } = await import('../useConfig.js')
+    const { fetchConfig, loading } = useConfig()
+
+    await fetchConfig()
+
+    expect(loading.value).toBe(false)
+  })
+})

--- a/client/src/composables/__tests__/useScannerLink.spec.js
+++ b/client/src/composables/__tests__/useScannerLink.spec.js
@@ -1,0 +1,125 @@
+/**
+ * Tests for useScannerLink composable.
+ *
+ * useScannerLink wraps useWidgetBus — test via onRowClick and verify
+ * activeTickers state. Reset bus between tests via clearActiveTicker.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { useScannerLink } from '../useScannerLink.js'
+import { useWidgetBus, LINK_COLORS } from '../useWidgetBus.js'
+
+function resetBus() {
+  const { clearActiveTicker } = useWidgetBus()
+  LINK_COLORS.forEach(c => clearActiveTicker(c.name))
+}
+
+describe('useScannerLink', () => {
+  beforeEach(() => {
+    resetBus()
+  })
+
+  // ------------------------------------------------------------------
+  // onRowClick
+  // ------------------------------------------------------------------
+
+  it('test_useScannerLink_with_color_and_ticker_expect_bus_updated', () => {
+    const linkColor = ref('blue')
+    const { onRowClick } = useScannerLink(linkColor)
+    const { activeTickers } = useWidgetBus()
+
+    onRowClick({ symbol: 'AAPL' })
+
+    expect(activeTickers['blue']).toBe('AAPL')
+  })
+
+  it('test_useScannerLink_with_no_color_expect_no_bus_update', () => {
+    const linkColor = ref(null)
+    const { onRowClick } = useScannerLink(linkColor)
+    const { activeTickers } = useWidgetBus()
+
+    onRowClick({ symbol: 'AAPL' })
+
+    LINK_COLORS.forEach(({ name }) => {
+      expect(activeTickers[name]).toBeNull()
+    })
+  })
+
+  it('test_useScannerLink_with_ticker_field_expect_bus_updated', () => {
+    // Some rows use 'ticker' instead of 'symbol'
+    const linkColor = ref('red')
+    const { onRowClick } = useScannerLink(linkColor)
+    const { activeTickers } = useWidgetBus()
+
+    onRowClick({ ticker: 'MSFT' })
+
+    expect(activeTickers['red']).toBe('MSFT')
+  })
+
+  it('test_useScannerLink_with_no_symbol_or_ticker_expect_no_bus_update', () => {
+    const linkColor = ref('green')
+    const { onRowClick } = useScannerLink(linkColor)
+    const { activeTickers } = useWidgetBus()
+
+    onRowClick({})
+
+    expect(activeTickers['green']).toBeNull()
+  })
+
+  it('test_useScannerLink_clicking_active_ticker_again_expect_clears', () => {
+    // Toggle behavior: clicking the same ticker clears it
+    const linkColor = ref('orange')
+    const { onRowClick } = useScannerLink(linkColor)
+    const { activeTickers } = useWidgetBus()
+
+    onRowClick({ symbol: 'NVDA' })
+    expect(activeTickers['orange']).toBe('NVDA')
+
+    onRowClick({ symbol: 'NVDA' })
+    expect(activeTickers['orange']).toBeNull()
+  })
+
+  it('test_useScannerLink_clicking_different_ticker_expect_updates', () => {
+    const linkColor = ref('cyan')
+    const { onRowClick } = useScannerLink(linkColor)
+    const { activeTickers } = useWidgetBus()
+
+    onRowClick({ symbol: 'AMD' })
+    onRowClick({ symbol: 'NVDA' })
+
+    expect(activeTickers['cyan']).toBe('NVDA')
+  })
+
+  // ------------------------------------------------------------------
+  // activeTicker computed
+  // ------------------------------------------------------------------
+
+  it('test_useScannerLink_activeTicker_reflects_bus_state', () => {
+    const linkColor = ref('violet')
+    const { activeTicker, onRowClick } = useScannerLink(linkColor)
+
+    expect(activeTicker.value).toBeNull()
+
+    onRowClick({ symbol: 'SPY' })
+    expect(activeTicker.value).toBe('SPY')
+  })
+
+  it('test_useScannerLink_activeTicker_with_no_color_expect_null', () => {
+    const linkColor = ref(null)
+    const { activeTicker } = useScannerLink(linkColor)
+
+    expect(activeTicker.value).toBeNull()
+  })
+
+  it('test_useScannerLink_activeTicker_updates_when_color_changes', () => {
+    const linkColor = ref('pink')
+    const { activeTicker, onRowClick } = useScannerLink(linkColor)
+
+    onRowClick({ symbol: 'QQQ' })
+    expect(activeTicker.value).toBe('QQQ')
+
+    // Switch to a color with no active ticker
+    linkColor.value = 'white'
+    expect(activeTicker.value).toBeNull()
+  })
+})


### PR DESCRIPTION
8 tests for `useConfig` and 9 tests for `useScannerLink`.

`useConfig` singleton state reset via `vi.resetModules()` in `beforeEach`. `useScannerLink` tested through bus state assertions.

closes #60