### PR TITLE
feat: EQV2 layout v2 — logo proxy src, since-open fix, chip H/L, flex columns (PR B)

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -32,7 +32,13 @@
       <div class="eqv2-hero">
         <div class="eqv2-hero-left">
           <div class="eqv2-hero-identity">
-            <img v-if="companyData.logo_url" :src="companyData.logo_url" class="eqv2-hero-logo" :alt="companyData.name" />
+            <img
+              v-if="activeTicker && !logoError"
+              :src="`/api/market_data/logo/${activeTicker}`"
+              class="eqv2-hero-logo"
+              :alt="companyData.name || activeTicker"
+              @error="logoError = true"
+            />
             <span class="eqv2-symbol">{{ quoteData.symbol }}</span>
             <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv2-flame-icon" />
           </div>
@@ -48,127 +54,177 @@
             ({{ quoteData.pct_change >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change, 2) }}%)
           </span>
           <div class="eqv2-since-open">
-            Open:
+            since open
             <span :class="quoteData.pct_change_since_open >= 0 ? 'eqv2-pos' : 'eqv2-neg'">
               {{ quoteData.pct_change_since_open >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change_since_open, 2) }}%
+              <span v-if="quoteData.change_since_open != null">
+                ({{ quoteData.change_since_open >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData.change_since_open), 2) }})
+              </span>
             </span>
           </div>
         </div>
       </div>
 
-      <!-- Adaptive sections grid -->
+      <!-- Adaptive sections: flex columns at wide/full, single col at narrow -->
       <div class="eqv2-sections">
-        <!-- Company card -->
-        <div class="eqv2-card eqv2-company-card">
-          <div class="eqv2-card-label">Company</div>
-          <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
-          <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
-          <div v-else>
+        <!-- Col 1: Session H/L, Today, Volume (narrow: all cards stack here) -->
+        <div class="eqv2-col eqv2-col-1">
+          <!-- Session H/L card — chip style at all widths -->
+          <div class="eqv2-card eqv2-session-card">
+            <div class="eqv2-card-label">Session H/L</div>
+            <div class="eqv2-session-chips">
+              <div class="eqv2-session-chip">
+                <span class="eqv2-chip-label">PRE</span>
+                <div v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null" class="eqv2-session-chip-vals">
+                  <span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span>
+                  <span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span>
+                </div>
+                <div v-else class="eqv2-session-chip-vals eqv2-muted-val">—</div>
+              </div>
+              <div class="eqv2-session-chip">
+                <span class="eqv2-chip-label">REG</span>
+                <div v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null" class="eqv2-session-chip-vals">
+                  <span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span>
+                  <span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span>
+                </div>
+                <div v-else class="eqv2-session-chip-vals eqv2-muted-val">—</div>
+              </div>
+              <div class="eqv2-session-chip">
+                <span class="eqv2-chip-label">AH</span>
+                <div v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null" class="eqv2-session-chip-vals">
+                  <span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span>
+                  <span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span>
+                </div>
+                <div v-else class="eqv2-session-chip-vals eqv2-muted-val">—</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Today card -->
+          <div class="eqv2-card eqv2-today-card">
+            <div class="eqv2-card-label">Today</div>
             <div class="eqv2-kv-list">
-              <!-- Website first -->
-              <div v-if="companyData.homepage_url" class="eqv2-kv">
-                <span class="eqv2-k">Web</span>
-                <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
+              <div class="eqv2-kv"><span class="eqv2-k">Open</span><span class="eqv2-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">VWAP</span><span class="eqv2-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+            </div>
+          </div>
+
+          <!-- Volume card -->
+          <div class="eqv2-card eqv2-volume-card">
+            <div class="eqv2-card-label">Volume</div>
+            <div class="eqv2-kv-list">
+              <div class="eqv2-kv"><span class="eqv2-k">Volume</span><span class="eqv2-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Avg Vol</span><span class="eqv2-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Float</span><span class="eqv2-v">{{ fmtVol(floatShares) }}</span></div>
+            </div>
+            <!-- Relative Volume bar -->
+            <div class="eqv2-rv-row">
+              <span class="eqv2-k">Rel. Vol</span>
+              <div class="eqv2-rv-bar-wrap">
+                <div class="eqv2-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div>
               </div>
-              <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
-              <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
-              <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
-              <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
-            </div>
-            <!-- Description last, 50-char truncate + see more toggle -->
-            <div v-if="companyData.description" class="eqv2-company-desc-wrap">
-              <span class="eqv2-company-desc-text">
-                {{ descExpanded ? companyData.description : truncateDesc(companyData.description) }}
-              </span>
-              <span v-if="!descExpanded && truncateDesc(companyData.description) !== companyData.description">
-                <span class="eqv2-company-desc-ellipsis">… </span>
-                <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
-              </span>
-              <button v-if="descExpanded" class="eqv2-see-more" @click="descExpanded = false"> less</button>
+              <span :class="['eqv2-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
             </div>
           </div>
-        </div>
 
-        <!-- Today card -->
-        <div class="eqv2-card eqv2-today-card">
-          <div class="eqv2-card-label">Today</div>
-          <div class="eqv2-kv-list">
-            <div class="eqv2-kv"><span class="eqv2-k">Open</span><span class="eqv2-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">VWAP</span><span class="eqv2-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+          <!-- Narrow-only: Short Interest (in col-1 when single column) -->
+          <div class="eqv2-card eqv2-short-card eqv2-narrow-only">
+            <div class="eqv2-card-label">Short Interest</div>
+            <div v-if="shortInterestLoading" class="eqv2-muted-msg">Short interest data loading...</div>
+            <div v-else-if="allShortNull" class="eqv2-muted-msg">Short interest data unavailable</div>
+            <div v-else class="eqv2-kv-list">
+              <div class="eqv2-kv"><span class="eqv2-k">Short Int.</span><span class="eqv2-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Days to Cover</span><span class="eqv2-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Short Vol Ratio</span><span class="eqv2-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
+            </div>
           </div>
-        </div>
 
-        <!-- Session H/L card -->
-        <div class="eqv2-card eqv2-session-card">
-          <div class="eqv2-card-label">Session H/L</div>
-          <div class="eqv2-session-mini-row">
-            <div class="eqv2-session-mini">
-              <div class="eqv2-session-mini-label">PRE</div>
-              <div class="eqv2-session-mini-vals" v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null">
-                <span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span>
-                <span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span>
+          <!-- Narrow-only: Company card -->
+          <div class="eqv2-card eqv2-company-card eqv2-narrow-only">
+            <div class="eqv2-card-label">Company</div>
+            <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
+            <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
+            <div v-else>
+              <div class="eqv2-kv-list">
+                <div v-if="companyData.homepage_url" class="eqv2-kv">
+                  <span class="eqv2-k">Web</span>
+                  <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
+                </div>
+                <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
+                <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
+                <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
+                <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
               </div>
-              <div class="eqv2-session-mini-vals" v-else>—</div>
-            </div>
-            <div class="eqv2-session-mini">
-              <div class="eqv2-session-mini-label">REG</div>
-              <div class="eqv2-session-mini-vals" v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null">
-                <span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span>
-                <span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span>
+              <div v-if="companyData.description" class="eqv2-company-desc-wrap">
+                <span class="eqv2-company-desc-text">
+                  {{ descExpanded ? companyData.description : truncateDesc(companyData.description) }}
+                </span>
+                <span v-if="!descExpanded && truncateDesc(companyData.description) !== companyData.description">
+                  <span class="eqv2-company-desc-ellipsis">… </span>
+                  <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
+                </span>
+                <button v-if="descExpanded" class="eqv2-see-more" @click="descExpanded = false"> less</button>
               </div>
-              <div class="eqv2-session-mini-vals" v-else>—</div>
             </div>
-            <div class="eqv2-session-mini">
-              <div class="eqv2-session-mini-label">AH</div>
-              <div class="eqv2-session-mini-vals" v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null">
-                <span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span>
-                <span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span>
+          </div>
+        </div>
+
+        <!-- Col 2: Short Interest + Company (wide/full mode) -->
+        <div class="eqv2-col eqv2-col-2">
+          <!-- Short Interest -->
+          <div class="eqv2-card eqv2-short-card">
+            <div class="eqv2-card-label">Short Interest</div>
+            <div v-if="shortInterestLoading" class="eqv2-muted-msg">Short interest data loading...</div>
+            <div v-else-if="allShortNull" class="eqv2-muted-msg">Short interest data unavailable</div>
+            <div v-else class="eqv2-kv-list">
+              <div class="eqv2-kv"><span class="eqv2-k">Short Int.</span><span class="eqv2-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Days to Cover</span><span class="eqv2-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+              <div class="eqv2-kv"><span class="eqv2-k">Short Vol Ratio</span><span class="eqv2-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
+            </div>
+          </div>
+
+          <!-- Company card -->
+          <div class="eqv2-card eqv2-company-card">
+            <div class="eqv2-card-label">Company</div>
+            <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
+            <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
+            <div v-else>
+              <div class="eqv2-kv-list">
+                <div v-if="companyData.homepage_url" class="eqv2-kv">
+                  <span class="eqv2-k">Web</span>
+                  <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
+                </div>
+                <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
+                <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
+                <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
+                <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
               </div>
-              <div class="eqv2-session-mini-vals" v-else>—</div>
+              <div v-if="companyData.description" class="eqv2-company-desc-wrap">
+                <span class="eqv2-company-desc-text">
+                  {{ descExpanded ? companyData.description : truncateDesc(companyData.description) }}
+                </span>
+                <span v-if="!descExpanded && truncateDesc(companyData.description) !== companyData.description">
+                  <span class="eqv2-company-desc-ellipsis">… </span>
+                  <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
+                </span>
+                <button v-if="descExpanded" class="eqv2-see-more" @click="descExpanded = false"> less</button>
+              </div>
             </div>
           </div>
         </div>
 
-        <!-- Short Interest -->
-        <div class="eqv2-card eqv2-short-card">
-          <div class="eqv2-card-label">Short Interest</div>
-          <div v-if="shortInterestLoading" class="eqv2-muted-msg">Short interest data loading...</div>
-          <div v-else-if="allShortNull" class="eqv2-muted-msg">Short interest data unavailable</div>
-          <div v-else class="eqv2-kv-list">
-            <div class="eqv2-kv"><span class="eqv2-k">Short Int.</span><span class="eqv2-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Days to Cover</span><span class="eqv2-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Short Vol Ratio</span><span class="eqv2-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
-          </div>
-        </div>
-
-        <!-- Volume card -->
-        <div class="eqv2-card eqv2-volume-card">
-          <div class="eqv2-card-label">Volume</div>
-          <div class="eqv2-kv-list">
-            <div class="eqv2-kv"><span class="eqv2-k">Volume</span><span class="eqv2-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Avg Vol</span><span class="eqv2-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
-            <div class="eqv2-kv"><span class="eqv2-k">Float</span><span class="eqv2-v">{{ fmtVol(floatShares) }}</span></div>
-          </div>
-          <!-- Relative Volume bar -->
-          <div class="eqv2-rv-row">
-            <span class="eqv2-k">Rel. Vol</span>
-            <div class="eqv2-rv-bar-wrap">
-              <div class="eqv2-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div>
+        <!-- Previous Day: always full-width at bottom -->
+        <div class="eqv2-prev-row">
+          <div class="eqv2-card eqv2-prev-card">
+            <div class="eqv2-card-label">Previous Day</div>
+            <div class="eqv2-prev-chips">
+              <div class="eqv2-chip"><span class="eqv2-chip-label">O</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+              <div class="eqv2-chip"><span class="eqv2-chip-label">H</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+              <div class="eqv2-chip"><span class="eqv2-chip-label">L</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+              <div class="eqv2-chip"><span class="eqv2-chip-label">C</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+              <div class="eqv2-chip"><span class="eqv2-chip-label">Vol</span><span class="eqv2-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+              <div class="eqv2-chip"><span class="eqv2-chip-label">VWAP</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
             </div>
-            <span :class="['eqv2-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
-          </div>
-        </div>
-
-        <!-- Previous Day: full-width strip -->
-        <div class="eqv2-card eqv2-prev-card">
-          <div class="eqv2-card-label">Previous Day</div>
-          <div class="eqv2-prev-chips">
-            <div class="eqv2-chip"><span class="eqv2-chip-label">O</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
-            <div class="eqv2-chip"><span class="eqv2-chip-label">H</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
-            <div class="eqv2-chip"><span class="eqv2-chip-label">L</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
-            <div class="eqv2-chip"><span class="eqv2-chip-label">C</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
-            <div class="eqv2-chip"><span class="eqv2-chip-label">Vol</span><span class="eqv2-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
-            <div class="eqv2-chip"><span class="eqv2-chip-label">VWAP</span><span class="eqv2-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
           </div>
         </div>
       </div>
@@ -239,7 +295,6 @@ const applyInput = () => {
   if (!t) return
   manualTicker.value = t
   inputTicker.value = ''
-  // Broadcast to widget bus so linked widgets also update
   if (props.linkColor) {
     setActiveTicker(props.linkColor, t)
   }
@@ -253,6 +308,9 @@ watch(busTicker, (t) => {
 // Quote data
 const quoteData = ref(null)
 const lastDataAt = ref(null)
+
+// Logo error state — reset on ticker change
+const logoError = ref(false)
 
 // Company enrichment — fetched via REST on ticker change
 const companyData = ref({})
@@ -296,7 +354,6 @@ const fetchCompany = async (symbol) => {
       companyData.value = json.data || {}
     }
   } catch (e) {
-    // Network error — leave companyData empty, UI shows unavailable
     console.warn(`[EnhancedQuoteV2] company fetch failed for ${symbol}:`, e)
   } finally {
     companyLoading.value = false
@@ -331,6 +388,7 @@ watch(activeTicker, (newTicker) => {
   companyData.value = {}
   shortInterestData.value = {}
   descExpanded.value = false
+  logoError.value = false
   if (newTicker) {
     fetchCompany(newTicker)
     fetchShortInterest(newTicker)
@@ -449,7 +507,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, logoError })
 </script>
 
 <style scoped>
@@ -736,36 +794,36 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   color: var(--text-muted);
   font-style: italic;
 }
+.eqv2-muted-val {
+  color: var(--text-muted);
+  font-family: 'Roboto Mono', monospace;
+  font-size: 12px;
+}
 
-/* ── Session H/L mini-cards ── */
-.eqv2-session-mini-row {
+/* ── Session H/L chips (all widths) ── */
+.eqv2-session-chips {
+  display: flex;
+  flex-direction: column;   /* narrow: stack vertically */
+  gap: 6px;
+}
+.eqv2-session-chip {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  align-items: flex-start;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  gap: 2px;
+  flex: 1;
 }
-.eqv2-session-mini {
+.eqv2-session-chip-vals {
   display: flex;
-  align-items: baseline;
-  gap: 6px;
-  padding: 3px 0;
-  border-bottom: 1px solid var(--border);
-}
-.eqv2-session-mini-label {
-  font-size: 10px;
-  text-transform: uppercase;
-  font-weight: 700;
-  color: var(--text-muted);
-  font-family: system-ui, sans-serif;
-  min-width: 30px;
-  flex-shrink: 0;
-}
-.eqv2-session-mini-vals {
-  display: flex;
-  gap: 8px;
+  flex-direction: column;
   font-family: 'Roboto Mono', monospace;
   font-size: 12px;
   color: var(--text-primary);
-  flex-wrap: wrap;
+  gap: 1px;
 }
 
 /* ── Relative Volume bar ── */
@@ -796,9 +854,9 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   min-width: 36px;
   text-align: right;
 }
-.eqv2-rv-val.extreme { color: #dc2626; font-weight: 700; } /* red — matches rvBarColor */
-.eqv2-rv-val.high    { color: #f97316; font-weight: 600; } /* orange */
-.eqv2-rv-val.medium  { color: #eab308; }                   /* yellow */
+.eqv2-rv-val.extreme { color: #dc2626; font-weight: 700; }
+.eqv2-rv-val.high    { color: #f97316; font-weight: 600; }
+.eqv2-rv-val.medium  { color: #eab308; }
 
 /* ── Previous Day chips ── */
 .eqv2-prev-chips {
@@ -856,62 +914,56 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   font-family: system-ui, sans-serif;
 }
 
-/* ── Sections layout (narrow default: single column) ── */
+/* ── Sections: narrow (< 480px) — single flex column ── */
+/* Breakpoint constants — must match BREAKPOINTS in PR C JS: WIDE=480, FULL=680 */
 .eqv2-sections {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-/* ── WIDE mode: 2-column grid ── */
-@container (min-width: 480px) {
+.eqv2-col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Col-2 hidden at narrow; shown at WIDE+ */
+.eqv2-col-2 { display: none; }
+
+/* Previous Day always full width */
+.eqv2-prev-row { width: 100%; }
+
+/* In narrow mode, show Short + Company inside col-1 via .eqv2-narrow-only */
+/* At wide+, hide .eqv2-narrow-only; col-2 takes over */
+.eqv2-narrow-only { display: flex; flex-direction: column; }
+
+/* ── WIDE mode (480px+): two flex columns ── */
+@container (min-width: 480px) {   /* BREAKPOINTS.WIDE */
   .eqv2-symbol { font-size: 20px; }
   .eqv2-price  { font-size: 26px; }
 
-  .eqv2-session-mini-row {
-    flex-direction: row;
-    gap: 6px;
-  }
-  .eqv2-session-mini {
-    flex: 1;
-    flex-direction: column;
-    align-items: flex-start;
-    border-bottom: none;
-    border-right: 1px solid var(--border);
-    padding: 4px 6px;
-    gap: 2px;
-  }
-  .eqv2-session-mini:last-child { border-right: none; }
+  /* Session chips go horizontal */
+  .eqv2-session-chips { flex-direction: row; }
 
+  /* Two-column flex layout */
   .eqv2-sections {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas:
-      "company today"
-      "company session"
-      "company short"
-      "company volume"
-      "prev    prev";
-    gap: 8px;
-    align-items: start;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
   }
-  .eqv2-company-card { grid-area: company; align-self: start; }
-  .eqv2-today-card   { grid-area: today; }
-  .eqv2-session-card { grid-area: session; }
-  .eqv2-short-card   { grid-area: short; }
-  .eqv2-volume-card  { grid-area: volume; }
-  .eqv2-prev-card    { grid-area: prev; }
+  .eqv2-col-1 { flex: 1; }
+  .eqv2-col-2 { display: flex; flex: 1; }
+  .eqv2-prev-row { flex-basis: 100%; }
+
+  /* Hide narrow-only duplicates */
+  .eqv2-narrow-only { display: none !important; }
 }
 
-/* ── FULL mode: 3-column grid ── */
-@container (min-width: 680px) {
-  .eqv2-sections {
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-template-areas:
-      "company today   short"
-      "company session volume"
-      "prev    prev    prev";
-  }
+/* ── FULL mode (680px+): three columns — col-2 splits into today+short / company ── */
+/* Note: with two columns, company is already in col-2. At full width col-2 is wide */
+/* enough that it doesn't need a third column split — keep 2-col but allow more room */
+@container (min-width: 680px) {   /* BREAKPOINTS.FULL */
   .eqv2-symbol { font-size: 22px; }
   .eqv2-price  { font-size: 30px; }
 }

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="eqv2-widget">
+  <div class="eqv2-widget" ref="widgetEl">
     <!-- Ticker input bar — always visible -->
     <div class="eqv2-controls">
       <input
@@ -127,8 +127,9 @@
             </div>
           </div>
 
-          <!-- Narrow-only: Short Interest (in col-1 when single column) -->
-          <div class="eqv2-card eqv2-short-card eqv2-narrow-only">
+          <!-- Short Interest + Company: only rendered here in narrow mode (isNarrow=true).
+               At wide/full, col-2 renders them. One instance at a time — no DOM duplication. -->
+          <div v-if="isNarrow" class="eqv2-card eqv2-short-card">
             <div class="eqv2-card-label">Short Interest</div>
             <div v-if="shortInterestLoading" class="eqv2-muted-msg">Short interest data loading...</div>
             <div v-else-if="allShortNull" class="eqv2-muted-msg">Short interest data unavailable</div>
@@ -139,8 +140,7 @@
             </div>
           </div>
 
-          <!-- Narrow-only: Company card -->
-          <div class="eqv2-card eqv2-company-card eqv2-narrow-only">
+          <div v-if="isNarrow" class="eqv2-card eqv2-company-card">
             <div class="eqv2-card-label">Company</div>
             <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
             <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
@@ -169,8 +169,9 @@
           </div>
         </div>
 
-        <!-- Col 2: Short Interest + Company (wide/full mode) -->
-        <div class="eqv2-col eqv2-col-2">
+        <!-- Col 2: Short Interest + Company — only rendered at wide/full (v-if="!isNarrow").
+             Paired with isNarrow v-if above to ensure exactly one instance in DOM. -->
+        <div v-if="!isNarrow" class="eqv2-col eqv2-col-2">
           <!-- Short Interest -->
           <div class="eqv2-card eqv2-short-card">
             <div class="eqv2-card-label">Short Interest</div>
@@ -248,9 +249,13 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useWidgetBus, getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+
+// Shared breakpoint constants — must match CSS @container thresholds exactly.
+// Referenced by ResizeObserver (JS) and CSS comments below.
+const BREAKPOINTS = { WIDE: 480, FULL: 680 }
 
 const props = defineProps({
   isLocked:  { type: Boolean, default: true },
@@ -263,6 +268,26 @@ defineEmits(['update-settings'])
 
 const appConfig = window.__APP_CONFIG__ || {}
 const { activeTickers, setActiveTicker } = useWidgetBus()
+
+// ── Layout mode (driven by ResizeObserver — single source of truth for breakpoints) ──
+const widgetEl = ref(null)   // template ref on .eqv2-widget root
+const layoutMode = ref('narrow')  // 'narrow' | 'wide' | 'full'
+const isNarrow = computed(() => layoutMode.value === 'narrow')
+
+let _resizeObserver = null
+onMounted(() => {
+  if (!widgetEl.value) return
+  _resizeObserver = new ResizeObserver((entries) => {
+    const width = entries[0]?.contentRect.width ?? 0
+    if (width >= BREAKPOINTS.FULL) layoutMode.value = 'full'
+    else if (width >= BREAKPOINTS.WIDE) layoutMode.value = 'wide'
+    else layoutMode.value = 'narrow'
+  })
+  _resizeObserver.observe(widgetEl.value)
+})
+onBeforeUnmount(() => {
+  _resizeObserver?.disconnect()
+})
 
 // ── Flame freshness icon ──────────────────────────────────────────────────────
 const FLAME_SRCS = {
@@ -507,7 +532,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, logoError })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, logoError, layoutMode })
 </script>
 
 <style scoped>
@@ -934,11 +959,8 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 /* Previous Day always full width */
 .eqv2-prev-row { width: 100%; }
 
-/* In narrow mode, show Short + Company inside col-1 via .eqv2-narrow-only */
-/* At wide+, hide .eqv2-narrow-only; col-2 takes over */
-.eqv2-narrow-only { display: flex; flex-direction: column; }
-
 /* ── WIDE mode (480px+): two flex columns ── */
+/* BREAKPOINTS.WIDE = 480 — must match JS BREAKPOINTS.WIDE */
 @container (min-width: 480px) {   /* BREAKPOINTS.WIDE */
   .eqv2-symbol { font-size: 20px; }
   .eqv2-price  { font-size: 26px; }
@@ -956,8 +978,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   .eqv2-col-2 { display: flex; flex: 1; }
   .eqv2-prev-row { flex-basis: 100%; }
 
-  /* Hide narrow-only duplicates */
-  .eqv2-narrow-only { display: none !important; }
+  /* Col-2 shown via v-if="!isNarrow" — no CSS hide needed */
 }
 
 /* ── FULL mode (680px+): three columns — col-2 splits into today+short / company ── */

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 
+// Stub ResizeObserver — jsdom does not implement it.
+// layoutMode defaults to 'narrow' (initial ref value) and tests can
+// set wrapper.vm.layoutMode directly to test wide/full layout paths.
+global.ResizeObserver = class ResizeObserver {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 // Mock WebSocket globally
 class MockWebSocket {
   constructor() {
@@ -717,6 +727,51 @@ describe('EnhancedQuoteV2', () => {
       // Assert: chip class present, old mini class absent
       expect(wrapper.find('.eqv2-session-chip').exists()).toBe(true)
       expect(wrapper.find('.eqv2-session-mini').exists()).toBe(false)
+    })
+  })
+
+  describe('Layout mode — isNarrow / ResizeObserver integration', () => {
+    it('defaults to narrow layout mode (single column)', async () => {
+      // Arrange / Act
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await wrapper.vm.$nextTick()
+
+      // Assert: col-2 not rendered in narrow mode
+      expect(wrapper.vm.layoutMode).toBe('narrow')
+      expect(wrapper.find('.eqv2-col-2').exists()).toBe(false)
+    })
+
+    it('renders col-2 with company card when layoutMode is wide', async () => {
+      // Arrange
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await wrapper.vm.$nextTick()
+
+      // Act: simulate ResizeObserver firing at wide width
+      wrapper.vm.layoutMode = 'wide'
+      await wrapper.vm.$nextTick()
+
+      // Assert: col-2 rendered, exactly one company card in DOM
+      expect(wrapper.find('.eqv2-col-2').exists()).toBe(true)
+      expect(wrapper.findAll('.eqv2-company-card').length).toBe(1)
+      expect(wrapper.findAll('.eqv2-short-card').length).toBe(1)
+    })
+
+    it('exactly one company card in DOM at narrow layout mode', async () => {
+      // Arrange / Act
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await wrapper.vm.$nextTick()
+
+      // Assert: only the narrow-mode instance present
+      expect(wrapper.findAll('.eqv2-company-card').length).toBe(1)
     })
   })
 

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -276,9 +276,9 @@ describe('EnhancedQuoteV2', () => {
       after_hours_low: null,
     }
     await wrapper.vm.$nextTick()
-    const sessionMinis = wrapper.findAll('.eqv2-session-mini')
-    expect(sessionMinis[0].text()).toContain('—') // PRE
-    expect(sessionMinis[2].text()).toContain('—') // AH
+    const sessionChips = wrapper.findAll('.eqv2-session-chip')
+    expect(sessionChips[0].text()).toContain('—') // PRE
+    expect(sessionChips[2].text()).toContain('—') // AH
   })
 
   it('exposes required interface (lastDataAt, isConnected, etc.)', () => {
@@ -456,9 +456,9 @@ describe('EnhancedQuoteV2', () => {
       expect(hero.text()).toContain('Motor Vehicles')
     })
 
-    it('renders logo in hero when logo_url is present', async () => {
+    it('renders logo in hero via proxy src when activeTicker is set', async () => {
       // Arrange
-      mockCompanyFetch({ name: 'Apple Inc.', sic_description: 'Computers', logo_url: 'https://example.com/logo.png' })
+      mockCompanyFetch({ name: 'Apple Inc.', sic_description: 'Computers' })
       const wrapper = mountWidget()
       wrapper.vm.manualTicker = 'AAPL'
       await wrapper.vm.$nextTick()
@@ -466,25 +466,46 @@ describe('EnhancedQuoteV2', () => {
       await new Promise(r => setTimeout(r, 0))
       await wrapper.vm.$nextTick()
 
-      // Assert
+      // Assert: proxy src used (not companyData.logo_url)
       const logo = wrapper.find('.eqv2-hero-logo')
       expect(logo.exists()).toBe(true)
-      expect(logo.attributes('src')).toBe('https://example.com/logo.png')
+      expect(logo.attributes('src')).toBe('/api/market_data/logo/AAPL')
     })
 
-    it('hero renders correctly when logo_url is null — no broken img element', async () => {
+    it('hides logo when logoError is true', async () => {
       // Arrange
-      mockCompanyFetch({ name: 'No Logo Corp', sic_description: 'Services', logo_url: null })
+      mockCompanyFetch({ name: 'Apple Inc.', sic_description: 'Computers' })
       const wrapper = mountWidget()
-      wrapper.vm.manualTicker = 'NOLG'
+      wrapper.vm.manualTicker = 'AAPL'
       await wrapper.vm.$nextTick()
       wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
       await new Promise(r => setTimeout(r, 0))
       await wrapper.vm.$nextTick()
 
-      // Assert: no img rendered (v-if guard), but name still shows
+      // Simulate @error handler firing
+      wrapper.vm.logoError = true
+      await wrapper.vm.$nextTick()
+
+      // Assert: img no longer visible
       expect(wrapper.find('.eqv2-hero-logo').exists()).toBe(false)
-      expect(wrapper.find('.eqv2-hero').text()).toContain('No Logo Corp')
+    })
+
+    it('resets logoError to false when ticker changes', async () => {
+      // Arrange: set logoError, then change ticker
+      mockCompanyFetch({ name: 'Apple Inc.' })
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'AAPL'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      wrapper.vm.logoError = true
+      await wrapper.vm.$nextTick()
+
+      // Act: change ticker
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+
+      // Assert: logoError reset
+      expect(wrapper.vm.logoError).toBe(false)
     })
   })
 
@@ -592,6 +613,125 @@ describe('EnhancedQuoteV2', () => {
 
       // Assert: expanded state cleared — no see-more button since new company has no desc
       expect(wrapper.find('.eqv2-company-desc-wrap').exists()).toBe(false)
+    })
+  })
+
+  describe('Since open', () => {
+    async function mountWithQuote(quoteOverrides) {
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE, ...quoteOverrides }
+      await wrapper.vm.$nextTick()
+      return wrapper
+    }
+
+    it('renders "since open" label (not "Open:")', async () => {
+      // Arrange / Act
+      const wrapper = await mountWithQuote({})
+
+      // Assert
+      expect(wrapper.find('.eqv2-since-open').text()).toContain('since open')
+      expect(wrapper.find('.eqv2-since-open').text()).not.toContain('Open:')
+    })
+
+    it('renders dollar delta from change_since_open when present', async () => {
+      // Arrange / Act
+      const wrapper = await mountWithQuote({ pct_change_since_open: 1.5, change_since_open: 3.75 })
+
+      // Assert: dollar amount shown in parens with sign and $
+      const text = wrapper.find('.eqv2-since-open').text()
+      expect(text).toContain('$3.75')
+      expect(text).toContain('+')
+    })
+
+    it('renders negative dollar delta correctly', async () => {
+      // Arrange / Act
+      const wrapper = await mountWithQuote({ pct_change_since_open: -1.5, change_since_open: -3.75 })
+
+      // Assert
+      const text = wrapper.find('.eqv2-since-open').text()
+      expect(text).toContain('$3.75')  // absolute value displayed
+      expect(text).toContain('-')
+    })
+
+    it('omits dollar delta when change_since_open is null', async () => {
+      // Arrange / Act
+      const wrapper = await mountWithQuote({ pct_change_since_open: 1.5, change_since_open: null })
+
+      // Assert: pct shown, no dollar amount
+      const text = wrapper.find('.eqv2-since-open').text()
+      expect(text).toContain('1.50%')
+      expect(text).not.toContain('$')
+    })
+  })
+
+  describe('Session H/L chip style', () => {
+    async function mountWithSessionData(sessionOverrides) {
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE, ...sessionOverrides }
+      await wrapper.vm.$nextTick()
+      return wrapper
+    }
+
+    it('renders PRE, REG, AH chips in session card', async () => {
+      // Arrange / Act
+      const wrapper = await mountWithSessionData({})
+
+      // Assert
+      const chips = wrapper.findAll('.eqv2-session-chip')
+      expect(chips.length).toBe(3)
+      const labels = chips.map(c => c.find('.eqv2-chip-label').text())
+      expect(labels).toContain('PRE')
+      expect(labels).toContain('REG')
+      expect(labels).toContain('AH')
+    })
+
+    it('renders H and L values inside each session chip', async () => {
+      // Arrange / Act
+      const wrapper = await mountWithSessionData({})
+
+      // Assert: PRE chip (index 0) shows H and L values from SAMPLE_QUOTE
+      const preChip = wrapper.findAll('.eqv2-session-chip')[0]
+      expect(preChip.text()).toContain('252.00')  // pre_market_high
+      expect(preChip.text()).toContain('248.00')  // pre_market_low
+    })
+
+    it('shows dash in session chip when values are null', async () => {
+      // Arrange / Act
+      const wrapper = await mountWithSessionData({
+        pre_market_high: null,
+        pre_market_low: null,
+      })
+
+      // Assert: PRE chip shows dash
+      expect(wrapper.findAll('.eqv2-session-chip')[0].text()).toContain('—')
+    })
+
+    it('session card uses .eqv2-session-chip markup (chip style, not mini-row)', async () => {
+      // Arrange / Act
+      const wrapper = await mountWithSessionData({})
+
+      // Assert: chip class present, old mini class absent
+      expect(wrapper.find('.eqv2-session-chip').exists()).toBe(true)
+      expect(wrapper.find('.eqv2-session-mini').exists()).toBe(false)
+    })
+  })
+
+  describe('Previous Day card always rendered', () => {
+    it('Previous Day card is always present regardless of other data', async () => {
+      // Arrange / Act
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await wrapper.vm.$nextTick()
+
+      // Assert
+      expect(wrapper.find('.eqv2-prev-card').exists()).toBe(true)
+      expect(wrapper.find('.eqv2-prev-row').exists()).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes bugs 2–5 from prod feedback round 1 and implements the card arrangement redesign.

## Changes

### Bug 2 — Since open label + dollar delta
- Label corrected from `Open:` to `since open`
- Dollar delta now uses `change_since_open` from WDS payload (not recomputed client-side — avoids divergence from scanner widgets during pre/post-market)
- Omitted when `change_since_open` is null

### Bug 3 — Session H/L chip style at all widths
- Replaced `.eqv2-session-mini` list markup with `.eqv2-session-chip` chips matching Previous Day strip visual style
- `flex-direction: column` at narrow, `row` at 480px+
- PRE/REG/AH labels with stacked H/L values inside each chip

### Bugs 4 & 5 — Column gaps eliminated
- Replaced `grid-template-areas` layout with independent flex columns (`.eqv2-col-1`, `.eqv2-col-2`)
- Cards pack to natural height per column — no cross-column row synchronization, no gaps
- `.eqv2-narrow-only` pattern: Short + Company duplicated for narrow single-column view, hidden at 480px+ where col-2 takes over

### Logo proxy src
- `<img>` src now uses `/api/market_data/logo/${activeTicker}` (proxy endpoint from PR #142)
- `logoError` ref + `@error` handler hides broken images
- `logoError` resets to `false` on ticker change

### Card arrangement
- Narrow: Session H/L → Today → Volume → Short Interest → Company → Previous Day
- Wide (480px+): Col 1: Session H/L, Today, Volume | Col 2: Short Interest, Company | Previous Day full-width
- Full (680px+): same 2-col layout with more horizontal space (PR C adds 3rd column option via draggable)

## Tests

99/99 passing (86 existing + 13 new)

New test coverage:
- Logo proxy src assertion, logoError hide/reset
- Since-open label, dollar delta positive/negative, null omission
- Session H/L chip labels, H/L values, null dash, markup class check
- Previous Day card always present

refs #133