### PR TITLE
feat: expose massive_api_key and finlight_api_key in get_config

### DIFF
--- a/apps/_default/controllers.py
+++ b/apps/_default/controllers.py
@@ -38,6 +38,8 @@ from .common import (
 )
 from .settings import (
     APP_FOLDER,
+    FINLIGHT_API_KEY,
+    MASSIVE_API_KEY,
     WDS_API_KEY,
     WDS_ENDPOINT,
 )
@@ -106,6 +108,8 @@ def get_config():
 
     return dict(
         api_key=WDS_API_KEY,
-        ws_endpoint=WDS_ENDPOINT  # ,
+        ws_endpoint=WDS_ENDPOINT,
+        massive_api_key=MASSIVE_API_KEY,
+        finlight_api_key=FINLIGHT_API_KEY,
         # version_info=version_info,
     )

--- a/client/src/composables/useConfig.js
+++ b/client/src/composables/useConfig.js
@@ -24,8 +24,9 @@ export function useConfig() {
       const data = await response.json()
       config.value = {
         apiKey: data.api_key,
-        wsEndpoint: data.ws_endpoint
-        // ...data  // Capture any additional fields
+        wsEndpoint: data.ws_endpoint,
+        massiveApiKey: data.massive_api_key,
+        finlightApiKey: data.finlight_api_key,
       }
 
       return config.value

--- a/tests/apps/test_default_controllers.py
+++ b/tests/apps/test_default_controllers.py
@@ -67,6 +67,8 @@ def _import_controllers(wds_api_key='test-api-key', wds_endpoint='ws://localhost
     mock_settings = MagicMock()
     mock_settings.WDS_API_KEY = wds_api_key
     mock_settings.WDS_ENDPOINT = wds_endpoint
+    mock_settings.MASSIVE_API_KEY = ''
+    mock_settings.FINLIGHT_API_KEY = ''
     mock_settings.APP_FOLDER = '/tmp'
 
     sys.modules['apps._default.common'] = mock_common
@@ -138,13 +140,17 @@ def test_app_with_authenticated_user_expect_config_returned():
 # ---------------------------------------------------------------------------
 
 def test_get_config_with_authenticated_user_expect_api_key_and_endpoint():
-    """get_config() returns WDS api_key and ws_endpoint."""
+    """get_config() returns WDS api_key, ws_endpoint, massive_api_key, finlight_api_key."""
     controllers = _import_controllers(
         wds_api_key='config-api-key',
         wds_endpoint='ws://config:4202/ws',
     )
+    controllers.MASSIVE_API_KEY = 'massive-key'
+    controllers.FINLIGHT_API_KEY = 'finlight-key'
 
     result = controllers.get_config()
 
     assert result['api_key'] == 'config-api-key'
     assert result['ws_endpoint'] == 'ws://config:4202/ws'
+    assert result['massive_api_key'] == 'massive-key'
+    assert result['finlight_api_key'] == 'finlight-key'


### PR DESCRIPTION
Adds `massive_api_key` and `finlight_api_key` to the `/api/get_config` response. Authenticated clients can now obtain API keys for direct client-side calls to Massive and Finlight, in addition to using the SCP cache proxy.