### PR TITLE
fix: restrict widget drag to .widget-header (prevents conflict with EQV2 card drag)

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -265,6 +265,7 @@
           :w="item.w"
           :h="item.h"
           :i="item.i"
+          drag-allow-from=".widget-header"
       >
         <WidgetWrapper
             :widget-id="item.i"


### PR DESCRIPTION
## Problem

Widget drag was capturing mousedown anywhere on the widget surface, including inside the EQV2 card drag handles (⠿). Dragging a card caused the entire widget to move instead.

## Fix

Add `drag-allow-from=".widget-header"` to `GridItem` in `DashboardGrid.vue`.

`vue3-grid-layout-next` passes this through to its underlying `interact.js` `allowFrom` option — widget drag only initiates when the pointer starts on `.widget-header`. Card drag handles inside `.widget-content` are now unambiguous.

## Why this works

`WidgetWrapper` already has a `.widget-header` div at the top of every widget (title, link color selector, close button). That's the natural drag target. No changes needed to `WidgetWrapper` or `EnhancedQuoteV2`.

## Tests

125/125 passing (no DashboardGrid unit tests exist — this is a layout interaction fix verified in prod).

refs #133