### PR TITLE
feat: add logo proxy endpoint with Redis byte cache (PR A)

### DIFF
--- a/apps/_default/api/market_data.py
+++ b/apps/_default/api/market_data.py
@@ -206,14 +206,19 @@ def logo(symbol: str):
 
 
 def _detect_image_content_type(data: bytes) -> str:
-    """Detect image MIME type from magic bytes."""
+    """Detect image MIME type from magic bytes.
+
+    SVG check scans the first 512 bytes to handle both bare '<svg' and
+    XML-declaration-prefixed '<?xml ...><svg' variants without false-positives
+    on non-SVG XML (XHTML, RSS, etc.).
+    """
     if data[:4] == b'\x89PNG':
         return "image/png"
     if data[:3] == b'GIF':
         return "image/gif"
-    if data[:2] in (b'\xff\xd8',):
+    if data[:2] == b'\xff\xd8':
         return "image/jpeg"
-    if data[:4] in (b'<svg', b'<?xm'):
+    if b'<svg' in data[:512]:
         return "image/svg+xml"
     return "image/png"  # safe fallback
 

--- a/apps/_default/api/market_data.py
+++ b/apps/_default/api/market_data.py
@@ -6,6 +6,7 @@ pipeline so both the MDS and SCP share the same enrichment layer.
 
 Routes:
     GET /api/market_data/company/<symbol>        — Massive ticker overview
+    GET /api/market_data/logo/<symbol>           — Company logo image proxy
     GET /api/market_data/news/<symbol>           — Finlight ticker news
     GET /api/market_data/short_interest/<symbol> — Massive FINRA short interest
     GET /api/market_data/short_volume/<symbol>   — Massive short volume ratio
@@ -13,7 +14,9 @@ Routes:
 import json
 import logging
 
-from py4web import action, request
+import requests as requests_lib
+
+from py4web import HTTP, action, request, response
 
 from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
 from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
@@ -40,9 +43,15 @@ _SV_TTL = 86400                 # 1 day — short volume is T+1
 
 
 def _get_wdc():
-    """Return a synchronous Redis client for WDC."""
+    """Return a synchronous Redis client for WDC (str values)."""
     import redis as redis_lib
     return redis_lib.from_url(WDC_REDIS_URL, decode_responses=True)
+
+
+def _get_wdc_bytes():
+    """Return a synchronous Redis client for WDC (raw bytes — for binary values)."""
+    import redis as redis_lib
+    return redis_lib.from_url(WDC_REDIS_URL, decode_responses=False)
 
 
 def _get_massive_client():
@@ -125,6 +134,88 @@ def company(symbol: str):
         except Exception:
             pass
         return dict(symbol=symbol, data={}, error="Company data temporarily unavailable")
+
+
+# ---------------------------------------------------------------------------
+# Company logo proxy
+# ---------------------------------------------------------------------------
+
+@action("api/market_data/logo/<symbol>", method=["GET"])
+@action.uses(session, auth.user)
+def logo(symbol: str):
+    """Return company logo bytes, proxied from Massive API with Redis cache.
+
+    Requires session auth (same as all market data endpoints).
+    Cache: enrichment:logo:{symbol} in WDC Redis (30-day TTL), raw bytes.
+    Reads logo_url from enrichment:overview:{symbol} (written by company endpoint).
+    Returns 404 if overview cache is missing, logo_url absent, or Massive returns non-200.
+    """
+    symbol = symbol.upper().strip()
+    logo_cache_key = f"enrichment:logo:{symbol}"
+    overview_cache_key = f"enrichment:overview:{symbol}"
+
+    # Check byte cache first
+    try:
+        wdc_bytes = _get_wdc_bytes()
+        cached_bytes = wdc_bytes.get(logo_cache_key)
+        if cached_bytes:
+            content_type = _detect_image_content_type(cached_bytes)
+            response.headers["Content-Type"] = content_type
+            logger.debug(f"[logo:{symbol}] cache hit ({len(cached_bytes)} bytes)")
+            return cached_bytes
+    except Exception as e:
+        logger.error(f"[logo:{symbol}] Redis bytes read error: {e}")
+
+    # Read logo_url from overview cache
+    logo_url = None
+    try:
+        wdc = _get_wdc()
+        overview_raw = wdc.get(overview_cache_key)
+        if overview_raw:
+            overview = json.loads(overview_raw)
+            logo_url = overview.get("logo_url")
+    except Exception as e:
+        logger.error(f"[logo:{symbol}] Redis overview read error: {e}")
+
+    if not logo_url:
+        logger.debug(f"[logo:{symbol}] no logo_url in overview cache")
+        raise HTTP(404)
+
+    # Fetch from Massive (authenticated)
+    try:
+        url = f"{logo_url}?apiKey={MASSIVE_API_KEY}"
+        resp = requests_lib.get(url, timeout=10)
+        if resp.status_code != 200:
+            logger.warning(f"[logo:{symbol}] Massive returned {resp.status_code}")
+            raise HTTP(404)
+        img_bytes = resp.content
+        content_type = resp.headers.get("Content-Type", "image/png").split(";")[0].strip()
+        try:
+            wdc_bytes = _get_wdc_bytes()
+            wdc_bytes.setex(logo_cache_key, _OVERVIEW_TTL, img_bytes)
+        except Exception as e:
+            logger.error(f"[logo:{symbol}] Redis bytes write error: {e}")
+        response.headers["Content-Type"] = content_type
+        logger.info(f"[logo:{symbol}] fetched from Massive ({len(img_bytes)} bytes)")
+        return img_bytes
+    except HTTP:
+        raise
+    except Exception as e:
+        logger.error(f"[logo:{symbol}] fetch error: {e}")
+        raise HTTP(404)
+
+
+def _detect_image_content_type(data: bytes) -> str:
+    """Detect image MIME type from magic bytes."""
+    if data[:4] == b'\x89PNG':
+        return "image/png"
+    if data[:3] == b'GIF':
+        return "image/gif"
+    if data[:2] in (b'\xff\xd8',):
+        return "image/jpeg"
+    if data[:4] in (b'<svg', b'<?xm'):
+        return "image/svg+xml"
+    return "image/png"  # safe fallback
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps/test_market_data.py
+++ b/tests/apps/test_market_data.py
@@ -15,11 +15,19 @@ from unittest.mock import MagicMock, patch
 # py4web / app import scaffolding (mirrors test_default_controllers.py pattern)
 # ---------------------------------------------------------------------------
 
+class _HTTP404(Exception):
+    """Minimal HTTP exception stub matching py4web HTTP interface."""
+    def __init__(self, status=200, *args, **kwargs):
+        self.status = status
+        super().__init__(status)
+
+
 def _stub_py4web():
     py4web = MagicMock()
     _passthrough = lambda *a, **kw: (lambda f: f)
     _passthrough.uses = lambda *a, **kw: (lambda f: f)
     py4web.action = _passthrough
+    py4web.HTTP = _HTTP404
     stubs = {
         "py4web": py4web,
         "py4web.core": MagicMock(required_folder=lambda *a: "/tmp"),
@@ -360,3 +368,105 @@ class TestShortVolume:
         assert si_key != sv_key
         assert "short_interest" in si_key
         assert "short_volume" in sv_key
+
+
+# ---------------------------------------------------------------------------
+# logo tests
+# ---------------------------------------------------------------------------
+
+class TestLogo:
+    def _make_bytes_redis_mock(self, cached_value=None):
+        """Return a mock Redis client for byte values."""
+        mock = MagicMock()
+        mock.get.return_value = cached_value
+        mock.setex.return_value = True
+        return mock
+
+    def test_logo_with_no_overview_cache_expect_404(self):
+        # Arrange
+        md = _import_market_data()
+        mock_bytes_redis = self._make_bytes_redis_mock(None)  # no cached bytes
+        mock_str_redis = _make_redis_mock(None)               # no overview cache
+
+        # Act / Assert
+        with patch.object(md, "_get_wdc_bytes", return_value=mock_bytes_redis), \
+             patch.object(md, "_get_wdc", return_value=mock_str_redis):
+            with pytest.raises(_HTTP404) as exc_info:
+                md.logo("AAPL")
+
+        assert exc_info.value.status == 404
+
+    def test_logo_with_cache_miss_fetches_polygon_and_returns_bytes(self):
+        # Arrange
+        md = _import_market_data()
+        img_bytes = b'\x89PNG\r\n\x1a\nfakeimagedata'
+        overview_data = {"name": "Apple Inc.", "logo_url": "https://api.polygon.io/v1/reference/company-branding/apple.com/logo"}
+
+        mock_bytes_redis = self._make_bytes_redis_mock(None)
+        mock_str_redis = _make_redis_mock(json.dumps(overview_data))
+
+        mock_requests = MagicMock()
+        mock_polygon_response = MagicMock()
+        mock_polygon_response.status_code = 200
+        mock_polygon_response.content = img_bytes
+        mock_polygon_response.headers = {"Content-Type": "image/png"}
+        mock_requests.get.return_value = mock_polygon_response
+
+        # Act
+        with patch.object(md, "_get_wdc_bytes", return_value=mock_bytes_redis), \
+             patch.object(md, "_get_wdc", return_value=mock_str_redis), \
+             patch.object(md, "requests_lib", mock_requests):
+            result = md.logo("AAPL")
+
+        # Assert — bytes returned, Polygon called with apiKey, bytes cached
+        assert result == img_bytes
+        call_url = mock_requests.get.call_args[0][0]
+        assert "apiKey=test-key" in call_url
+        assert "logo" in call_url
+        mock_bytes_redis.setex.assert_called_once()
+        cache_key, ttl, stored = mock_bytes_redis.setex.call_args[0]
+        assert "logo" in cache_key
+        assert ttl == 30 * 86400  # _OVERVIEW_TTL
+        assert stored == img_bytes
+
+    def test_logo_with_byte_cache_hit_skips_polygon(self):
+        # Arrange
+        md = _import_market_data()
+        img_bytes = b'\x89PNG\r\n\x1a\nfakeimagedata'
+        mock_bytes_redis = self._make_bytes_redis_mock(img_bytes)  # cache hit
+        mock_requests = MagicMock()
+
+        # Act
+        with patch.object(md, "_get_wdc_bytes", return_value=mock_bytes_redis), \
+             patch.object(md, "_get_wdc") as mock_str_redis_cls, \
+             patch.object(md, "requests_lib", mock_requests):
+            result = md.logo("AAPL")
+
+        # Assert — bytes returned, Polygon NOT called, overview Redis NOT read
+        assert result == img_bytes
+        mock_requests.get.assert_not_called()
+        mock_str_redis_cls.assert_not_called()
+
+    def test_logo_with_polygon_non_200_expect_404(self):
+        # Arrange
+        md = _import_market_data()
+        overview_data = {"name": "Apple Inc.", "logo_url": "https://api.polygon.io/v1/reference/company-branding/apple.com/logo"}
+
+        mock_bytes_redis = self._make_bytes_redis_mock(None)
+        mock_str_redis = _make_redis_mock(json.dumps(overview_data))
+
+        mock_requests = MagicMock()
+        mock_polygon_response = MagicMock()
+        mock_polygon_response.status_code = 403
+        mock_polygon_response.content = b''
+        mock_requests.get.return_value = mock_polygon_response
+
+        # Act / Assert
+        with patch.object(md, "_get_wdc_bytes", return_value=mock_bytes_redis), \
+             patch.object(md, "_get_wdc", return_value=mock_str_redis), \
+             patch.object(md, "requests_lib", mock_requests):
+            with pytest.raises(_HTTP404) as exc_info:
+                md.logo("AAPL")
+
+        assert exc_info.value.status == 404
+        mock_bytes_redis.setex.assert_not_called()  # nothing cached on failure


### PR DESCRIPTION
## Summary

Adds `GET /api/market_data/logo/<symbol>` — a server-side proxy for Polygon company branding images. Fixes the HTTP 401 broken logo bug reported after PR #141 merged to prod.

## Problem

`companyData.logo_url` from Polygon requires `?apiKey=<key>` authentication. Browser `<img>` tags make unauthenticated requests → 401 → broken image in the widget hero.

## Solution

Back-end proxy endpoint that:
- Reads `logo_url` from the existing `enrichment:overview:{symbol}` Redis cache (written by the `/company` endpoint)
- Checks `enrichment:logo:{symbol}` for cached image bytes (30-day TTL, `decode_responses=False`)
- On cache miss: fetches `{logo_url}?apiKey={MASSIVE_API_KEY}` server-side via `requests`
- Returns bytes with correct Content-Type; returns 404 on any failure
- Auth: `@action.uses(session, auth.user)` — consistent with all other market data endpoints

## Changes

- `apps/_default/api/market_data.py`: new `logo()` endpoint, `_get_wdc_bytes()` helper, `_detect_image_content_type()` helper, `requests` promoted to module-level import
- `tests/apps/test_market_data.py`: 4 new tests — 404 on no cache, Polygon fetch + cache write, byte cache hit skips Polygon, Polygon non-200 returns 404

## Test Results

17/17 passing (13 existing + 4 new)

refs #133