### PR TITLE
fix(eqv2): await two nextTick cycles in onDragEnd for cross-column card drag

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -414,10 +414,11 @@ const onColReorder = (newVal, colNum) => {
 
 const onDragEnd = async () => {
   isDragging.value = false
-  // Wait for both @update:model-value events to settle before reading override refs.
-  // SortableJS fires @end before @update:model-value is guaranteed to have run on
-  // both source and destination columns in a cross-column drag. Without nextTick,
-  // one column override may still be null, causing a stale cardOrder to be emitted.
+  // Wait for all @update:model-value events to settle before reading override refs.
+  // vuedraggable wraps each emission in nextTick(), and a cross-column drag fires
+  // two separate emissions (source remove + destination add) in successive ticks.
+  // Two awaits ensure both columns' overrides are set before we read them.
+  await nextTick()
   await nextTick()
   const c1 = _col1.value ?? col1Cards.value
   const c2 = _col2.value ?? col2Cards.value

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -1003,16 +1003,24 @@ describe('EnhancedQuoteV2', () => {
       wrapper.vm.layoutMode = 'wide'  // col1: [session,today,volume], col2: [short,company]
       await wrapper.vm.$nextTick()
 
-      // Act: simulate cross-column drag — card moved from col2 to col1
-      // Both @update:model-value handlers fire before @end
+      // Act: reproduce the real race condition.
+      // vuedraggable wraps each update:modelValue in nextTick(), so a cross-column drag
+      // delivers the source column override on tick 1 and the destination on tick 2.
+      // Simulate this: col1 override arrives synchronously, col2 arrives one tick later
+      // (after onDragEnd has already started and consumed the first nextTick).
       const newCol1 = ['session', 'today', 'volume', 'short'].map(id => ({ id, label: id }))
       const newCol2 = ['company'].map(id => ({ id, label: id }))
-      wrapper.vm.onColReorder(newCol1, 1)
-      wrapper.vm.onColReorder(newCol2, 2)
-      await wrapper.vm.onDragEnd()
+
+      wrapper.vm.onColReorder(newCol1, 1)  // col1 override set immediately
+      // Start onDragEnd — it will await its first nextTick before we set col2
+      const dragEndPromise = wrapper.vm.onDragEnd()
+      // After the first tick (which onDragEnd just consumed), deliver col2
+      await wrapper.vm.$nextTick()
+      wrapper.vm.onColReorder(newCol2, 2)  // col2 arrives on second tick
+      await dragEndPromise
       await wrapper.vm.$nextTick()
 
-      // Assert: all 5 cards present, col1 then col2 order
+      // Assert: all 5 cards present in correct merged order
       expect(updateSettingsCalls.length).toBe(1)
       expect(updateSettingsCalls[0].cardOrder).toEqual(
         ['session', 'today', 'volume', 'short', 'company']


### PR DESCRIPTION
## Problem

Cards could only be reordered within the same column — dragging from col1 to col2 (or vice versa) caused the card to snap back.

## Root Cause

vuedraggable wraps each `update:modelValue` emission in `nextTick()`. A cross-column drag fires two separate emissions in succession: one from the source column (remove) and one from the destination (add). The single `await nextTick()` in `onDragEnd` only waited for one tick, leaving one column's `_col` override ref still null when the order was read and emitted.

## Fix

Two `await nextTick()` calls in `onDragEnd` — ensures both the source and destination column overrides are set before the merged `cardOrder` is computed and emitted.

## Tests

125/125 passing.

refs #133