### PR TITLE
feat: enable short interest section in EnhancedQuote and EnhancedQuoteV2

### DIFF
--- a/client/src/components/widgets/EnhancedQuote.vue
+++ b/client/src/components/widgets/EnhancedQuote.vue
@@ -107,8 +107,7 @@
         </div>
       </div>
       
-      <!-- Short Interest — temporarily disabled (refs #85) -->
-      <!-- TODO: re-enable once short interest/volume enrichment is stable
+      <!-- Short Interest -->
       <div class="eq-section-label">Short Interest</div>
       <div v-if="allShortNull" class="eq-short-loading">Short interest data loading...</div>
       <div v-else class="eq-grid">
@@ -116,7 +115,6 @@
         <div class="eq-kv"><span class="eq-k">Days to Cover</span><span class="eq-v">{{ fmt(quoteData.days_to_cover, 1) }}</span></div>
         <div class="eq-kv"><span class="eq-k">Short Vol Ratio</span><span class="eq-v">{{ fmt(quoteData.short_volume_ratio, 1) }}%</span></div>
       </div>
-      -->
 
       <!-- Volume -->
       <div class="eq-section-label">Volume</div>

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -110,8 +110,7 @@
           </div>
         </div>
 
-        <!-- Short Interest — temporarily disabled (refs #85) -->
-        <!--
+        <!-- Short Interest -->
         <div class="eqv2-card eqv2-short-card">
           <div class="eqv2-card-label">Short Interest</div>
           <div v-if="allShortNull" class="eqv2-muted-msg">Short interest data loading...</div>
@@ -121,7 +120,6 @@
             <div class="eqv2-kv"><span class="eqv2-k">Short Vol Ratio</span><span class="eqv2-v">{{ fmt(quoteData.short_volume_ratio, 1) }}%</span></div>
           </div>
         </div>
-        -->
 
         <!-- Volume card -->
         <div class="eqv2-card eqv2-volume-card">
@@ -762,6 +760,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
     grid-template-areas:
       "company today"
       "company session"
+      "company short"
       "company volume"
       "prev    prev";
     gap: 8px;
@@ -769,6 +768,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   .eqv2-company-card { grid-area: company; }
   .eqv2-today-card   { grid-area: today; }
   .eqv2-session-card { grid-area: session; }
+  .eqv2-short-card   { grid-area: short; }
   .eqv2-volume-card  { grid-area: volume; }
   .eqv2-prev-card    { grid-area: prev; }
 }
@@ -779,7 +779,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
     grid-template-columns: 1fr 1fr 1fr;
     grid-template-areas:
       "company today   volume"
-      "company session volume"
+      "company session short"
       "prev    prev    prev";
   }
 }


### PR DESCRIPTION
## Summary

Uncomments the short interest sections in both quote widgets now that the backing REST endpoints are live.

refs #135

## Changes

### `EnhancedQuote.vue`
Removes the `<!-- TODO: re-enable once short interest/volume enrichment is stable -->` comment wrapper. The section was already fully implemented — just disabled.

### `EnhancedQuoteV2.vue`
- Uncomments the `eqv2-short-card` block
- Adds `short` area to `grid-template-areas` in both layout modes:
  - Wide (≥480px): 2-column — short slots between session and volume on the right
  - Full (≥680px): 3-column — short replaces volume in the right column's second row

## What Users See

Both widgets now display a Short Interest section:
| Field | Source |
|---|---|
| Short Int. | `quoteData.short_interest` (absolute share count) |
| Days to Cover | `quoteData.days_to_cover` |
| Short Vol Ratio | `quoteData.short_volume_ratio` % |

The section shows a loading message while data is null, consistent with the existing behavior pattern.