### PR TITLE
feat: add GitHub release step to build-images.yml + releases badge to README

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -3,9 +3,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# Re-declared per-job for least-privilege; top-level is intentionally restrictive.
+
 on:
   push:
     branches: [ mainline ]
+    tags: [ 'v*' ]
   workflow_dispatch:
 
 jobs:
@@ -96,3 +99,22 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/kuhl-haus-mdp-app-server:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  github-release:
+    name: Create GitHub Release
+    if: startsWith(github.ref, 'refs/tags/')  # only release on tag pushes
+    needs: [ build-docker ]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+
+    steps:
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >
+        gh release create
+        "$GITHUB_REF_NAME"
+        --repo "$GITHUB_REPOSITORY"
+        --notes ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![License](https://img.shields.io/github/license/kuhl-haus/kuhl-haus-mdp-app)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/blob/mainline/LICENSE.txt)
 [![Build Images](https://github.com/kuhl-haus/kuhl-haus-mdp-app/actions/workflows/build-images.yml/badge.svg)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/actions/workflows/build-images.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/kuhl-haus/kuhl-haus-mdp-app)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/releases)
 [![CodeQL Advanced](https://github.com/kuhl-haus/kuhl-haus-mdp-app/actions/workflows/codeql.yml/badge.svg)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/actions/workflows/codeql.yml)
 [![GitHub issues](https://img.shields.io/github/issues/kuhl-haus/kuhl-haus-mdp-app)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/kuhl-haus/kuhl-haus-mdp-app)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/pulls)


### PR DESCRIPTION
## Changes

### `.github/workflows/build-images.yml`
- **Trigger on tags**: added `tags: ['v*']` to `on.push` — workflow now runs on both mainline branch pushes and version tag pushes
- **New `github-release` job**: runs only on tag pushes (`if: startsWith(github.ref, 'refs/tags/')`), depends on `build-docker`
  - `contents: write` permission (required for `gh release create`)
  - Single step: `gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --notes ""`
  - Pattern matches `github-release` job in `kuhl-haus-mdp/publish-to-pypi.yml`
  - No artifact signing (no Python dist — Docker-only repo)

### `README.md`
- Added GitHub Release badge (`shields.io/github/v/release`) after Build Images badge

## Reference
- Pattern from: `kuhl-haus/kuhl-haus-mdp` → `.github/workflows/publish-to-pypi.yml` → `github-release` job