### PR TITLE
feat: EnhancedQuoteV2 layout optimizations + company logo/description

### DIFF
--- a/apps/_default/api/market_data.py
+++ b/apps/_default/api/market_data.py
@@ -97,6 +97,7 @@ def company(symbol: str):
                 "name": getattr(ticker_details, "name", None),
                 "description": getattr(ticker_details, "description", None),
                 "homepage_url": getattr(ticker_details, "homepage_url", None),
+                "logo_url": getattr(getattr(ticker_details, "branding", None), "logo_url", None),
                 "list_date": getattr(ticker_details, "list_date", None),
                 "market_cap": getattr(ticker_details, "market_cap", None),
                 "primary_exchange": getattr(ticker_details, "primary_exchange", None),

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -31,11 +31,18 @@
       <!-- Price Hero -->
       <div class="eqv2-hero">
         <div class="eqv2-hero-left">
-          <span class="eqv2-symbol">{{ quoteData.symbol }}</span>
-          <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv2-flame-icon" />
-          <span class="eqv2-price">${{ fmt(quoteData.close, 2) }}</span>
+          <div class="eqv2-hero-identity">
+            <img v-if="companyData.logo_url" :src="companyData.logo_url" class="eqv2-hero-logo" :alt="companyData.name" />
+            <span class="eqv2-symbol">{{ quoteData.symbol }}</span>
+            <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv2-flame-icon" />
+          </div>
+          <div v-if="companyData.name || companyData.sic_description" class="eqv2-hero-company">
+            <span v-if="companyData.name" class="eqv2-hero-company-name">{{ companyData.name }}</span>
+            <span v-if="companyData.sic_description" class="eqv2-hero-sic"> · {{ companyData.sic_description }}</span>
+          </div>
         </div>
         <div class="eqv2-hero-right">
+          <span class="eqv2-price">${{ fmt(quoteData.close, 2) }}</span>
           <span :class="['eqv2-change-badge', changeClass]">
             {{ quoteData.change >= 0 ? '+' : '' }}{{ fmt(quoteData.change, 2) }}
             ({{ quoteData.pct_change >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change, 2) }}%)
@@ -57,25 +64,27 @@
           <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
           <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
           <div v-else>
-            <!-- Company header: logo + name + exchange -->
-            <div class="eqv2-company-header">
-              <img v-if="companyData.logo_url" :src="companyData.logo_url" class="eqv2-company-logo" :alt="companyData.name" />
-              <div class="eqv2-company-name-block">
-                <div class="eqv2-company-name">{{ companyData.name || '—' }}</div>
-                <div class="eqv2-company-meta">{{ [companyData.primary_exchange, companyData.sic_description].filter(Boolean).join(' · ') || '—' }}</div>
-              </div>
-            </div>
-            <!-- Description -->
-            <div v-if="companyData.description" class="eqv2-company-desc">{{ companyData.description }}</div>
-            <!-- Stats grid -->
             <div class="eqv2-kv-list">
-              <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
-              <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
-              <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
+              <!-- Website first -->
               <div v-if="companyData.homepage_url" class="eqv2-kv">
                 <span class="eqv2-k">Web</span>
                 <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
               </div>
+              <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
+            </div>
+            <!-- Description last, 50-char truncate + see more toggle -->
+            <div v-if="companyData.description" class="eqv2-company-desc-wrap">
+              <span class="eqv2-company-desc-text">
+                {{ descExpanded ? companyData.description : companyData.description.slice(0, 50) }}
+              </span>
+              <span v-if="!descExpanded && companyData.description.length > 50">
+                <span class="eqv2-company-desc-ellipsis">… </span>
+                <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
+              </span>
+              <button v-if="descExpanded" class="eqv2-see-more" @click="descExpanded = false"> less</button>
             </div>
           </div>
         </div>
@@ -248,6 +257,7 @@ const lastDataAt = ref(null)
 // Company enrichment — fetched via REST on ticker change
 const companyData = ref({})
 const companyLoading = ref(false)
+const descExpanded = ref(false)
 
 const shortInterestData = ref({})
 const shortInterestLoading = ref(false)
@@ -320,6 +330,7 @@ watch(activeTicker, (newTicker) => {
   quoteData.value = null
   companyData.value = {}
   shortInterestData.value = {}
+  descExpanded.value = false
   if (newTicker) {
     fetchCompany(newTicker)
     fetchShortInterest(newTicker)
@@ -532,9 +543,42 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 
 .eqv2-hero-left {
   display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
+}
+
+.eqv2-hero-identity {
+  display: flex;
+  align-items: center;
   gap: 6px;
+}
+
+.eqv2-hero-logo {
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  object-fit: contain;
+  flex-shrink: 0;
+  background: rgba(255,255,255,0.05);
+}
+
+.eqv2-hero-company {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.eqv2-hero-company-name {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.eqv2-hero-sic {
+  color: var(--text-muted);
 }
 
 .eqv2-hero-right {
@@ -654,52 +698,32 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 }
 .eqv2-link:hover { text-decoration: underline; }
 
-/* ── Company header ── */
-.eqv2-company-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
-}
-.eqv2-company-logo {
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
-  object-fit: contain;
-  flex-shrink: 0;
-  background: rgba(255,255,255,0.05);
-}
-.eqv2-company-name-block {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
-}
-.eqv2-company-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.eqv2-company-meta {
-  font-size: 10px;
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.eqv2-company-desc {
+/* ── Company description see-more ── */
+.eqv2-company-desc-wrap {
+  margin-top: 6px;
   font-size: 11px;
   color: var(--text-muted);
   line-height: 1.4;
-  margin-bottom: 6px;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
+.eqv2-company-desc-text {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.eqv2-company-desc-ellipsis {
+  color: var(--text-muted);
+}
+.eqv2-see-more {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+  font-family: system-ui, sans-serif;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.eqv2-see-more:hover { opacity: 0.8; }
 
 .eqv2-muted-msg {
   font-size: 11px;
@@ -836,7 +860,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 /* ── WIDE mode: 2-column grid ── */
 @container (min-width: 480px) {
   .eqv2-symbol { font-size: 20px; }
-  .eqv2-price  { font-size: 28px; }
+  .eqv2-price  { font-size: 26px; }
 
   .eqv2-session-mini-row {
     flex-direction: row;
@@ -882,8 +906,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
       "company session volume"
       "prev    prev    prev";
   }
-  .eqv2-hero-left  { gap: 10px; }
-  .eqv2-symbol     { font-size: 22px; }
-  .eqv2-price      { font-size: 30px; }
+  .eqv2-symbol { font-size: 22px; }
+  .eqv2-price  { font-size: 30px; }
 }
 </style>

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -30,21 +30,22 @@
     <div v-else class="eqv2-body">
       <!-- Price Hero -->
       <div class="eqv2-hero">
-        <div class="eqv2-ticker-row">
+        <div class="eqv2-hero-left">
           <span class="eqv2-symbol">{{ quoteData.symbol }}</span>
           <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv2-flame-icon" />
           <span class="eqv2-price">${{ fmt(quoteData.close, 2) }}</span>
+        </div>
+        <div class="eqv2-hero-right">
           <span :class="['eqv2-change-badge', changeClass]">
             {{ quoteData.change >= 0 ? '+' : '' }}{{ fmt(quoteData.change, 2) }}
             ({{ quoteData.pct_change >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change, 2) }}%)
           </span>
-        </div>
-        <div class="eqv2-since-open">
-          Since open:
-          <span :class="quoteData.pct_change_since_open >= 0 ? 'eqv2-pos' : 'eqv2-neg'">
-            {{ quoteData.pct_change_since_open >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change_since_open, 2) }}%
-            ({{ quoteData.change_since_open >= 0 ? '+' : '' }}${{ fmt(quoteData.change_since_open, 2) }})
-          </span>
+          <div class="eqv2-since-open">
+            Open:
+            <span :class="quoteData.pct_change_since_open >= 0 ? 'eqv2-pos' : 'eqv2-neg'">
+              {{ quoteData.pct_change_since_open >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change_since_open, 2) }}%
+            </span>
+          </div>
         </div>
       </div>
 
@@ -55,18 +56,27 @@
           <div class="eqv2-card-label">Company</div>
           <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
           <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
-          <div v-else class="eqv2-kv-list">
-            <div class="eqv2-kv"><span class="eqv2-k">Name</span><span class="eqv2-v">{{ companyData.name || '—' }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Sector</span><span class="eqv2-v">{{ companyData.sic_description || '—' }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
-            <div v-if="companyData.homepage_url" class="eqv2-kv">
-              <span class="eqv2-k">Web</span>
-              <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
+          <div v-else>
+            <!-- Company header: logo + name + exchange -->
+            <div class="eqv2-company-header">
+              <img v-if="companyData.logo_url" :src="companyData.logo_url" class="eqv2-company-logo" :alt="companyData.name" />
+              <div class="eqv2-company-name-block">
+                <div class="eqv2-company-name">{{ companyData.name || '—' }}</div>
+                <div class="eqv2-company-meta">{{ [companyData.primary_exchange, companyData.sic_description].filter(Boolean).join(' · ') || '—' }}</div>
+              </div>
             </div>
-            <div v-else class="eqv2-kv"><span class="eqv2-k">Web</span><span class="eqv2-v">—</span></div>
+            <!-- Description -->
+            <div v-if="companyData.description" class="eqv2-company-desc">{{ companyData.description }}</div>
+            <!-- Stats grid -->
+            <div class="eqv2-kv-list">
+              <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
+              <div v-if="companyData.homepage_url" class="eqv2-kv">
+                <span class="eqv2-k">Web</span>
+                <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -513,15 +523,26 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   border: 1px solid var(--border);
   border-radius: 6px;
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 12px;
 }
 
-.eqv2-ticker-row {
+.eqv2-hero-left {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
+}
+
+.eqv2-hero-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
 .eqv2-symbol {
@@ -558,8 +579,9 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 }
 
 .eqv2-since-open {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--text-muted);
+  text-align: right;
 }
 .eqv2-pos { color: var(--positive); font-weight: 600; }
 .eqv2-neg { color: var(--negative); font-weight: 600; }
@@ -631,6 +653,53 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   text-align: right;
 }
 .eqv2-link:hover { text-decoration: underline; }
+
+/* ── Company header ── */
+.eqv2-company-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.eqv2-company-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  object-fit: contain;
+  flex-shrink: 0;
+  background: rgba(255,255,255,0.05);
+}
+.eqv2-company-name-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.eqv2-company-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.eqv2-company-meta {
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.eqv2-company-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+  margin-bottom: 6px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
 
 .eqv2-muted-msg {
   font-size: 11px;
@@ -794,8 +863,9 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
       "company volume"
       "prev    prev";
     gap: 8px;
+    align-items: start;
   }
-  .eqv2-company-card { grid-area: company; }
+  .eqv2-company-card { grid-area: company; align-self: start; }
   .eqv2-today-card   { grid-area: today; }
   .eqv2-session-card { grid-area: session; }
   .eqv2-short-card   { grid-area: short; }
@@ -808,9 +878,12 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   .eqv2-sections {
     grid-template-columns: 1fr 1fr 1fr;
     grid-template-areas:
-      "company today   volume"
-      "company session short"
+      "company today   short"
+      "company session volume"
       "prev    prev    prev";
   }
+  .eqv2-hero-left  { gap: 10px; }
+  .eqv2-symbol     { font-size: 22px; }
+  .eqv2-price      { font-size: 30px; }
 }
 </style>

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -78,9 +78,9 @@
             <!-- Description last, 50-char truncate + see more toggle -->
             <div v-if="companyData.description" class="eqv2-company-desc-wrap">
               <span class="eqv2-company-desc-text">
-                {{ descExpanded ? companyData.description : companyData.description.slice(0, 50) }}
+                {{ descExpanded ? companyData.description : truncateDesc(companyData.description) }}
               </span>
-              <span v-if="!descExpanded && companyData.description.length > 50">
+              <span v-if="!descExpanded && truncateDesc(companyData.description) !== companyData.description">
                 <span class="eqv2-company-desc-ellipsis">… </span>
                 <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
               </span>
@@ -425,6 +425,12 @@ const allCompanyNull = computed(() => {
 const truncateUrl = (url) => {
   if (!url) return ''
   return url.replace(/^https?:\/\//, '').replace(/\/$/, '').slice(0, 30)
+}
+
+const truncateDesc = (text, maxLen = 50) => {
+  if (!text || text.length <= maxLen) return text
+  const cut = text.lastIndexOf(' ', maxLen)
+  return cut > 0 ? text.slice(0, cut) : text.slice(0, maxLen)
 }
 
 // Relative volume bar

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -197,7 +197,11 @@ describe('EnhancedQuoteV2', () => {
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await new Promise(r => setTimeout(r, 0))
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('.eqv2-company-card').text()).toContain('Tesla Inc.')
+    // Company name + sic_description now rendered in the hero card
+    expect(wrapper.find('.eqv2-hero').text()).toContain('Tesla Inc.')
+    expect(wrapper.find('.eqv2-hero').text()).toContain('Motor Vehicles')
+    // Company card shows exchange and website
+    expect(wrapper.find('.eqv2-company-card').text()).toContain('XNAS')
   })
 
   it('renders relative volume bar', async () => {

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -431,4 +431,168 @@ describe('EnhancedQuoteV2', () => {
     })
   })
 
+  describe('Hero company identity', () => {
+    function mockCompanyFetch(data) {
+      global.fetch = vi.fn().mockImplementation((url) => {
+        if (url.includes('short_interest') || url.includes('short_volume'))
+          return Promise.resolve({ ok: true, json: async () => ({ data: {} }) })
+        return Promise.resolve({ ok: true, json: async () => ({ data }) })
+      })
+    }
+
+    it('shows company name and sic_description in hero when available', async () => {
+      // Arrange
+      mockCompanyFetch({ name: 'Tesla Inc.', sic_description: 'Motor Vehicles', logo_url: null })
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert
+      const hero = wrapper.find('.eqv2-hero')
+      expect(hero.text()).toContain('Tesla Inc.')
+      expect(hero.text()).toContain('Motor Vehicles')
+    })
+
+    it('renders logo in hero when logo_url is present', async () => {
+      // Arrange
+      mockCompanyFetch({ name: 'Apple Inc.', sic_description: 'Computers', logo_url: 'https://example.com/logo.png' })
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'AAPL'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert
+      const logo = wrapper.find('.eqv2-hero-logo')
+      expect(logo.exists()).toBe(true)
+      expect(logo.attributes('src')).toBe('https://example.com/logo.png')
+    })
+
+    it('hero renders correctly when logo_url is null — no broken img element', async () => {
+      // Arrange
+      mockCompanyFetch({ name: 'No Logo Corp', sic_description: 'Services', logo_url: null })
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'NOLG'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert: no img rendered (v-if guard), but name still shows
+      expect(wrapper.find('.eqv2-hero-logo').exists()).toBe(false)
+      expect(wrapper.find('.eqv2-hero').text()).toContain('No Logo Corp')
+    })
+  })
+
+  describe('Description see-more toggle', () => {
+    const SHORT_DESC = 'Short desc.'
+    const LONG_DESC = 'Apple Inc. designs, manufactures, and markets smartphones, personal computers, tablets, and wearables.'
+
+    function mountWithDescription(description) {
+      global.fetch = vi.fn().mockImplementation((url) => {
+        if (url.includes('short_interest') || url.includes('short_volume'))
+          return Promise.resolve({ ok: true, json: async () => ({ data: {} }) })
+        return Promise.resolve({ ok: true, json: async () => ({ data: { name: 'ACME', description } }) })
+      })
+      const wrapper = mountWidget()
+      return wrapper
+    }
+
+    it('shows full text without toggle when description is short', async () => {
+      // Arrange
+      const wrapper = mountWithDescription(SHORT_DESC)
+      wrapper.vm.manualTicker = 'ACME'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert: no see-more button, full text shown
+      expect(wrapper.find('.eqv2-see-more').exists()).toBe(false)
+      expect(wrapper.find('.eqv2-company-desc-text').text()).toContain(SHORT_DESC)
+    })
+
+    it('truncates long description and shows see-more button', async () => {
+      // Arrange
+      const wrapper = mountWithDescription(LONG_DESC)
+      wrapper.vm.manualTicker = 'ACME'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert
+      const descText = wrapper.find('.eqv2-company-desc-text')
+      expect(descText.text().length).toBeLessThan(LONG_DESC.length)
+      expect(wrapper.find('.eqv2-see-more').exists()).toBe(true)
+      expect(wrapper.find('.eqv2-see-more').text()).toContain('see more')
+    })
+
+    it('expands to full description when see-more is clicked', async () => {
+      // Arrange
+      const wrapper = mountWithDescription(LONG_DESC)
+      wrapper.vm.manualTicker = 'ACME'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Act
+      await wrapper.find('.eqv2-see-more').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Assert: full text visible, button changes to 'less'
+      expect(wrapper.find('.eqv2-company-desc-text').text()).toContain(LONG_DESC)
+      expect(wrapper.find('.eqv2-see-more').text()).toContain('less')
+    })
+
+    it('collapses back when less is clicked', async () => {
+      // Arrange
+      const wrapper = mountWithDescription(LONG_DESC)
+      wrapper.vm.manualTicker = 'ACME'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+      await wrapper.find('.eqv2-see-more').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Act
+      await wrapper.find('.eqv2-see-more').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // Assert: truncated again, see-more button back
+      expect(wrapper.find('.eqv2-company-desc-text').text().length).toBeLessThan(LONG_DESC.length)
+      expect(wrapper.find('.eqv2-see-more').text()).toContain('see more')
+    })
+
+    it('resets description to collapsed when ticker changes', async () => {
+      // Arrange: load ACME with long desc, expand
+      const wrapper = mountWithDescription(LONG_DESC)
+      wrapper.vm.manualTicker = 'ACME'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+      await wrapper.find('.eqv2-see-more').trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.eqv2-company-desc-text').text()).toContain(LONG_DESC)
+
+      // Act: change ticker
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: {} }) })
+      wrapper.vm.manualTicker = 'OTHER'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert: expanded state cleared — no see-more button since new company has no desc
+      expect(wrapper.find('.eqv2-company-desc-wrap').exists()).toBe(false)
+    })
+  })
+
 })


### PR DESCRIPTION
## Layout Optimizations

### Hero card
Previously: all content left-aligned, empty right half
Now: symbol+price left, change badge+since-open right (`justify-content: space-between`). Full width used at every breakpoint. Font sizes scale up in 3-col mode.

### Company card
Previously: in 2-col it spanned all rows and had empty space equivalent to SI + Volume combined
Now: `align-self: start` — card sizes to its content; logo + name + exchange/sector on one compact header line; full company description (3-line clamp); exchange and sector consolidated into one meta line

### 3-column grid layout
Previously: company/today/volume | company/session/short | prev
Now: company/today/short | company/session/volume | prev — better balance

## New Company Data

### Backend (`/api/market_data/company`)
- Added `logo_url` from `ticker_details.branding.logo_url`
- `description` was already in the response (verified)

### Widget display
- Company logo (28×28px, rounded, graceful fallback if null)
- Full `description` field (company business description, 3-line clamp)
- `sic_description` consolidated with `primary_exchange` into a compact meta line below the name

refs #133