### PR TITLE
fix: fetch short interest via REST endpoints on ticker change

### DIFF
--- a/client/src/components/widgets/EnhancedQuote.vue
+++ b/client/src/components/widgets/EnhancedQuote.vue
@@ -109,11 +109,12 @@
       
       <!-- Short Interest -->
       <div class="eq-section-label">Short Interest</div>
-      <div v-if="allShortNull" class="eq-short-loading">Short interest data loading...</div>
+      <div v-if="shortInterestLoading" class="eq-short-loading">Short interest data loading...</div>
+      <div v-else-if="allShortNull" class="eq-short-loading">Short interest data unavailable</div>
       <div v-else class="eq-grid">
-        <div class="eq-kv"><span class="eq-k">Short Int.</span><span class="eq-v">{{ fmtVol(quoteData.short_interest) }}</span></div>
-        <div class="eq-kv"><span class="eq-k">Days to Cover</span><span class="eq-v">{{ fmt(quoteData.days_to_cover, 1) }}</span></div>
-        <div class="eq-kv"><span class="eq-k">Short Vol Ratio</span><span class="eq-v">{{ fmt(quoteData.short_volume_ratio, 1) }}%</span></div>
+        <div class="eq-kv"><span class="eq-k">Short Int.</span><span class="eq-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+        <div class="eq-kv"><span class="eq-k">Days to Cover</span><span class="eq-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+        <div class="eq-kv"><span class="eq-k">Short Vol Ratio</span><span class="eq-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
       </div>
 
       <!-- Volume -->
@@ -222,6 +223,32 @@ const lastDataAt = ref(null)
 const companyData = ref({})
 const companyLoading = ref(false)
 
+const shortInterestData = ref({})
+const shortInterestLoading = ref(false)
+
+const fetchShortInterest = async (symbol) => {
+  if (!symbol) return
+  shortInterestLoading.value = true
+  shortInterestData.value = {}
+  try {
+    const [siResp, svResp] = await Promise.all([
+      fetch(`/api/market_data/short_interest/${symbol}`),
+      fetch(`/api/market_data/short_volume/${symbol}`),
+    ])
+    const siJson = siResp.ok ? await siResp.json() : {}
+    const svJson = svResp.ok ? await svResp.json() : {}
+    shortInterestData.value = {
+      short_interest: siJson.data?.short_interest ?? null,
+      days_to_cover: siJson.data?.days_to_cover ?? null,
+      short_volume_ratio: svJson.data?.short_volume_ratio ?? null,
+    }
+  } catch (e) {
+    console.warn(`[EnhancedQuote] short interest fetch failed for ${symbol}:`, e)
+  } finally {
+    shortInterestLoading.value = false
+  }
+}
+
 const fetchCompany = async (symbol) => {
   if (!symbol) return
   companyLoading.value = true
@@ -266,8 +293,10 @@ watch(activeTicker, (newTicker) => {
   }
   quoteData.value = null
   companyData.value = {}
+  shortInterestData.value = {}
   if (newTicker) {
     fetchCompany(newTicker)
+    fetchShortInterest(newTicker)
     const feed = `daily_range:${newTicker}`
     feedName.value = feed
     cacheKey.value = feed
@@ -336,10 +365,11 @@ const floatShares = computed(() => {
 
 // Short interest: null if all three fields are null
 const allShortNull = computed(() => {
-  if (!quoteData.value) return true
-  return quoteData.value.short_interest == null &&
-         quoteData.value.days_to_cover == null &&
-         quoteData.value.short_volume_ratio == null
+  const d = shortInterestData.value
+  if (!d) return true
+  return d.short_interest == null &&
+         d.days_to_cover == null &&
+         d.short_volume_ratio == null
 })
 
 // Company: null if all company fields are null
@@ -360,7 +390,7 @@ const truncateUrl = (url) => {
   return url.replace(/^https?:\/\//, '').replace(/\/$/, '').slice(0, 30)
 }
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading })
 </script>
 
 <style scoped>

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -113,11 +113,12 @@
         <!-- Short Interest -->
         <div class="eqv2-card eqv2-short-card">
           <div class="eqv2-card-label">Short Interest</div>
-          <div v-if="allShortNull" class="eqv2-muted-msg">Short interest data loading...</div>
+          <div v-if="shortInterestLoading" class="eqv2-muted-msg">Short interest data loading...</div>
+          <div v-else-if="allShortNull" class="eqv2-muted-msg">Short interest data unavailable</div>
           <div v-else class="eqv2-kv-list">
-            <div class="eqv2-kv"><span class="eqv2-k">Short Int.</span><span class="eqv2-v">{{ fmtVol(quoteData.short_interest) }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Days to Cover</span><span class="eqv2-v">{{ fmt(quoteData.days_to_cover, 1) }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Short Vol Ratio</span><span class="eqv2-v">{{ fmt(quoteData.short_volume_ratio, 1) }}%</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Short Int.</span><span class="eqv2-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Days to Cover</span><span class="eqv2-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+            <div class="eqv2-kv"><span class="eqv2-k">Short Vol Ratio</span><span class="eqv2-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
           </div>
         </div>
 
@@ -238,6 +239,32 @@ const lastDataAt = ref(null)
 const companyData = ref({})
 const companyLoading = ref(false)
 
+const shortInterestData = ref({})
+const shortInterestLoading = ref(false)
+
+const fetchShortInterest = async (symbol) => {
+  if (!symbol) return
+  shortInterestLoading.value = true
+  shortInterestData.value = {}
+  try {
+    const [siResp, svResp] = await Promise.all([
+      fetch(`/api/market_data/short_interest/${symbol}`),
+      fetch(`/api/market_data/short_volume/${symbol}`),
+    ])
+    const siJson = siResp.ok ? await siResp.json() : {}
+    const svJson = svResp.ok ? await svResp.json() : {}
+    shortInterestData.value = {
+      short_interest: siJson.data?.short_interest ?? null,
+      days_to_cover: siJson.data?.days_to_cover ?? null,
+      short_volume_ratio: svJson.data?.short_volume_ratio ?? null,
+    }
+  } catch (e) {
+    console.warn(`[EnhancedQuoteV2] short interest fetch failed for ${symbol}:`, e)
+  } finally {
+    shortInterestLoading.value = false
+  }
+}
+
 const fetchCompany = async (symbol) => {
   if (!symbol) return
   companyLoading.value = true
@@ -282,8 +309,10 @@ watch(activeTicker, (newTicker) => {
   }
   quoteData.value = null
   companyData.value = {}
+  shortInterestData.value = {}
   if (newTicker) {
     fetchCompany(newTicker)
+    fetchShortInterest(newTicker)
     const feed = `daily_range:${newTicker}`
     feedName.value = feed
     cacheKey.value = feed
@@ -352,10 +381,11 @@ const floatShares = computed(() => {
 
 // Short interest: null if all three fields are null
 const allShortNull = computed(() => {
-  if (!quoteData.value) return true
-  return quoteData.value.short_interest == null &&
-         quoteData.value.days_to_cover == null &&
-         quoteData.value.short_volume_ratio == null
+  const d = shortInterestData.value
+  if (!d) return true
+  return d.short_interest == null &&
+         d.days_to_cover == null &&
+         d.short_volume_ratio == null
 })
 
 // Company: null if all company fields are null
@@ -392,7 +422,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading })
 </script>
 
 <style scoped>

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -316,4 +316,111 @@ describe('EnhancedQuoteV2', () => {
       expect(wrapper.find('.eqv2-volume-card').text()).toContain('5.5K')
     })
   })
+  describe('Short Interest section', () => {
+    const SI_RESPONSE = { data: { short_interest: 12000000, days_to_cover: 2.5, avg_daily_volume: 5000000, settlement_date: '2026-03-28' } }
+    const SV_RESPONSE = { data: { short_volume: 8000000, total_volume: 20000000, short_volume_ratio: 40.0, date: '2026-04-11' } }
+
+    function mockFetchForSI() {
+      global.fetch = vi.fn().mockImplementation((url) => {
+        if (url.includes('short_interest')) return Promise.resolve({ ok: true, json: async () => SI_RESPONSE })
+        if (url.includes('short_volume')) return Promise.resolve({ ok: true, json: async () => SV_RESPONSE })
+        // company endpoint
+        return Promise.resolve({ ok: true, json: async () => ({ data: {} }) })
+      })
+    }
+
+    it('fetches short interest and short volume in parallel on ticker change', async () => {
+      // Arrange
+      mockFetchForSI()
+      const wrapper = mountWidget()
+
+      // Act
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert: both endpoints called
+      const urls = global.fetch.mock.calls.map(c => c[0])
+      expect(urls.some(u => u.includes('short_interest/TSLA'))).toBe(true)
+      expect(urls.some(u => u.includes('short_volume/TSLA'))).toBe(true)
+    })
+
+    it('displays short interest values from REST response', async () => {
+      // Arrange
+      mockFetchForSI()
+      const wrapper = mountWidget()
+
+      // Act
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert: short card shows merged data from both endpoints
+      const shortCard = wrapper.find('.eqv2-short-card')
+      expect(shortCard.exists()).toBe(true)
+      expect(shortCard.text()).toContain('12.0M')  // short_interest formatted
+      expect(shortCard.text()).toContain('2.5')     // days_to_cover
+      expect(shortCard.text()).toContain('40.0')    // short_volume_ratio
+    })
+
+    it('shows unavailable message when endpoints return null data', async () => {
+      // Arrange
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: {} }) })
+      const wrapper = mountWidget()
+
+      // Act
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert
+      const shortCard = wrapper.find('.eqv2-short-card')
+      expect(shortCard.text()).toContain('unavailable')
+    })
+
+    it('resets short interest data when ticker changes', async () => {
+      // Arrange
+      mockFetchForSI()
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Act: change ticker
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: {} }) })
+      wrapper.vm.manualTicker = 'AAPL'
+      await wrapper.vm.$nextTick()
+
+      // Assert: shortInterestData reset while new fetch pending
+      const exposed = wrapper.vm.shortInterestData
+      expect(exposed).toEqual({})
+    })
+
+    it('handles fetch network error gracefully — shows unavailable, does not throw', async () => {
+      // Arrange
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+      const wrapper = mountWidget()
+
+      // Act
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert: no crash, unavailable shown
+      expect(wrapper.find('.eqv2-short-card').exists()).toBe(true)
+      expect(wrapper.find('.eqv2-short-card').text()).toContain('unavailable')
+      expect(wrapper.vm.shortInterestLoading).toBe(false)
+    })
+  })
+
 })

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -385,7 +385,7 @@ describe('EnhancedQuoteV2', () => {
     })
 
     it('resets short interest data when ticker changes', async () => {
-      // Arrange
+      // Arrange: load TSLA with real SI data
       mockFetchForSI()
       const wrapper = mountWidget()
       wrapper.vm.manualTicker = 'TSLA'
@@ -394,14 +394,18 @@ describe('EnhancedQuoteV2', () => {
       await new Promise(r => setTimeout(r, 0))
       await wrapper.vm.$nextTick()
 
-      // Act: change ticker
+      // Act: change ticker — new fetch returns null data
       global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: {} }) })
       wrapper.vm.manualTicker = 'AAPL'
       await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE, symbol: 'AAPL' }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
 
-      // Assert: shortInterestData reset while new fetch pending
-      const exposed = wrapper.vm.shortInterestData
-      expect(exposed).toEqual({})
+      // Assert: previous ticker's short interest values are gone from the DOM
+      const shortCard = wrapper.find('.eqv2-short-card')
+      expect(shortCard.text()).not.toContain('12.0M')
+      expect(shortCard.text()).toContain('unavailable')
     })
 
     it('handles fetch network error gracefully — shows unavailable, does not throw', async () => {


### PR DESCRIPTION
## Problem

Short interest section showed 'loading' forever. The widgets were reading `short_interest`, `days_to_cover`, and `short_volume_ratio` off the WebSocket `quoteData` payload, but the `daily_range` feed doesn't include those fields.

## Fix

Same pattern as company data enrichment — fetch from the new REST endpoints on ticker change instead of waiting for WebSocket data.

Both widgets now call `/api/market_data/short_interest/<symbol>` and `/api/market_data/short_volume/<symbol>` in parallel when the ticker changes, and store the results in a separate `shortInterestData` ref.

## Changes (EnhancedQuote + EnhancedQuoteV2)

- Add `shortInterestData` ref + `shortInterestLoading` ref  
- Add `fetchShortInterest()` — parallel fetch of both endpoints  
- Call alongside `fetchCompany()` on ticker change  
- Reset on ticker clear  
- Update `allShortNull` to check `shortInterestData` (not `quoteData`)  
- Update template bindings to read from `shortInterestData`  
- Distinct loading vs unavailable messages  

refs #135