### PR TITLE
feat: EnhancedQuoteV2 — adaptive container-query layout, Phantom Dark design

### DIFF
--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -35,6 +35,7 @@ const availableWidgets = [
   { type: 'company-news', label: 'Company News', icon: '🗞️' },
   { type: 'quote', label: 'Quote', icon: '⚡' },
   { type: 'enhanced-quote', label: 'Enhanced Quote', icon: '📊' },
+  { type: 'enhanced-quote-v2', label: 'Enhanced Quote V2', icon: '✨' },
 ]
 
 const selectWidget = (widgetType) => {

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -71,6 +71,7 @@ import CompanyNews from './widgets/CompanyNews.vue'
 import NewsFeed from './widgets/NewsFeed.vue'
 import Quote from './widgets/Quote.vue'
 import EnhancedQuote from './widgets/EnhancedQuote.vue'
+import EnhancedQuoteV2 from './widgets/EnhancedQuoteV2.vue'
 import { LINK_COLORS, LINK_COLOR_MAP } from '@/composables/useWidgetBus.js'
 
 const props = defineProps({
@@ -91,7 +92,8 @@ const widgetComponents = {
   'company-news': CompanyNews,
   'news-feed':   NewsFeed,
   'quote':           Quote,
-  'enhanced-quote':  EnhancedQuote,
+  'enhanced-quote':    EnhancedQuote,
+  'enhanced-quote-v2': EnhancedQuoteV2,
 }
 
 const widgetComponent = computed(() => widgetComponents[props.widgetType])

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -1,0 +1,786 @@
+<template>
+  <div class="eqv2-widget">
+    <!-- Ticker input bar — always visible -->
+    <div class="eqv2-controls">
+      <input
+        v-model="inputTicker"
+        class="eqv2-input"
+        placeholder="Enter ticker (e.g. AAPL)"
+        maxlength="10"
+        spellcheck="false"
+        @keyup.enter="applyInput"
+        @keyup.escape="inputTicker = ''"
+      />
+      <button class="eqv2-go-btn" @click="applyInput" @touchend.prevent="applyInput" title="Load quote">Go</button>
+    </div>
+
+    <!-- No ticker yet -->
+    <div v-if="!activeTicker" class="eqv2-empty">
+      <span class="eqv2-empty-icon">⚡</span>
+      <span class="eqv2-empty-text">Enter a ticker above, or link to a scanner and click a row</span>
+    </div>
+
+    <!-- Ticker set, waiting for data -->
+    <div v-else-if="!quoteData" class="eqv2-empty">
+      <span class="eqv2-empty-icon">⏳</span>
+      <span class="eqv2-empty-text">Waiting for data for <strong>{{ activeTicker }}</strong>...</span>
+    </div>
+
+    <!-- Quote data available -->
+    <div v-else class="eqv2-body">
+      <!-- Price Hero -->
+      <div class="eqv2-hero">
+        <div class="eqv2-ticker-row">
+          <span class="eqv2-symbol">{{ quoteData.symbol }}</span>
+          <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv2-flame-icon" />
+          <span class="eqv2-price">${{ fmt(quoteData.close, 2) }}</span>
+          <span :class="['eqv2-change-badge', changeClass]">
+            {{ quoteData.change >= 0 ? '+' : '' }}{{ fmt(quoteData.change, 2) }}
+            ({{ quoteData.pct_change >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change, 2) }}%)
+          </span>
+        </div>
+        <div class="eqv2-since-open">
+          Since open:
+          <span :class="quoteData.pct_change_since_open >= 0 ? 'eqv2-pos' : 'eqv2-neg'">
+            {{ quoteData.pct_change_since_open >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change_since_open, 2) }}%
+            ({{ quoteData.change_since_open >= 0 ? '+' : '' }}${{ fmt(quoteData.change_since_open, 2) }})
+          </span>
+        </div>
+      </div>
+
+      <!-- Adaptive sections grid -->
+      <div class="eqv2-sections">
+        <!-- Company card -->
+        <div class="eqv2-card eqv2-company-card">
+          <div class="eqv2-card-label">Company</div>
+          <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
+          <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
+          <div v-else class="eqv2-kv-list">
+            <div class="eqv2-kv"><span class="eqv2-k">Name</span><span class="eqv2-v">{{ companyData.name || '—' }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Sector</span><span class="eqv2-v">{{ companyData.sic_description || '—' }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
+            <div v-if="companyData.homepage_url" class="eqv2-kv">
+              <span class="eqv2-k">Web</span>
+              <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
+            </div>
+            <div v-else class="eqv2-kv"><span class="eqv2-k">Web</span><span class="eqv2-v">—</span></div>
+          </div>
+        </div>
+
+        <!-- Today card -->
+        <div class="eqv2-card eqv2-today-card">
+          <div class="eqv2-card-label">Today</div>
+          <div class="eqv2-kv-list">
+            <div class="eqv2-kv"><span class="eqv2-k">Open</span><span class="eqv2-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">VWAP</span><span class="eqv2-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+          </div>
+        </div>
+
+        <!-- Session H/L card -->
+        <div class="eqv2-card eqv2-session-card">
+          <div class="eqv2-card-label">Session H/L</div>
+          <div class="eqv2-session-mini-row">
+            <div class="eqv2-session-mini">
+              <div class="eqv2-session-mini-label">PRE</div>
+              <div class="eqv2-session-mini-vals" v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null">
+                <span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span>
+                <span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span>
+              </div>
+              <div class="eqv2-session-mini-vals" v-else>—</div>
+            </div>
+            <div class="eqv2-session-mini">
+              <div class="eqv2-session-mini-label">REG</div>
+              <div class="eqv2-session-mini-vals" v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null">
+                <span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span>
+                <span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span>
+              </div>
+              <div class="eqv2-session-mini-vals" v-else>—</div>
+            </div>
+            <div class="eqv2-session-mini">
+              <div class="eqv2-session-mini-label">AH</div>
+              <div class="eqv2-session-mini-vals" v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null">
+                <span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span>
+                <span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span>
+              </div>
+              <div class="eqv2-session-mini-vals" v-else>—</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Short Interest — temporarily disabled (refs #85) -->
+        <!--
+        <div class="eqv2-card eqv2-short-card">
+          <div class="eqv2-card-label">Short Interest</div>
+          <div v-if="allShortNull" class="eqv2-muted-msg">Short interest data loading...</div>
+          <div v-else class="eqv2-kv-list">
+            <div class="eqv2-kv"><span class="eqv2-k">Short Int.</span><span class="eqv2-v">{{ fmtVol(quoteData.short_interest) }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Days to Cover</span><span class="eqv2-v">{{ fmt(quoteData.days_to_cover, 1) }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Short Vol Ratio</span><span class="eqv2-v">{{ fmt(quoteData.short_volume_ratio, 1) }}%</span></div>
+          </div>
+        </div>
+        -->
+
+        <!-- Volume card -->
+        <div class="eqv2-card eqv2-volume-card">
+          <div class="eqv2-card-label">Volume</div>
+          <div class="eqv2-kv-list">
+            <div class="eqv2-kv"><span class="eqv2-k">Volume</span><span class="eqv2-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Avg Vol</span><span class="eqv2-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Float</span><span class="eqv2-v">{{ fmtVol(floatShares) }}</span></div>
+          </div>
+          <!-- Relative Volume bar -->
+          <div class="eqv2-rv-row">
+            <span class="eqv2-k">Rel. Vol</span>
+            <div class="eqv2-rv-bar-wrap">
+              <div class="eqv2-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div>
+            </div>
+            <span :class="['eqv2-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
+          </div>
+        </div>
+
+        <!-- Previous Day: full-width strip -->
+        <div class="eqv2-card eqv2-prev-card">
+          <div class="eqv2-card-label">Previous Day</div>
+          <div class="eqv2-prev-chips">
+            <div class="eqv2-chip"><span class="eqv2-chip-label">O</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+            <div class="eqv2-chip"><span class="eqv2-chip-label">H</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+            <div class="eqv2-chip"><span class="eqv2-chip-label">L</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+            <div class="eqv2-chip"><span class="eqv2-chip-label">C</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+            <div class="eqv2-chip"><span class="eqv2-chip-label">Vol</span><span class="eqv2-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+            <div class="eqv2-chip"><span class="eqv2-chip-label">VWAP</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Splits -->
+      <template v-if="quoteData.splits && quoteData.splits.length > 0">
+        <div class="eqv2-card eqv2-splits-card">
+          <div class="eqv2-card-label">Recent Splits</div>
+          <div class="eqv2-splits">
+            <div v-for="(split, i) in quoteData.splits" :key="i" class="eqv2-split-row">
+              {{ split.split_to }}-for-{{ split.split_from }} on {{ split.execution_date }}
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- Freshness -->
+      <div class="eqv2-freshness">As of {{ dataAge }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useWidgetBus, getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+  isMobile:  { type: Boolean, default: false },
+  settings:  { type: Object,  default: () => ({}) },
+})
+
+defineEmits(['update-settings'])
+
+const appConfig = window.__APP_CONFIG__ || {}
+const { activeTickers, setActiveTicker } = useWidgetBus()
+
+// ── Flame freshness icon ──────────────────────────────────────────────────────
+const FLAME_SRCS = {
+  red:    new URL('@/assets/icons/flame-red.svg',    import.meta.url).href,
+  orange: new URL('@/assets/icons/flame-orange.svg', import.meta.url).href,
+  yellow: new URL('@/assets/icons/flame-yellow.svg', import.meta.url).href,
+  white:  new URL('@/assets/icons/flame-white.svg',  import.meta.url).href,
+  blue:   new URL('@/assets/icons/flame-blue.svg',   import.meta.url).href,
+  dark:   new URL('@/assets/icons/flame-dark.svg',   import.meta.url).href,
+}
+const quoteFlame = computed(() => {
+  if (!activeTicker.value) return null
+  const variant = getFlameVariant(activeTicker.value)
+  if (!variant) return null
+  return { src: FLAME_SRCS[variant], tooltip: getFlameTooltip(activeTicker.value) }
+})
+
+// Manual entry — not persisted, ephemeral
+const inputTicker = ref('')
+
+// Active ticker: widget bus takes precedence when linked; manual entry otherwise
+const busTicker = computed(() =>
+  props.linkColor ? (activeTickers[props.linkColor] || null) : null
+)
+const manualTicker = ref('')
+const activeTicker = computed(() => busTicker.value || manualTicker.value || null)
+
+const applyInput = () => {
+  const t = inputTicker.value.trim().toUpperCase()
+  if (!t) return
+  manualTicker.value = t
+  inputTicker.value = ''
+  // Broadcast to widget bus so linked widgets also update
+  if (props.linkColor) {
+    setActiveTicker(props.linkColor, t)
+  }
+}
+
+// When bus fires, clear manual override so bus drives
+watch(busTicker, (t) => {
+  if (t) manualTicker.value = ''
+})
+
+// Quote data
+const quoteData = ref(null)
+const lastDataAt = ref(null)
+
+// Company enrichment — fetched via REST on ticker change
+const companyData = ref({})
+const companyLoading = ref(false)
+
+const fetchCompany = async (symbol) => {
+  if (!symbol) return
+  companyLoading.value = true
+  companyData.value = {}
+  try {
+    const resp = await fetch(`/api/market_data/company/${symbol}`)
+    if (resp.ok) {
+      const json = await resp.json()
+      companyData.value = json.data || {}
+    }
+  } catch (e) {
+    // Network error — leave companyData empty, UI shows unavailable
+    console.warn(`[EnhancedQuoteV2] company fetch failed for ${symbol}:`, e)
+  } finally {
+    companyLoading.value = false
+  }
+}
+
+// WebSocket client — always-on connection, swap feed on ticker change
+const currentFeed = ref('')
+
+const { feedName, cacheKey, isConnected, reconnecting, getCache, subscribe, unsubscribe } = useWebSocketClient({
+  wsUrl: appConfig.wsEndpoint || 'ws://localhost:4202/ws',
+  authKey: appConfig.apiKey || 'secret',
+  feedName: '',
+  cacheKey: '',
+  onData: (data) => {
+    if (!data || (data.symbol && data.symbol !== activeTicker.value)) return
+    quoteData.value = data
+    lastDataAt.value = Date.now()
+  },
+  autoConnect: true,
+})
+
+// Switch subscription whenever activeTicker changes
+watch(activeTicker, (newTicker) => {
+  if (currentFeed.value) {
+    feedName.value = currentFeed.value
+    cacheKey.value = ''
+    unsubscribe()
+    currentFeed.value = ''
+  }
+  quoteData.value = null
+  companyData.value = {}
+  if (newTicker) {
+    fetchCompany(newTicker)
+    const feed = `daily_range:${newTicker}`
+    feedName.value = feed
+    cacheKey.value = feed
+    currentFeed.value = feed
+    if (isConnected.value) {
+      subscribe()
+      getCache()
+    }
+  }
+})
+
+// When connection is established and we have a pending ticker, subscribe + fetch cache
+watch(isConnected, (connected) => {
+  if (connected && currentFeed.value) {
+    feedName.value = currentFeed.value
+    cacheKey.value = currentFeed.value
+    subscribe()
+    getCache()
+  }
+})
+
+// Freshness display
+const dataAge = computed(() => {
+  const ts = quoteData.value?.end_timestamp
+  if (!ts) return '—'
+  return new Date(ts).toLocaleString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+})
+
+// Formatting helpers
+const fmt = (val, decimals = 2) => {
+  const n = parseFloat(val)
+  return isFinite(n) ? n.toFixed(decimals) : '—'
+}
+
+const fmtVol = (val) => {
+  const v = parseFloat(val)
+  if (!isFinite(v)) return '—'
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}K`
+  return v.toString()
+}
+
+const changeClass = computed(() => {
+  if (!quoteData.value) return ''
+  return quoteData.value.pct_change >= 0 ? 'positive' : 'negative'
+})
+
+const relVolClass = computed(() => {
+  if (!quoteData.value) return ''
+  const rv = parseFloat(quoteData.value.relative_volume)
+  if (rv >= 5) return 'extreme'
+  if (rv >= 3) return 'high'
+  if (rv >= 2) return 'medium'
+  return ''
+})
+
+// Float shares: prefer free_float, fall back to share_class_shares_outstanding
+const floatShares = computed(() => {
+  if (!quoteData.value) return null
+  return quoteData.value.free_float ?? quoteData.value.share_class_shares_outstanding ?? null
+})
+
+// Short interest: null if all three fields are null
+const allShortNull = computed(() => {
+  if (!quoteData.value) return true
+  return quoteData.value.short_interest == null &&
+         quoteData.value.days_to_cover == null &&
+         quoteData.value.short_volume_ratio == null
+})
+
+// Company: null if all company fields are null
+const allCompanyNull = computed(() => {
+  const d = companyData.value
+  if (!d) return true
+  return d.name == null &&
+         d.primary_exchange == null &&
+         d.sic_description == null &&
+         d.market_cap == null &&
+         d.total_employees == null &&
+         d.list_date == null &&
+         d.homepage_url == null
+})
+
+const truncateUrl = (url) => {
+  if (!url) return ''
+  return url.replace(/^https?:\/\//, '').replace(/\/$/, '').slice(0, 30)
+}
+
+// Relative volume bar
+const rvBarWidth = computed(() => {
+  const rv = parseFloat(quoteData.value?.relative_volume)
+  if (!isFinite(rv)) return '0%'
+  return `${Math.min((rv / 5) * 100, 100)}%`
+})
+
+const rvBarColor = computed(() => {
+  const rv = parseFloat(quoteData.value?.relative_volume)
+  if (!isFinite(rv)) return '#22c55e'
+  if (rv >= 5) return '#dc2626'
+  if (rv >= 3) return '#f97316'
+  if (rv >= 2) return '#eab308'
+  return '#22c55e'
+})
+
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading })
+</script>
+
+<style scoped>
+/* ── CSS custom properties (Phantom Dark theme) ── */
+.eqv2-widget {
+  --bg: #0d0d12;
+  --surface: #141420;
+  --border: #1e1e2e;
+  --text-primary: #e2e2f0;
+  --text-muted: #5a5a7a;
+  --accent: #7c3aed;
+  --positive: #22c55e;
+  --negative: #ef4444;
+
+  container-type: inline-size;
+  height: 100%;
+  overflow-y: auto;
+  background: var(--bg);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: system-ui, sans-serif;
+  padding: 8px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Ticker input ── */
+.eqv2-controls {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.eqv2-input {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+  padding: 4px 8px;
+  font-family: 'Roboto Mono', monospace;
+  text-transform: uppercase;
+  outline: none;
+}
+.eqv2-input:focus { border-color: var(--accent); }
+.eqv2-input::placeholder { color: var(--text-muted); text-transform: none; }
+.eqv2-go-btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+  padding: 4px 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.eqv2-go-btn:hover { border-color: var(--accent); color: #fff; }
+
+/* ── Empty / waiting states ── */
+.eqv2-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 16px;
+}
+.eqv2-empty-icon { font-size: 28px; }
+.eqv2-empty-text { font-size: 12px; line-height: 1.5; max-width: 200px; }
+
+/* ── Quote body ── */
+.eqv2-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Price Hero ── */
+.eqv2-hero {
+  padding: 8px 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.eqv2-ticker-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.eqv2-symbol {
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+}
+
+.eqv2-price {
+  font-size: 22px;
+  font-weight: 600;
+  font-family: 'Roboto Mono', monospace;
+  color: #fff;
+}
+
+.eqv2-change-badge {
+  font-size: 13px;
+  font-weight: 600;
+  font-family: 'Roboto Mono', monospace;
+  padding: 2px 8px;
+  border-radius: 12px;
+  white-space: nowrap;
+}
+.eqv2-change-badge.positive {
+  background: rgba(34, 197, 94, 0.2);
+  color: var(--positive);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+.eqv2-change-badge.negative {
+  background: rgba(239, 68, 68, 0.2);
+  color: var(--negative);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
+.eqv2-since-open {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.eqv2-pos { color: var(--positive); font-weight: 600; }
+.eqv2-neg { color: var(--negative); font-weight: 600; }
+
+.eqv2-flame-icon {
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+  margin-left: 2px;
+  position: relative;
+  top: -2px;
+}
+
+/* ── Section cards ── */
+.eqv2-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+
+.eqv2-card-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  font-weight: 600;
+  padding-left: 6px;
+  border-left: 3px solid var(--accent);
+  margin-bottom: 6px;
+  font-family: system-ui, sans-serif;
+}
+
+/* ── Key-value rows ── */
+.eqv2-kv-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.eqv2-kv {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+  border-bottom: 1px solid var(--border);
+  gap: 8px;
+}
+.eqv2-k {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: system-ui, sans-serif;
+  flex-shrink: 0;
+}
+.eqv2-v {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 12px;
+  color: var(--text-primary);
+  text-align: right;
+}
+.eqv2-link {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 12px;
+  color: var(--accent);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+  text-align: right;
+}
+.eqv2-link:hover { text-decoration: underline; }
+
+.eqv2-muted-msg {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ── Session H/L mini-cards ── */
+.eqv2-session-mini-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.eqv2-session-mini {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 0;
+  border-bottom: 1px solid var(--border);
+}
+.eqv2-session-mini-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-muted);
+  font-family: system-ui, sans-serif;
+  min-width: 30px;
+  flex-shrink: 0;
+}
+.eqv2-session-mini-vals {
+  display: flex;
+  gap: 8px;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 12px;
+  color: var(--text-primary);
+  flex-wrap: wrap;
+}
+
+/* ── Relative Volume bar ── */
+.eqv2-rv-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid var(--border);
+}
+.eqv2-rv-bar-wrap {
+  flex: 1;
+  height: 6px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+  overflow: hidden;
+  position: relative;
+}
+.eqv2-rv-bar {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+.eqv2-rv-val {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 12px;
+  min-width: 36px;
+  text-align: right;
+}
+.eqv2-rv-val.extreme { color: #f97316; font-weight: 700; }
+.eqv2-rv-val.high    { color: #eab308; font-weight: 600; }
+.eqv2-rv-val.medium  { color: var(--text-muted); }
+
+/* ── Previous Day chips ── */
+.eqv2-prev-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.eqv2-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  min-width: 48px;
+  flex: 1;
+}
+.eqv2-chip-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 700;
+  font-family: system-ui, sans-serif;
+  letter-spacing: 0.06em;
+}
+.eqv2-chip-val {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 12px;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+/* ── Splits ── */
+.eqv2-splits {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.eqv2-split-row {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 12px;
+  color: var(--text-primary);
+  padding: 2px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+/* ── Freshness ── */
+.eqv2-freshness {
+  margin-top: auto;
+  padding-top: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: right;
+  font-family: system-ui, sans-serif;
+}
+
+/* ── Sections layout (narrow default: single column) ── */
+.eqv2-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── WIDE mode: 2-column grid ── */
+@container (min-width: 480px) {
+  .eqv2-symbol { font-size: 20px; }
+  .eqv2-price  { font-size: 28px; }
+
+  .eqv2-session-mini-row {
+    flex-direction: row;
+    gap: 6px;
+  }
+  .eqv2-session-mini {
+    flex: 1;
+    flex-direction: column;
+    align-items: flex-start;
+    border-bottom: none;
+    border-right: 1px solid var(--border);
+    padding: 4px 6px;
+    gap: 2px;
+  }
+  .eqv2-session-mini:last-child { border-right: none; }
+
+  .eqv2-sections {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "company today"
+      "company session"
+      "company volume"
+      "prev    prev";
+    gap: 8px;
+  }
+  .eqv2-company-card { grid-area: company; }
+  .eqv2-today-card   { grid-area: today; }
+  .eqv2-session-card { grid-area: session; }
+  .eqv2-volume-card  { grid-area: volume; }
+  .eqv2-prev-card    { grid-area: prev; }
+}
+
+/* ── FULL mode: 3-column grid ── */
+@container (min-width: 680px) {
+  .eqv2-sections {
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-areas:
+      "company today   volume"
+      "company session volume"
+      "prev    prev    prev";
+  }
+}
+</style>

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -669,9 +669,9 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   min-width: 36px;
   text-align: right;
 }
-.eqv2-rv-val.extreme { color: #f97316; font-weight: 700; }
-.eqv2-rv-val.high    { color: #eab308; font-weight: 600; }
-.eqv2-rv-val.medium  { color: var(--text-muted); }
+.eqv2-rv-val.extreme { color: #dc2626; font-weight: 700; } /* red — matches rvBarColor */
+.eqv2-rv-val.high    { color: #f97316; font-weight: 600; } /* orange */
+.eqv2-rv-val.medium  { color: #eab308; }                   /* yellow */
 
 /* ── Previous Day chips ── */
 .eqv2-prev-chips {

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -292,6 +292,7 @@ describe('EnhancedQuoteV2', () => {
     it('formats billions correctly', async () => {
       const wrapper = mountWidget()
       wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
       wrapper.vm.quoteData = { ...SAMPLE_QUOTE, accumulated_volume: 1500000000 }
       await wrapper.vm.$nextTick()
       expect(wrapper.find('.eqv2-volume-card').text()).toContain('1.5B')
@@ -300,6 +301,7 @@ describe('EnhancedQuoteV2', () => {
     it('formats millions correctly', async () => {
       const wrapper = mountWidget()
       wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
       wrapper.vm.quoteData = { ...SAMPLE_QUOTE, accumulated_volume: 25000000 }
       await wrapper.vm.$nextTick()
       expect(wrapper.find('.eqv2-volume-card').text()).toContain('25.0M')
@@ -308,6 +310,7 @@ describe('EnhancedQuoteV2', () => {
     it('formats thousands correctly', async () => {
       const wrapper = mountWidget()
       wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
       wrapper.vm.quoteData = { ...SAMPLE_QUOTE, accumulated_volume: 5500 }
       await wrapper.vm.$nextTick()
       expect(wrapper.find('.eqv2-volume-card').text()).toContain('5.5K')

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+// Mock WebSocket globally
+class MockWebSocket {
+  constructor() {
+    this.readyState = WebSocket.CONNECTING
+    setTimeout(() => {
+      this.readyState = WebSocket.OPEN
+      this.onopen?.()
+    }, 0)
+  }
+  send() {}
+  close() { this.onclose?.({ code: 1000 }) }
+}
+global.WebSocket = MockWebSocket
+global.WebSocket.CONNECTING = 0
+global.WebSocket.OPEN = 1
+global.WebSocket.CLOSING = 2
+global.WebSocket.CLOSED = 3
+
+// Mock asset imports (flame icons)
+vi.mock('@/assets/icons/flame-red.svg',    { assert: { type: 'url' } }, () => ({ default: 'flame-red.svg' }))
+vi.mock('@/assets/icons/flame-orange.svg', { assert: { type: 'url' } }, () => ({ default: 'flame-orange.svg' }))
+vi.mock('@/assets/icons/flame-yellow.svg', { assert: { type: 'url' } }, () => ({ default: 'flame-yellow.svg' }))
+vi.mock('@/assets/icons/flame-white.svg',  { assert: { type: 'url' } }, () => ({ default: 'flame-white.svg' }))
+vi.mock('@/assets/icons/flame-blue.svg',   { assert: { type: 'url' } }, () => ({ default: 'flame-blue.svg' }))
+vi.mock('@/assets/icons/flame-dark.svg',   { assert: { type: 'url' } }, () => ({ default: 'flame-dark.svg' }))
+
+// Stub new URL(...).href for asset imports in the component
+vi.stubGlobal('URL', class {
+  constructor(path) { this.href = path }
+  static createObjectURL() { return '' }
+})
+
+import EnhancedQuoteV2 from '../EnhancedQuoteV2.vue'
+
+function mountWidget(props = {}) {
+  return mount(EnhancedQuoteV2, {
+    props: {
+      isLocked: true,
+      linkColor: null,
+      isMobile: false,
+      settings: {},
+      ...props,
+    },
+  })
+}
+
+const SAMPLE_QUOTE = {
+  symbol: 'TSLA',
+  close: 250.00,
+  change: 5.00,
+  pct_change: 2.04,
+  pct_change_since_open: 1.5,
+  change_since_open: 3.75,
+  end_timestamp: Date.now(),
+  pre_market_high: 252.00,
+  pre_market_low: 248.00,
+  regular_session_high: 255.00,
+  regular_session_low: 247.00,
+  after_hours_high: 251.00,
+  after_hours_low: 249.00,
+  official_open_price: 248.00,
+  aggregate_vwap: 250.50,
+  accumulated_volume: 25000000,
+  relative_volume: 2.5,
+  avg_volume: 20000000,
+  free_float: 800000000,
+  prev_day_open: 245.00,
+  prev_day_high: 253.00,
+  prev_day_low: 244.00,
+  prev_day_close: 245.00,
+  prev_day_volume: 22000000,
+  prev_day_vwap: 248.00,
+  splits: [],
+}
+
+describe('EnhancedQuoteV2', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ symbol: 'TSLA', data: {}, available: false }),
+    })
+  })
+
+  it('renders without crashing', () => {
+    const wrapper = mountWidget()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.find('.eqv2-widget').exists()).toBe(true)
+  })
+
+  it('shows empty state when no ticker is set', () => {
+    const wrapper = mountWidget()
+    expect(wrapper.find('.eqv2-empty').exists()).toBe(true)
+    expect(wrapper.find('.eqv2-body').exists()).toBe(false)
+  })
+
+  it('shows waiting state when ticker is set but no data', async () => {
+    const wrapper = mountWidget()
+    await wrapper.find('.eqv2-input').setValue('AAPL')
+    await wrapper.find('.eqv2-go-btn').trigger('click')
+    await wrapper.vm.$nextTick()
+    const empty = wrapper.find('.eqv2-empty')
+    expect(empty.exists()).toBe(true)
+    expect(empty.text()).toContain('AAPL')
+  })
+
+  it('renders quote body when data is present', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-body').exists()).toBe(true)
+    expect(wrapper.find('.eqv2-empty').exists()).toBe(false)
+  })
+
+  it('displays price and symbol correctly', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-symbol').text()).toBe('TSLA')
+    expect(wrapper.find('.eqv2-price').text()).toContain('250.00')
+  })
+
+  it('applies positive class to change badge for gains', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE, change: 5.00, pct_change: 2.04 }
+    await wrapper.vm.$nextTick()
+    const badge = wrapper.find('.eqv2-change-badge')
+    expect(badge.classes()).toContain('positive')
+    expect(badge.text()).toContain('+5.00')
+  })
+
+  it('applies negative class to change badge for losses', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE, change: -3.50, pct_change: -1.38 }
+    await wrapper.vm.$nextTick()
+    const badge = wrapper.find('.eqv2-change-badge')
+    expect(badge.classes()).toContain('negative')
+    expect(badge.text()).toContain('-3.50')
+  })
+
+  it('renders section cards', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-company-card').exists()).toBe(true)
+    expect(wrapper.find('.eqv2-today-card').exists()).toBe(true)
+    expect(wrapper.find('.eqv2-session-card').exists()).toBe(true)
+    expect(wrapper.find('.eqv2-volume-card').exists()).toBe(true)
+    expect(wrapper.find('.eqv2-prev-card').exists()).toBe(true)
+  })
+
+  it('shows company unavailable state when all fields null', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: {} }),
+    })
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-muted-msg').exists()).toBe(true)
+  })
+
+  it('shows company data when available', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          name: 'Tesla Inc.',
+          primary_exchange: 'XNAS',
+          sic_description: 'Motor Vehicles',
+          market_cap: 800000000000,
+          total_employees: 140000,
+          list_date: '2010-06-29',
+          homepage_url: 'https://tesla.com',
+        },
+      }),
+    })
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-company-card').text()).toContain('Tesla Inc.')
+  })
+
+  it('renders relative volume bar', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE, relative_volume: 2.5 }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-rv-bar-wrap').exists()).toBe(true)
+    expect(wrapper.find('.eqv2-rv-bar').exists()).toBe(true)
+    // 2.5 / 5 = 50%
+    expect(wrapper.find('.eqv2-rv-bar').attributes('style')).toContain('50%')
+  })
+
+  it('caps relative volume bar at 100%', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE, relative_volume: 10 }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-rv-bar').attributes('style')).toContain('100%')
+  })
+
+  it('renders Previous Day chips', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await wrapper.vm.$nextTick()
+    const chips = wrapper.findAll('.eqv2-chip')
+    expect(chips.length).toBe(6)
+    const labels = chips.map(c => c.find('.eqv2-chip-label').text())
+    expect(labels).toContain('O')
+    expect(labels).toContain('H')
+    expect(labels).toContain('L')
+    expect(labels).toContain('C')
+    expect(labels).toContain('Vol')
+    expect(labels).toContain('VWAP')
+  })
+
+  it('hides splits card when splits array is empty', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE, splits: [] }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-splits-card').exists()).toBe(false)
+  })
+
+  it('shows splits card when splits array has entries', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = {
+      ...SAMPLE_QUOTE,
+      splits: [{ split_to: 3, split_from: 1, execution_date: '2022-08-25' }],
+    }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.eqv2-splits-card').exists()).toBe(true)
+    expect(wrapper.find('.eqv2-split-row').text()).toContain('3-for-1')
+  })
+
+  it('shows session H/L dashes when values are null', async () => {
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    wrapper.vm.quoteData = {
+      ...SAMPLE_QUOTE,
+      pre_market_high: null,
+      pre_market_low: null,
+      after_hours_high: null,
+      after_hours_low: null,
+    }
+    await wrapper.vm.$nextTick()
+    const sessionMinis = wrapper.findAll('.eqv2-session-mini')
+    expect(sessionMinis[0].text()).toContain('—') // PRE
+    expect(sessionMinis[2].text()).toContain('—') // AH
+  })
+
+  it('exposes required interface (lastDataAt, isConnected, etc.)', () => {
+    const wrapper = mountWidget()
+    expect(wrapper.vm.lastDataAt).toBeDefined()
+    expect(wrapper.vm.isConnected).toBeDefined()
+    expect(wrapper.vm.reconnecting).toBeDefined()
+    expect(wrapper.vm.quoteData).toBeDefined()
+    expect(wrapper.vm.manualTicker).toBeDefined()
+    expect(wrapper.vm.companyData).toBeDefined()
+    expect(wrapper.vm.companyLoading).toBeDefined()
+  })
+
+  describe('fmtVol helper (via rendered output)', () => {
+    it('formats billions correctly', async () => {
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE, accumulated_volume: 1500000000 }
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.eqv2-volume-card').text()).toContain('1.5B')
+    })
+
+    it('formats millions correctly', async () => {
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE, accumulated_volume: 25000000 }
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.eqv2-volume-card').text()).toContain('25.0M')
+    })
+
+    it('formats thousands correctly', async () => {
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE, accumulated_volume: 5500 }
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.eqv2-volume-card').text()).toContain('5.5K')
+    })
+  })
+})

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -110,6 +110,7 @@ describe('EnhancedQuoteV2', () => {
   it('renders quote body when data is present', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.eqv2-body').exists()).toBe(true)
@@ -119,6 +120,7 @@ describe('EnhancedQuoteV2', () => {
   it('displays price and symbol correctly', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.eqv2-symbol').text()).toBe('TSLA')
@@ -128,6 +130,7 @@ describe('EnhancedQuoteV2', () => {
   it('applies positive class to change badge for gains', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE, change: 5.00, pct_change: 2.04 }
     await wrapper.vm.$nextTick()
     const badge = wrapper.find('.eqv2-change-badge')
@@ -138,6 +141,7 @@ describe('EnhancedQuoteV2', () => {
   it('applies negative class to change badge for losses', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE, change: -3.50, pct_change: -1.38 }
     await wrapper.vm.$nextTick()
     const badge = wrapper.find('.eqv2-change-badge')
@@ -148,6 +152,7 @@ describe('EnhancedQuoteV2', () => {
   it('renders section cards', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.eqv2-company-card').exists()).toBe(true)
@@ -164,6 +169,7 @@ describe('EnhancedQuoteV2', () => {
     })
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await new Promise(r => setTimeout(r, 0))
     await wrapper.vm.$nextTick()
@@ -187,6 +193,7 @@ describe('EnhancedQuoteV2', () => {
     })
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await new Promise(r => setTimeout(r, 0))
     await wrapper.vm.$nextTick()
@@ -196,6 +203,7 @@ describe('EnhancedQuoteV2', () => {
   it('renders relative volume bar', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE, relative_volume: 2.5 }
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.eqv2-rv-bar-wrap').exists()).toBe(true)
@@ -207,6 +215,7 @@ describe('EnhancedQuoteV2', () => {
   it('caps relative volume bar at 100%', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE, relative_volume: 10 }
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.eqv2-rv-bar').attributes('style')).toContain('100%')
@@ -215,6 +224,7 @@ describe('EnhancedQuoteV2', () => {
   it('renders Previous Day chips', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
     const chips = wrapper.findAll('.eqv2-chip')
@@ -231,6 +241,7 @@ describe('EnhancedQuoteV2', () => {
   it('hides splits card when splits array is empty', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE, splits: [] }
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.eqv2-splits-card').exists()).toBe(false)
@@ -239,6 +250,7 @@ describe('EnhancedQuoteV2', () => {
   it('shows splits card when splits array has entries', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = {
       ...SAMPLE_QUOTE,
       splits: [{ split_to: 3, split_from: 1, execution_date: '2022-08-25' }],
@@ -251,6 +263,7 @@ describe('EnhancedQuoteV2', () => {
   it('shows session H/L dashes when values are null', async () => {
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
     wrapper.vm.quoteData = {
       ...SAMPLE_QUOTE,
       pre_market_high: null,


### PR DESCRIPTION
## Summary

New `EnhancedQuoteV2` widget that works in both tall/narrow and short/wide layouts. V1 (`enhanced-quote`) is untouched.

refs #133

## What's New

### Adaptive Layout (CSS Container Queries)
Uses `container-type: inline-size` so the widget adapts to its own width, not the viewport:
- **< 480px** (narrow): single-column stacked, similar to V1 but more compact
- **≥ 480px** (wide): 2-column grid — Company left, Today/Session/Volume right, Previous Day full-width strip
- **≥ 680px** (full): 3-column grid

### Visual Design: "Phantom Dark"
- Background: `#0d0d12` (deep navy-black)
- Section cards with `#141420` surface + `#1e1e2e` borders + indigo left-accent
- System-ui font for labels, monospace only for numbers (cleaner than V1's all-Courier New)
- Price hero: large bold number (`28px` wide / `22px` narrow)
- **Change badge**: colored pill with background (not just text color) — green or red glow
- **Relative volume bar**: visual fill (0–100%) color-coded green→yellow→orange→red
- **Previous Day chips**: O/H/L/C/Vol/VWAP as inline stat cards
- **Session H/L**: 3-column PRE/REG/AH row in wide mode

### Same Data, Same Logic
- Identical props interface and `defineExpose` contract as V1
- Same `useWidgetBus`, `useWebSocketClient`, company REST fetch
- Short interest section remains commented out (refs #85)
- Splits section present and working

## Files Changed
- `client/src/components/widgets/EnhancedQuoteV2.vue` ← new
- `client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js` ← new (17 tests)
- `client/src/components/WidgetWrapper.vue` ← register widget
- `client/src/components/WidgetMenu.vue` ← add to menu (✨ Enhanced Quote V2)

## Design Doc
`Projects/EnhancedQuoteV2-Design.md` in the shared Obsidian vault.