### PR TITLE
chore: add update-changelog.sh and CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,95 @@
+============
+Contributing
+============
+
+Welcome to ``kuhl-haus-mdp-app`` contributor's guide.
+
+Please notice, all users and contributors are expected to be **open,
+considerate, reasonable, and respectful**. When in doubt, `Python Software
+Foundation's Code of Conduct`_ is a good reference in terms of behavior
+guidelines.
+
+
+Issue Reports
+=============
+
+If you experience bugs or general issues with ``kuhl-haus-mdp-app``, please have a look
+on the `issue tracker`_. If you don't see anything useful there, please feel
+free to fire an issue report.
+
+
+Code Contributions
+==================
+
+Before diving in, please review the README_ for an overview of the application
+architecture and component descriptions.
+
+#. Create a branch to hold your changes::
+
+    git checkout -b my-feature
+
+   Never work on the main branch!
+
+#. When you're done editing::
+
+    git add <MODIFIED FILES>
+    git commit
+
+#. Run the backend unit tests::
+
+    pytest tests -v
+
+#. Run the frontend unit tests::
+
+    cd client && npm test
+
+#. Push your branch and open a pull request targeting ``mainline``.
+
+
+Maintainer tasks
+================
+
+Releases
+--------
+
+If you are part of the group of maintainers and have correct permissions
+on the container registry, the following steps can be used to release a new
+version of ``kuhl-haus-mdp-app``:
+
+#. Make sure all workflows for the latest commit are successful.
+
+#. Generate release notes by running the changelog script with the appropriate version bump:
+
+   **Linux / macOS / Windows with WSLv2:**
+
+   .. code-block:: bash
+
+      # For a patch release (e.g., 0.2.28 → 0.2.29)
+      ./update-changelog.sh --bump patch
+
+      # For a minor release (e.g., 0.2.28 → 0.3.0)
+      ./update-changelog.sh --bump minor
+
+      # For a major release (e.g., 0.2.28 → 1.0.0)
+      ./update-changelog.sh --bump major
+
+   The script will generate a new version section in ``CHANGELOG.rst`` with all
+   commits since the last tagged release.
+
+#. Review the generated ``CHANGELOG.rst``, commit it, and create a pull request
+   targeting the mainline branch.
+
+#. After the PR is merged, tag the merge commit on the mainline branch with the
+   corresponding release tag, e.g., ``v1.2.3``.
+
+#. Push the new tag to the upstream repository_, e.g., ``git push upstream v1.2.3``
+
+#. The `build-images`_ GitHub Actions workflow will build and push the Docker
+   image automatically.
+
+
+.. _repository: https://github.com/kuhl-haus/kuhl-haus-mdp-app
+.. _issue tracker: https://github.com/kuhl-haus/kuhl-haus-mdp-app/issues
+.. _build-images: https://github.com/kuhl-haus/kuhl-haus-mdp-app/actions/workflows/build-images.yml
+.. _README: https://github.com/kuhl-haus/kuhl-haus-mdp-app/blob/mainline/README.rst
+.. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/

--- a/update-changelog.sh
+++ b/update-changelog.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# update-changelog.sh
+# Generates CHANGELOG.rst from git tags and commits.
+#
+# Usage: update-changelog.sh [--bump <major|minor|patch>]
+#   --bump: How to increment version for unreleased commits (default: patch)
+
+set -euo pipefail
+
+# Parse arguments
+bump_type="patch"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bump)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --bump requires an argument (major|minor|patch)" >&2
+                exit 1
+            fi
+            bump_type="$2"
+            if [[ ! "$bump_type" =~ ^(major|minor|patch)$ ]]; then
+                echo "Error: --bump must be one of: major, minor, patch" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            echo "Usage: $0 [--bump <major|minor|patch>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+repo_url=$(git remote get-url origin | sed 's/\.git$//' | sed 's|git@github\.com:|https://github.com/|')
+
+outfile="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/CHANGELOG.rst"
+
+{
+    echo "========="
+    echo "Changelog"
+    echo "========="
+
+    mapfile -t tag_array < <(git tag --sort=-creatordate | grep '^v')
+
+    # Check if there are unreleased commits
+    if [[ ${#tag_array[@]} -gt 0 ]]; then
+        latest_tag="${tag_array[0]}"
+        unreleased_count=$(git rev-list --count "$latest_tag"..HEAD)
+
+        if ((unreleased_count > 0)); then
+            # Compute next version based on bump type
+            version="${latest_tag#v}"
+            IFS='.' read -r major minor patch <<< "$version"
+
+            case "$bump_type" in
+                major)
+                    major=$((major + 1))
+                    minor=0
+                    patch=0
+                    ;;
+                minor)
+                    minor=$((minor + 1))
+                    patch=0
+                    ;;
+                patch)
+                    patch=$((patch + 1))
+                    ;;
+            esac
+
+            next_version="${major}.${minor}.${patch}"
+            current_date=$(date +%Y-%m-%d)
+
+            # Add next version section
+            title="Version $next_version ($current_date)"
+            underline=$(printf '=%.0s' $(seq 1 ${#title}))
+
+            echo "$title"
+            echo "$underline"
+            echo ""
+
+            delim="---COMMIT_DELIM---"
+            raw=$(git log --format="${delim}%h %s%n%b" "$latest_tag"..HEAD)
+
+            # Process unreleased commits
+            while IFS= read -r -d $'\x00' entry; do
+                [[ -z "${entry// /}" ]] && continue
+
+                first_line=$(echo "$entry" | head -n1 | sed 's/^[[:space:]]*//')
+
+                if [[ "$first_line" =~ ^([0-9a-f]+)[[:space:]]+(.+)$ ]]; then
+                    hash="${BASH_REMATCH[1]}"
+                    subject="${BASH_REMATCH[2]}"
+                else
+                    continue
+                fi
+
+                hash_link="\`$hash <$repo_url/commit/$hash>\`_"
+
+                mapfile -t body_lines < <(echo "$entry" | tail -n +2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' || true)
+
+                if ((${#body_lines[@]} > 0)); then
+                    echo "- $hash_link $subject"
+                    echo ""
+                    for ((b = 0; b < ${#body_lines[@]}; b++)); do
+                        echo "  ${body_lines[$b]}"
+                        if ((b < ${#body_lines[@]} - 1)); then
+                            echo ""
+                        fi
+                    done
+                    echo ""
+                else
+                    echo "- $hash_link $subject"
+                fi
+            done < <(echo "$raw" | perl -e "
+                local \$/;
+                my \$input = <STDIN>;
+                my @parts = split(/\Q$delim\E/, \$input);
+                shift @parts;
+                for my \$p (@parts) {
+                    \$p =~ s/\s+\$//;
+                    print \$p . \"\0\";
+                }
+            ")
+
+            echo ""
+        fi
+    fi
+
+    for ((i = 0; i < ${#tag_array[@]}; i++)); do
+        tag="${tag_array[$i]}"
+        version="${tag#v}"
+        date=$(git log -1 --format="%ai" "$tag" | cut -d' ' -f1)
+
+        title="Version $version ($date)"
+        underline=$(printf '=%.0s' $(seq 1 ${#title}))
+
+        echo "$title"
+        echo "$underline"
+        echo ""
+
+        if ((i < ${#tag_array[@]} - 1)); then
+            range="${tag_array[$((i + 1))]}..$tag"
+        else
+            range="$tag"
+        fi
+
+        delim="---COMMIT_DELIM---"
+        raw=$(git log --format="${delim}%h %s%n%b" "$range")
+
+        # Split on delimiter, process each commit
+        # Use perl for reliable multi-char delimiter splitting
+        while IFS= read -r -d $'\x00' entry; do
+            [[ -z "${entry// /}" ]] && continue
+
+            # First line has hash + subject
+            first_line=$(echo "$entry" | head -n1 | sed 's/^[[:space:]]*//')
+
+            if [[ "$first_line" =~ ^([0-9a-f]+)[[:space:]]+(.+)$ ]]; then
+                hash="${BASH_REMATCH[1]}"
+                subject="${BASH_REMATCH[2]}"
+            else
+                continue
+            fi
+
+            hash_link="\`$hash <$repo_url/commit/$hash>\`_"
+
+            # Collect non-empty body lines
+            mapfile -t body_lines < <(echo "$entry" | tail -n +2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' || true)
+
+            if ((${#body_lines[@]} > 0)); then
+                echo "- $hash_link $subject"
+                echo ""
+                for ((b = 0; b < ${#body_lines[@]}; b++)); do
+                    echo "  ${body_lines[$b]}"
+                    if ((b < ${#body_lines[@]} - 1)); then
+                        echo ""
+                    fi
+                done
+                echo ""
+            else
+                echo "- $hash_link $subject"
+            fi
+        done < <(echo "$raw" | perl -e "
+            local \$/;
+            my \$input = <STDIN>;
+            my @parts = split(/\Q$delim\E/, \$input);
+            shift @parts;  # first element is empty
+            for my \$p (@parts) {
+                \$p =~ s/\s+\$//;
+                print \$p . \"\0\";
+            }
+        ")
+
+        echo ""
+    done
+} > "$outfile"
+
+echo "CHANGELOG.rst updated successfully."


### PR DESCRIPTION
Adds `update-changelog.sh` (copied from kuhl-haus-mdp-servers) and `CONTRIBUTING.rst` with maintainer release instructions.

Release flow: tag → `build-images` GHA workflow builds and pushes Docker image automatically.