### PR TITLE
feat(eqv2): three-column layout at full width + hero logo/identity restructure

### DIFF
--- a/client/src/components/widgets/EQV2CompanyCard.vue
+++ b/client/src/components/widgets/EQV2CompanyCard.vue
@@ -1,0 +1,57 @@
+<template>
+  <div v-if="loading" class="eqv2-muted-msg">Company data loading...</div>
+  <div v-else-if="allNull" class="eqv2-muted-msg">Company data unavailable</div>
+  <div v-else>
+    <div class="eqv2-kv-list">
+      <div v-if="data.homepage_url" class="eqv2-kv">
+        <span class="eqv2-k">Web</span>
+        <a :href="data.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(data.homepage_url) }}</a>
+      </div>
+      <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ data.primary_exchange || '—' }}</span></div>
+      <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ data.market_cap != null ? '$' + fmtVol(data.market_cap) : '—' }}</span></div>
+      <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ data.total_employees != null ? fmtVol(data.total_employees) : '—' }}</span></div>
+      <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ data.list_date || '—' }}</span></div>
+    </div>
+    <div v-if="data.description" class="eqv2-company-desc-wrap">
+      <span class="eqv2-company-desc-text">
+        {{ expanded ? data.description : truncateDesc(data.description) }}
+      </span>
+      <span v-if="!expanded && truncateDesc(data.description) !== data.description">
+        <span class="eqv2-company-desc-ellipsis">… </span>
+        <button class="eqv2-see-more" @click="$emit('expand')">see more</button>
+      </span>
+      <button v-if="expanded" class="eqv2-see-more" @click="$emit('collapse')"> less</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  loading: { type: Boolean, default: false },
+  allNull: { type: Boolean, default: false },
+  data: { type: Object, default: () => ({}) },
+  expanded: { type: Boolean, default: false },
+})
+
+defineEmits(['expand', 'collapse'])
+
+const truncateUrl = (url) => {
+  if (!url) return ''
+  return url.replace(/^https?:\/\//, '').replace(/\/$/, '').slice(0, 30)
+}
+
+const truncateDesc = (text, maxLen = 175) => {
+  if (!text || text.length <= maxLen) return text
+  const cut = text.lastIndexOf(' ', maxLen)
+  return cut > 0 ? text.slice(0, cut) : text.slice(0, maxLen)
+}
+
+const fmtVol = (n) => {
+  if (n == null || isNaN(n)) return '—'
+  if (Math.abs(n) >= 1e12) return (n / 1e12).toFixed(2) + 'T'
+  if (Math.abs(n) >= 1e9)  return (n / 1e9).toFixed(2) + 'B'
+  if (Math.abs(n) >= 1e6)  return (n / 1e6).toFixed(2) + 'M'
+  if (Math.abs(n) >= 1e3)  return (n / 1e3).toFixed(1) + 'K'
+  return String(n)
+}
+</script>

--- a/client/src/components/widgets/EQV2CompanyCard.vue
+++ b/client/src/components/widgets/EQV2CompanyCard.vue
@@ -1,4 +1,5 @@
 <template>
+  <div class="eqv2-company-card-body">
   <div v-if="loading" class="eqv2-muted-msg">Company data loading...</div>
   <div v-else-if="allNull" class="eqv2-muted-msg">Company data unavailable</div>
   <div v-else>
@@ -18,40 +19,25 @@
       </span>
       <span v-if="!expanded && truncateDesc(data.description) !== data.description">
         <span class="eqv2-company-desc-ellipsis">… </span>
-        <button class="eqv2-see-more" @click="$emit('expand')">see more</button>
+        <button class="eqv2-see-more" @click="onExpand">see more</button>
       </span>
-      <button v-if="expanded" class="eqv2-see-more" @click="$emit('collapse')"> less</button>
+      <button v-if="expanded" class="eqv2-see-more" @click="onCollapse"> less</button>
     </div>
+  </div>
   </div>
 </template>
 
 <script setup>
-const props = defineProps({
+import { truncateUrl, truncateDesc, fmtVol } from './eqv2Utils.js'
+
+defineProps({
   loading: { type: Boolean, default: false },
   allNull: { type: Boolean, default: false },
   data: { type: Object, default: () => ({}) },
   expanded: { type: Boolean, default: false },
 })
 
-defineEmits(['expand', 'collapse'])
-
-const truncateUrl = (url) => {
-  if (!url) return ''
-  return url.replace(/^https?:\/\//, '').replace(/\/$/, '').slice(0, 30)
-}
-
-const truncateDesc = (text, maxLen = 175) => {
-  if (!text || text.length <= maxLen) return text
-  const cut = text.lastIndexOf(' ', maxLen)
-  return cut > 0 ? text.slice(0, cut) : text.slice(0, maxLen)
-}
-
-const fmtVol = (n) => {
-  if (n == null || isNaN(n)) return '—'
-  if (Math.abs(n) >= 1e12) return (n / 1e12).toFixed(2) + 'T'
-  if (Math.abs(n) >= 1e9)  return (n / 1e9).toFixed(2) + 'B'
-  if (Math.abs(n) >= 1e6)  return (n / 1e6).toFixed(2) + 'M'
-  if (Math.abs(n) >= 1e3)  return (n / 1e3).toFixed(1) + 'K'
-  return String(n)
-}
+const emit = defineEmits(['expand', 'collapse'])
+const onExpand = () => emit('expand')
+const onCollapse = () => emit('collapse')
 </script>

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -328,6 +328,7 @@ import draggable from 'vuedraggable'
 import { useWidgetBus, getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import EQV2CompanyCard from './EQV2CompanyCard.vue'
+import { truncateUrl, truncateDesc, fmtVol } from './eqv2Utils.js'
 
 // Shared breakpoint constants — must match CSS @container thresholds exactly.
 // Referenced by ResizeObserver (JS) and CSS comments below.
@@ -611,14 +612,7 @@ const fmt = (val, decimals = 2) => {
   return isFinite(n) ? n.toFixed(decimals) : '—'
 }
 
-const fmtVol = (val) => {
-  const v = parseFloat(val)
-  if (!isFinite(v)) return '—'
-  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`
-  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`
-  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}K`
-  return v.toString()
-}
+// fmtVol, truncateUrl, truncateDesc — imported from eqv2Utils.js
 
 const changeClass = computed(() => {
   if (!quoteData.value) return ''
@@ -661,17 +655,6 @@ const allCompanyNull = computed(() => {
          d.list_date == null &&
          d.homepage_url == null
 })
-
-const truncateUrl = (url) => {
-  if (!url) return ''
-  return url.replace(/^https?:\/\//, '').replace(/\/$/, '').slice(0, 30)
-}
-
-const truncateDesc = (text, maxLen = 175) => {
-  if (!text || text.length <= maxLen) return text
-  const cut = text.lastIndexOf(' ', maxLen)
-  return cut > 0 ? text.slice(0, cut) : text.slice(0, maxLen)
-}
 
 // Relative volume bar
 const rvBarWidth = computed(() => {

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -39,12 +39,14 @@
               :alt="companyData.name || activeTicker"
               @error="logoError = true"
             />
-            <span class="eqv2-symbol">{{ quoteData.symbol }}</span>
-            <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv2-flame-icon" />
-          </div>
-          <div v-if="companyData.name || companyData.sic_description" class="eqv2-hero-company">
-            <span v-if="companyData.name" class="eqv2-hero-company-name">{{ companyData.name }}</span>
-            <span v-if="companyData.sic_description" class="eqv2-hero-sic">{{ companyData.sic_description }}</span>
+            <div class="eqv2-hero-identity-text">
+              <div class="eqv2-hero-symbol-row">
+                <span class="eqv2-symbol">{{ quoteData.symbol }}</span>
+                <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv2-flame-icon" />
+              </div>
+              <span v-if="companyData.name" class="eqv2-hero-company-name">{{ companyData.name }}</span>
+              <span v-if="companyData.sic_description" class="eqv2-hero-sic">{{ companyData.sic_description }}</span>
+            </div>
           </div>
         </div>
         <div class="eqv2-hero-right">
@@ -184,7 +186,7 @@
           </draggable>
         </div>
 
-        <!-- Col 2: second half of cards at wide/full (v-if="!isNarrow") -->
+        <!-- Col 2: second half of cards at wide/full; at full excludes company (v-if="!isNarrow") -->
         <div v-if="!isNarrow" class="eqv2-col eqv2-col-2">
           <draggable
             :model-value="col2Cards"
@@ -196,7 +198,7 @@
             @end="onDragEnd()"
             @update:model-value="(val) => onColReorder(val, 2)"
           >
-            <template #item="{ element: card }">
+            <template #item="{ element: card }" :key="card.id">
               <div :class="['eqv2-card', `eqv2-${card.id}-card`]">
                 <div class="eqv2-card-label">
                   <span v-if="!isLocked" class="eqv2-drag-handle" title="Drag to reorder">⠿</span>
@@ -281,6 +283,55 @@
                   </div>
                 </template>
 
+              </div>
+            </template>
+          </draggable>
+        </div>
+
+        <!-- Col 3: company card only at full width (≥680px) -->
+        <div v-if="layoutMode === 'full'" class="eqv2-col eqv2-col-3">
+          <draggable
+            :model-value="col3Cards"
+            group="eqv2-cards"
+            item-key="id"
+            :disabled="isLocked"
+            handle=".eqv2-drag-handle"
+            @start="isDragging = true"
+            @end="onDragEnd()"
+            @update:model-value="(val) => onColReorder(val, 3)"
+          >
+            <template #item="{ element: card }">
+              <div :class="['eqv2-card', `eqv2-${card.id}-card`]">
+                <div class="eqv2-card-label">
+                  <span v-if="!isLocked" class="eqv2-drag-handle" title="Drag to reorder">⠿</span>
+                  {{ card.label }}
+                </div>
+                <template v-if="card.id === 'company'">
+                  <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
+                  <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
+                  <div v-else>
+                    <div class="eqv2-kv-list">
+                      <div v-if="companyData.homepage_url" class="eqv2-kv">
+                        <span class="eqv2-k">Web</span>
+                        <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
+                      </div>
+                      <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
+                      <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
+                      <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
+                      <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
+                    </div>
+                    <div v-if="companyData.description" class="eqv2-company-desc-wrap">
+                      <span class="eqv2-company-desc-text">
+                        {{ descExpanded ? companyData.description : truncateDesc(companyData.description) }}
+                      </span>
+                      <span v-if="!descExpanded && truncateDesc(companyData.description) !== companyData.description">
+                        <span class="eqv2-company-desc-ellipsis">… </span>
+                        <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
+                      </span>
+                      <button v-if="descExpanded" class="eqv2-see-more" @click="descExpanded = false"> less</button>
+                    </div>
+                  </div>
+                </template>
               </div>
             </template>
           </draggable>
@@ -374,26 +425,38 @@ const activeCards = computed(() => {
 
 // Distribute activeCards across columns based on layout mode.
 // Previous Day is excluded — it's always pinned outside the draggable lists.
+// FULL (>=680px): col1=session+volume, col2=today+short, col3=company
+// WIDE (480-679px): col1=first half, col2=second half (including company)
+// NARROW (<480px): col1=all cards
 const col1Cards = computed(() => {
   const cards = activeCards.value
   if (isNarrow.value) return cards  // all in one column
+  if (layoutMode.value === 'full') return cards.filter(c => c.id !== 'today' && c.id !== 'short' && c.id !== 'company')
   return cards.slice(0, Math.ceil(cards.length / 2))
 })
 
 const col2Cards = computed(() => {
   if (isNarrow.value) return []  // col-2 hidden in narrow
   const cards = activeCards.value
+  if (layoutMode.value === 'full') return cards.filter(c => c.id === 'today' || c.id === 'short')
   return cards.slice(Math.ceil(cards.length / 2))
+})
+
+const col3Cards = computed(() => {
+  if (layoutMode.value !== 'full') return []  // col-3 only at full width
+  return activeCards.value.filter(c => c.id === 'company')
 })
 
 // Mutable column state — holds reordered cards within a drag session
 // vuedraggable emits @update:model-value with the new order for the affected column
 const _col1 = ref(null)  // overrides col1Cards during/after drag
 const _col2 = ref(null)  // overrides col2Cards during/after drag
+const _col3 = ref(null)  // overrides col3Cards during/after drag
 
 const onColReorder = (newVal, colNum) => {
   if (colNum === 1) _col1.value = newVal
-  else _col2.value = newVal
+  else if (colNum === 2) _col2.value = newVal
+  else _col3.value = newVal
 }
 
 const onDragEnd = async () => {
@@ -405,12 +468,14 @@ const onDragEnd = async () => {
   await nextTick()
   const c1 = _col1.value ?? col1Cards.value
   const c2 = _col2.value ?? col2Cards.value
+  const c3 = _col3.value ?? col3Cards.value
   const newOrder = isNarrow.value
     ? c1.map(c => c.id)
-    : [...c1, ...c2].map(c => c.id)
+    : [...c1, ...c2, ...c3].map(c => c.id)
   // Clear overrides — activeCards computed will now drive from settings
   _col1.value = null
   _col2.value = null
+  _col3.value = null
   emit('update-settings', { ...props.settings, cardOrder: newOrder })
 }
 
@@ -672,7 +737,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, logoError, layoutMode, activeCards, isDragging, onColReorder, onDragEnd })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, logoError, layoutMode, activeCards, col3Cards, isDragging, onColReorder, onDragEnd })
 </script>
 
 <style scoped>
@@ -795,11 +860,18 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   align-self: stretch;
 }
 
-.eqv2-hero-company {
+.eqv2-hero-identity-text {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  min-width: 0;
   overflow: hidden;
+}
+
+.eqv2-hero-symbol-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .eqv2-hero-company-name {
@@ -1126,8 +1198,8 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   gap: 8px;
 }
 
-/* Col-2 hidden at narrow; shown at WIDE+ */
-.eqv2-col-2 { display: none; }
+/* Col-2 and col-3 hidden at narrow */
+.eqv2-col-2, .eqv2-col-3 { display: none; }
 
 /* Previous Day always full width */
 .eqv2-prev-row { width: 100%; }
@@ -1151,11 +1223,11 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   /* Col-2 shown via v-if="!isNarrow" — no CSS hide needed */
 }
 
-/* ── FULL mode (680px+): three columns — col-2 splits into today+short / company ── */
-/* Note: with two columns, company is already in col-2. At full width col-2 is wide */
-/* enough that it doesn't need a third column split — keep 2-col but allow more room */
+/* ── FULL mode (680px+): three columns — col1=session+volume, col2=today+short, col3=company ── */
+/* BREAKPOINTS.FULL = 680 — must match JS BREAKPOINTS.FULL */
 @container (min-width: 680px) {   /* BREAKPOINTS.FULL */
   .eqv2-symbol { font-size: 22px; }
   .eqv2-price  { font-size: 30px; }
+  .eqv2-col-3  { display: flex; flex: 1; }
 }
 </style>

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -82,7 +82,7 @@
             @update:model-value="(val) => onColReorder(val, 1)"
           >
             <template #item="{ element: card }">
-              <div :class="['eqv2-card', `eqv2-${card.id}-card`]">
+              <div :key="card.id" :class="['eqv2-card', `eqv2-${card.id}-card`]">
                 <div class="eqv2-card-label">
                   <span v-if="!isLocked" class="eqv2-drag-handle" title="Drag to reorder">⠿</span>
                   {{ card.label }}
@@ -155,30 +155,14 @@
 
                 <!-- Company -->
                 <template v-else-if="card.id === 'company'">
-                  <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
-                  <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
-                  <div v-else>
-                    <div class="eqv2-kv-list">
-                      <div v-if="companyData.homepage_url" class="eqv2-kv">
-                        <span class="eqv2-k">Web</span>
-                        <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
-                      </div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
-                    </div>
-                    <div v-if="companyData.description" class="eqv2-company-desc-wrap">
-                      <span class="eqv2-company-desc-text">
-                        {{ descExpanded ? companyData.description : truncateDesc(companyData.description) }}
-                      </span>
-                      <span v-if="!descExpanded && truncateDesc(companyData.description) !== companyData.description">
-                        <span class="eqv2-company-desc-ellipsis">… </span>
-                        <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
-                      </span>
-                      <button v-if="descExpanded" class="eqv2-see-more" @click="descExpanded = false"> less</button>
-                    </div>
-                  </div>
+                  <EQV2CompanyCard
+                    :loading="companyLoading"
+                    :all-null="allCompanyNull"
+                    :data="companyData"
+                    :expanded="descExpanded"
+                    @expand="descExpanded = true"
+                    @collapse="descExpanded = false"
+                  />
                 </template>
 
               </div>
@@ -198,8 +182,8 @@
             @end="onDragEnd()"
             @update:model-value="(val) => onColReorder(val, 2)"
           >
-            <template #item="{ element: card }" :key="card.id">
-              <div :class="['eqv2-card', `eqv2-${card.id}-card`]">
+            <template #item="{ element: card }">
+              <div :key="card.id" :class="['eqv2-card', `eqv2-${card.id}-card`]">
                 <div class="eqv2-card-label">
                   <span v-if="!isLocked" class="eqv2-drag-handle" title="Drag to reorder">⠿</span>
                   {{ card.label }}
@@ -218,30 +202,14 @@
 
                 <!-- Company -->
                 <template v-else-if="card.id === 'company'">
-                  <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
-                  <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
-                  <div v-else>
-                    <div class="eqv2-kv-list">
-                      <div v-if="companyData.homepage_url" class="eqv2-kv">
-                        <span class="eqv2-k">Web</span>
-                        <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
-                      </div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
-                    </div>
-                    <div v-if="companyData.description" class="eqv2-company-desc-wrap">
-                      <span class="eqv2-company-desc-text">
-                        {{ descExpanded ? companyData.description : truncateDesc(companyData.description) }}
-                      </span>
-                      <span v-if="!descExpanded && truncateDesc(companyData.description) !== companyData.description">
-                        <span class="eqv2-company-desc-ellipsis">… </span>
-                        <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
-                      </span>
-                      <button v-if="descExpanded" class="eqv2-see-more" @click="descExpanded = false"> less</button>
-                    </div>
-                  </div>
+                  <EQV2CompanyCard
+                    :loading="companyLoading"
+                    :all-null="allCompanyNull"
+                    :data="companyData"
+                    :expanded="descExpanded"
+                    @expand="descExpanded = true"
+                    @collapse="descExpanded = false"
+                  />
                 </template>
 
                 <!-- Session / Today / Volume (if reordered into col-2) -->
@@ -301,37 +269,20 @@
             @update:model-value="(val) => onColReorder(val, 3)"
           >
             <template #item="{ element: card }">
-              <div :class="['eqv2-card', `eqv2-${card.id}-card`]">
+              <div :key="card.id" :class="['eqv2-card', `eqv2-${card.id}-card`]">
                 <div class="eqv2-card-label">
                   <span v-if="!isLocked" class="eqv2-drag-handle" title="Drag to reorder">⠿</span>
                   {{ card.label }}
                 </div>
-                <template v-if="card.id === 'company'">
-                  <div v-if="companyLoading" class="eqv2-muted-msg">Company data loading...</div>
-                  <div v-else-if="allCompanyNull" class="eqv2-muted-msg">Company data unavailable</div>
-                  <div v-else>
-                    <div class="eqv2-kv-list">
-                      <div v-if="companyData.homepage_url" class="eqv2-kv">
-                        <span class="eqv2-k">Web</span>
-                        <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv2-link">{{ truncateUrl(companyData.homepage_url) }}</a>
-                      </div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Exchange</span><span class="eqv2-v">{{ companyData.primary_exchange || '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Mkt Cap</span><span class="eqv2-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Employees</span><span class="eqv2-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
-                      <div class="eqv2-kv"><span class="eqv2-k">Listed</span><span class="eqv2-v">{{ companyData.list_date || '—' }}</span></div>
-                    </div>
-                    <div v-if="companyData.description" class="eqv2-company-desc-wrap">
-                      <span class="eqv2-company-desc-text">
-                        {{ descExpanded ? companyData.description : truncateDesc(companyData.description) }}
-                      </span>
-                      <span v-if="!descExpanded && truncateDesc(companyData.description) !== companyData.description">
-                        <span class="eqv2-company-desc-ellipsis">… </span>
-                        <button class="eqv2-see-more" @click="descExpanded = true">see more</button>
-                      </span>
-                      <button v-if="descExpanded" class="eqv2-see-more" @click="descExpanded = false"> less</button>
-                    </div>
-                  </div>
-                </template>
+                <!-- Col-3 only ever contains the company card -->
+                <EQV2CompanyCard
+                  :loading="companyLoading"
+                  :all-null="allCompanyNull"
+                  :data="companyData"
+                  :expanded="descExpanded"
+                  @expand="descExpanded = true"
+                  @collapse="descExpanded = false"
+                />
               </div>
             </template>
           </draggable>
@@ -376,6 +327,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import draggable from 'vuedraggable'
 import { useWidgetBus, getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import EQV2CompanyCard from './EQV2CompanyCard.vue'
 
 // Shared breakpoint constants — must match CSS @container thresholds exactly.
 // Referenced by ResizeObserver (JS) and CSS comments below.

--- a/client/src/components/widgets/__tests__/EQV2CompanyCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV2CompanyCard.spec.js
@@ -73,13 +73,12 @@ describe('EQV2CompanyCard', () => {
       expect(wrapper.text()).not.toContain('Web')
     })
 
-    it('formats market cap with fmtVol (B suffix for billions)', () => {
+    it('formats market cap with fmtVol (3.2T input → 3200.0B)', () => {
       // Arrange / Act
       const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: false, data: SAMPLE_DATA, expanded: false } })
 
-      // Assert: 3.2T market cap → "3200.0B" ... actually >= 1e12 would be T if supported
-      // fmtVol only goes to B — 3.2T = 3200.0B
-      expect(wrapper.text()).toContain('B')
+      // Assert: fmtVol has no T suffix — 3.2T (3_200_000_000_000) → 3200.0B
+      expect(wrapper.text()).toContain('3200.0B')
     })
   })
 
@@ -118,6 +117,9 @@ describe('EQV2CompanyCard', () => {
   })
 
   describe('Expand/collapse events', () => {
+    // Note: wrapper.emitted() does not capture Vue emissions from <script setup>
+    // components in VTU 2.4.x / jsdom. The attrs listener pattern is intentional —
+    // same approach used in EnhancedQuoteV2.spec.js for update-settings.
     it('emits expand when see-more button is clicked', async () => {
       // Arrange
       const expandCalls = []

--- a/client/src/components/widgets/__tests__/EQV2CompanyCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV2CompanyCard.spec.js
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EQV2CompanyCard from '../EQV2CompanyCard.vue'
+
+// Sample company data for tests
+const SAMPLE_DATA = {
+  homepage_url: 'https://www.apple.com/',
+  primary_exchange: 'NASDAQ',
+  market_cap: 3_200_000_000_000,
+  total_employees: 161_000,
+  list_date: '1980-12-12',
+  description: 'Apple Inc. designs, manufactures, and markets smartphones and personal computers.',
+}
+
+// Description that exceeds the 175-char truncation limit
+const LONG_DESC = 'Apple Inc. designs, manufactures, and markets smartphones, personal computers, tablets, wearables, and accessories. The Company sells a variety of related services. Products include iPhone, Mac, iPad, and accessories.'
+
+describe('EQV2CompanyCard', () => {
+  describe('Loading state', () => {
+    it('renders loading message when loading=true', () => {
+      // Arrange / Act
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: true, allNull: false, data: {}, expanded: false } })
+
+      // Assert
+      expect(wrapper.find('.eqv2-muted-msg').text()).toContain('loading')
+      expect(wrapper.find('.eqv2-kv-list').exists()).toBe(false)
+    })
+  })
+
+  describe('Unavailable state', () => {
+    it('renders unavailable message when allNull=true and loading=false', () => {
+      // Arrange / Act
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: true, data: {}, expanded: false } })
+
+      // Assert
+      expect(wrapper.find('.eqv2-muted-msg').text()).toContain('unavailable')
+      expect(wrapper.find('.eqv2-kv-list').exists()).toBe(false)
+    })
+  })
+
+  describe('Data rendering', () => {
+    it('renders exchange, mkt cap, employees, listed kv rows', () => {
+      // Arrange / Act
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: false, data: SAMPLE_DATA, expanded: false } })
+
+      // Assert
+      const text = wrapper.text()
+      expect(text).toContain('NASDAQ')
+      expect(text).toContain('Exchange')
+      expect(text).toContain('Mkt Cap')
+      expect(text).toContain('Employees')
+      expect(text).toContain('Listed')
+      expect(text).toContain('1980-12-12')
+    })
+
+    it('renders homepage_url as a web link when present', () => {
+      // Arrange / Act
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: false, data: SAMPLE_DATA, expanded: false } })
+
+      // Assert
+      const link = wrapper.find('.eqv2-link')
+      expect(link.exists()).toBe(true)
+      expect(link.attributes('href')).toBe('https://www.apple.com/')
+    })
+
+    it('does not render web row when homepage_url is absent', () => {
+      // Arrange
+      const dataNoUrl = { ...SAMPLE_DATA, homepage_url: null }
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: false, data: dataNoUrl, expanded: false } })
+
+      // Assert
+      expect(wrapper.find('.eqv2-link').exists()).toBe(false)
+      expect(wrapper.text()).not.toContain('Web')
+    })
+
+    it('formats market cap with fmtVol (B suffix for billions)', () => {
+      // Arrange / Act
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: false, data: SAMPLE_DATA, expanded: false } })
+
+      // Assert: 3.2T market cap → "3200.0B" ... actually >= 1e12 would be T if supported
+      // fmtVol only goes to B — 3.2T = 3200.0B
+      expect(wrapper.text()).toContain('B')
+    })
+  })
+
+  describe('Description truncation', () => {
+    it('renders full short description without see-more button', () => {
+      // Arrange
+      const shortData = { ...SAMPLE_DATA, description: 'Short description.' }
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: false, data: shortData, expanded: false } })
+
+      // Assert
+      expect(wrapper.find('.eqv2-company-desc-text').text()).toContain('Short description.')
+      expect(wrapper.find('.eqv2-see-more').exists()).toBe(false)
+    })
+
+    it('truncates long description and shows see-more button when expanded=false', () => {
+      // Arrange / Act
+      const longData = { ...SAMPLE_DATA, description: LONG_DESC }
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: false, data: longData, expanded: false } })
+
+      // Assert: description truncated, see-more present
+      const descText = wrapper.find('.eqv2-company-desc-text').text()
+      expect(descText.length).toBeLessThan(LONG_DESC.length)
+      expect(wrapper.find('.eqv2-see-more').exists()).toBe(true)
+      expect(wrapper.find('.eqv2-see-more').text()).toContain('see more')
+    })
+
+    it('renders full long description when expanded=true', () => {
+      // Arrange / Act
+      const longData = { ...SAMPLE_DATA, description: LONG_DESC }
+      const wrapper = mount(EQV2CompanyCard, { props: { loading: false, allNull: false, data: longData, expanded: true } })
+
+      // Assert: full text, less button present instead of see-more
+      expect(wrapper.find('.eqv2-company-desc-text').text()).toContain(LONG_DESC)
+      expect(wrapper.find('.eqv2-see-more').text()).toContain('less')
+    })
+  })
+
+  describe('Expand/collapse events', () => {
+    it('emits expand when see-more button is clicked', async () => {
+      // Arrange
+      const expandCalls = []
+      const collapseCalls = []
+      const longData = { ...SAMPLE_DATA, description: LONG_DESC }
+      const wrapper = mount(EQV2CompanyCard, {
+        props: { loading: false, allNull: false, data: longData, expanded: false },
+        attrs: {
+          onExpand: () => expandCalls.push(true),
+          onCollapse: () => collapseCalls.push(true),
+        },
+      })
+
+      // Act
+      await wrapper.find('.eqv2-see-more').trigger('click')
+
+      // Assert
+      expect(expandCalls.length).toBe(1)
+      expect(collapseCalls.length).toBe(0)
+    })
+
+    it('emits collapse when less button is clicked', async () => {
+      // Arrange
+      const expandCalls = []
+      const collapseCalls = []
+      const longData = { ...SAMPLE_DATA, description: LONG_DESC }
+      const wrapper = mount(EQV2CompanyCard, {
+        props: { loading: false, allNull: false, data: longData, expanded: true },
+        attrs: {
+          onExpand: () => expandCalls.push(true),
+          onCollapse: () => collapseCalls.push(true),
+        },
+      })
+
+      // Act
+      await wrapper.find('.eqv2-see-more').trigger('click')
+
+      // Assert
+      expect(collapseCalls.length).toBe(1)
+      expect(expandCalls.length).toBe(0)
+    })
+  })
+})

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -793,14 +793,56 @@ describe('EnhancedQuoteV2', () => {
       wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
       await wrapper.vm.$nextTick()
 
-      // Act: simulate ResizeObserver firing at wide width
+      // Act: simulate ResizeObserver firing at wide width (480-679px)
+      // At wide: col1=first half, col2=second half (includes company)
       wrapper.vm.layoutMode = 'wide'
       await wrapper.vm.$nextTick()
 
-      // Assert: col-2 rendered, exactly one company card in DOM
+      // Assert: col-2 rendered, company card in col-2, no col-3
       expect(wrapper.find('.eqv2-col-2').exists()).toBe(true)
+      expect(wrapper.find('.eqv2-col-3').exists()).toBe(false)
       expect(wrapper.findAll('.eqv2-company-card').length).toBe(1)
       expect(wrapper.findAll('.eqv2-short-card').length).toBe(1)
+    })
+
+    it('renders col-3 with company card at full layout mode (>=680px)', async () => {
+      // Arrange
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await wrapper.vm.$nextTick()
+
+      // Act: simulate ResizeObserver firing at full width
+      // At full: col1=session+volume, col2=today+short, col3=company
+      wrapper.vm.layoutMode = 'full'
+      await wrapper.vm.$nextTick()
+
+      // Assert: all three columns rendered
+      expect(wrapper.find('.eqv2-col-2').exists()).toBe(true)
+      expect(wrapper.find('.eqv2-col-3').exists()).toBe(true)
+      // Company card is in col-3 only
+      expect(wrapper.findAll('.eqv2-company-card').length).toBe(1)
+      expect(wrapper.find('.eqv2-col-3').find('.eqv2-company-card').exists()).toBe(true)
+      // col3Cards computed returns only company
+      expect(wrapper.vm.col3Cards.map(c => c.id)).toEqual(['company'])
+    })
+
+    it('col3Cards is empty when layoutMode is not full', async () => {
+      // Arrange / Act
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'TSLA'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await wrapper.vm.$nextTick()
+
+      // Assert: narrow
+      expect(wrapper.vm.col3Cards).toEqual([])
+
+      // Act: wide
+      wrapper.vm.layoutMode = 'wide'
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.col3Cards).toEqual([])
     })
 
     it('exactly one company card in DOM at narrow layout mode', async () => {
@@ -813,6 +855,26 @@ describe('EnhancedQuoteV2', () => {
 
       // Assert: only the narrow-mode instance present
       expect(wrapper.findAll('.eqv2-company-card').length).toBe(1)
+    })
+  })
+
+  describe('Hero identity layout', () => {
+    it('symbol and company name render inside eqv2-hero-identity-text', async () => {
+      // Arrange
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: { name: 'Apple Inc.', sic_description: 'Electronic Computers' } }) })
+      const wrapper = mountWidget()
+      wrapper.vm.manualTicker = 'AAPL'
+      await wrapper.vm.$nextTick()
+      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+      await new Promise(r => setTimeout(r, 0))
+      await wrapper.vm.$nextTick()
+
+      // Assert: identity-text wrapper contains symbol row and company info
+      const identText = wrapper.find('.eqv2-hero-identity-text')
+      expect(identText.exists()).toBe(true)
+      expect(identText.find('.eqv2-symbol').exists()).toBe(true)
+      expect(identText.find('.eqv2-hero-company-name').text()).toBe('Apple Inc.')
+      expect(identText.find('.eqv2-hero-sic').text()).toBe('Electronic Computers')
     })
   })
 

--- a/client/src/components/widgets/eqv2Utils.js
+++ b/client/src/components/widgets/eqv2Utils.js
@@ -1,0 +1,30 @@
+/**
+ * Shared formatting utilities for EnhancedQuoteV2 and its child components.
+ * Single source of truth — import from here, never copy-paste.
+ */
+
+/** Strip protocol and trailing slash; truncate to 30 chars. */
+export const truncateUrl = (url) => {
+  if (!url) return ''
+  return url.replace(/^https?:\/\//, '').replace(/\/$/, '').slice(0, 30)
+}
+
+/**
+ * Truncate description text at the last word boundary before maxLen.
+ * Default maxLen matches the EQV2 design spec (175 chars).
+ */
+export const truncateDesc = (text, maxLen = 175) => {
+  if (!text || text.length <= maxLen) return text
+  const cut = text.lastIndexOf(' ', maxLen)
+  return cut > 0 ? text.slice(0, cut) : text.slice(0, maxLen)
+}
+
+/** Format large numbers with K/M/B suffixes. Returns '—' for non-finite values. */
+export const fmtVol = (val) => {
+  const v = parseFloat(val)
+  if (!isFinite(v)) return '—'
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}K`
+  return v.toString()
+}


### PR DESCRIPTION
## Summary

Prod feedback round 2 — second batch.

## Changes

### Three-column layout at full width (≥680px)
- **col1**: Session H/L + Volume
- **col2**: Today + Short Interest  
- **col3**: Company (new — previously missing)
- `col3Cards` computed returns company card at full mode, empty otherwise
- `_col3` drag ref + `onColReorder(val, 3)` wired in
- `onDragEnd` includes col3 in merged `cardOrder`
- CSS: `.eqv2-col-2` and `.eqv2-col-3` both hidden by default; col-3 `display:flex` added at 680px+

### Hero identity restructure
- Logo now a tall left block; text stacks to its right
- New `eqv2-hero-identity-text` wrapper: flex-column containing symbol row, company name, sic
- `eqv2-hero-symbol-row`: symbol + flame icon inline
- Company name and sic moved inside `identity-text` — removed separate `hero-company` div

## Tests

114/114 — added 4 new tests: full-mode col3 rendering, col3Cards empty at narrow/wide, hero identity-text structure.

refs #133