### PR TITLE
fix: use next(iter(results)) for Massive list_* generator returns

### DIFF
--- a/apps/_default/api/market_data.py
+++ b/apps/_default/api/market_data.py
@@ -160,6 +160,9 @@ def short_interest(symbol: str):
     # Cache miss — call Massive
     try:
         client = _get_massive_client()
+        # list_short_interest() returns a lazy generator (paginator), not a list.
+        # Use next(iter(...)) — subscript access ([0]) raises TypeError.
+        # Verified against legion-mcp/massive_data_provider.py.
         results = client.list_short_interest(
             ticker=symbol,
             limit=1,

--- a/apps/_default/api/market_data.py
+++ b/apps/_default/api/market_data.py
@@ -234,6 +234,9 @@ def short_volume(symbol: str):
     # Cache miss — call Massive
     try:
         client = _get_massive_client()
+        # list_short_volume() returns a lazy generator (paginator), not a list.
+        # Same pattern as list_short_interest() — use next(iter(...)).
+        # Verified against legion-mcp/massive_data_provider.py.
         results = client.list_short_volume(
             ticker=symbol,
             limit=1,

--- a/apps/_default/api/market_data.py
+++ b/apps/_default/api/market_data.py
@@ -166,8 +166,8 @@ def short_interest(symbol: str):
             order="desc",
             sort="settlement_date",
         )
-        if results:
-            r = results[0]
+        r = next(iter(results), None)
+        if r is not None:
             data = {
                 "short_interest": getattr(r, "short_interest", None),
                 "days_to_cover": getattr(r, "days_to_cover", None),
@@ -240,8 +240,8 @@ def short_volume(symbol: str):
             order="desc",
             sort="date",
         )
-        if results:
-            r = results[0]
+        r = next(iter(results), None)
+        if r is not None:
             data = {
                 "short_volume": getattr(r, "short_volume", None),
                 "total_volume": getattr(r, "total_volume", None),

--- a/tests/apps/test_market_data.py
+++ b/tests/apps/test_market_data.py
@@ -183,7 +183,7 @@ class TestShortInterest:
         mock_redis = _make_redis_mock(None)
         record = _make_short_interest_record()
         mock_massive = MagicMock()
-        mock_massive.list_short_interest.return_value = [record]
+        mock_massive.list_short_interest.return_value = iter([record])
 
         with patch.object(md, "_get_wdc", return_value=mock_redis), \
              patch.object(md, "_get_massive_client", return_value=mock_massive):
@@ -203,7 +203,7 @@ class TestShortInterest:
         md = _import_market_data()
         mock_redis = _make_redis_mock(None)
         mock_massive = MagicMock()
-        mock_massive.list_short_interest.return_value = []
+        mock_massive.list_short_interest.return_value = iter([])
 
         with patch.object(md, "_get_wdc", return_value=mock_redis), \
              patch.object(md, "_get_massive_client", return_value=mock_massive):
@@ -286,7 +286,7 @@ class TestShortVolume:
         mock_redis = _make_redis_mock(None)
         record = _make_short_volume_record()
         mock_massive = MagicMock()
-        mock_massive.list_short_volume.return_value = [record]
+        mock_massive.list_short_volume.return_value = iter([record])
 
         with patch.object(md, "_get_wdc", return_value=mock_redis), \
              patch.object(md, "_get_massive_client", return_value=mock_massive):
@@ -308,7 +308,7 @@ class TestShortVolume:
         md = _import_market_data()
         mock_redis = _make_redis_mock(None)
         mock_massive = MagicMock()
-        mock_massive.list_short_volume.return_value = []
+        mock_massive.list_short_volume.return_value = iter([])
 
         with patch.object(md, "_get_wdc", return_value=mock_redis), \
              patch.object(md, "_get_massive_client", return_value=mock_massive):
@@ -343,9 +343,9 @@ class TestShortVolume:
         si_redis = _make_redis_mock(None)
         sv_redis = _make_redis_mock(None)
         si_massive = MagicMock()
-        si_massive.list_short_interest.return_value = [_make_short_interest_record()]
+        si_massive.list_short_interest.return_value = iter([_make_short_interest_record()])
         sv_massive = MagicMock()
-        sv_massive.list_short_volume.return_value = [_make_short_volume_record()]
+        sv_massive.list_short_volume.return_value = iter([_make_short_volume_record()])
 
         with patch.object(md, "_get_wdc", return_value=si_redis), \
              patch.object(md, "_get_massive_client", return_value=si_massive):


### PR DESCRIPTION
## Bug

`list_short_interest()` and `list_short_volume()` return lazy generators, not subscriptable lists. `results[0]` blew up in production:

```
[short_interest:MSFT] Massive API error: 'generator' object is not subscriptable
[short_volume:MSFT] Massive API error: 'generator' object is not subscriptable
```

## Root Cause

The design doc explicitly flagged verifying method names/return types against the Massive SDK as an open question. That step was skipped. `list_short_interest()` and `list_short_volume()` were assumed to return a list based on their type signatures, but the actual return type is a lazy generator/paginator.

The tests passed because the mocks returned `[record]` (a list, which is subscriptable), masking the mismatch. The test that should have caught this (`test_with_cache_miss_expect_api_called`) was written to match the assumed behavior, not the actual client contract.

**Reference that should have been consulted first:** `legion-mcp/massive_data_provider.py` — which correctly iterates with `for r in records`.

## Fix

- `results[0]` → `next(iter(results), None)` — safe for both generators and lists
- Test mocks updated from `[record]` to `iter([record])` — now catches this failure mode at test time
- In-code comments document the generator return type and reference the legion-mcp verification

## What changes

- `apps/_default/api/market_data.py` — fix + documentation comments
- `tests/apps/test_market_data.py` — mocks now match production behavior