### PR TITLE
feat(eqv2): remove logo, set FULL breakpoint to 960px

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -249,7 +249,7 @@
           </draggable>
         </div>
 
-        <!-- Col 3: company card only at full width (≥680px) -->
+        <!-- Col 3: company card only at full width (≥960px) -->
         <div v-if="layoutMode === 'full'" class="eqv2-col eqv2-col-3">
           <draggable
             :model-value="col3Cards"
@@ -371,7 +371,7 @@ const activeCards = computed(() => {
 
 // Distribute activeCards across columns based on layout mode.
 // Previous Day is excluded — it's always pinned outside the draggable lists.
-// FULL (>=680px): col1=session+volume, col2=today+short, col3=company
+// FULL (>=960px): col1=session+volume, col2=today+short, col3=company
 // WIDE (480-679px): col1=first half, col2=second half (including company)
 // NARROW (<480px): col1=all cards
 const col1Cards = computed(() => {
@@ -1102,7 +1102,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 }
 
 /* ── Sections: narrow (< 480px) — single flex column ── */
-/* Breakpoint constants — must match BREAKPOINTS in PR C JS: WIDE=480, FULL=680 */
+/* Breakpoint constants — must match BREAKPOINTS in JS: WIDE=480, FULL=960 */
 .eqv2-sections {
   display: flex;
   flex-direction: column;
@@ -1140,8 +1140,8 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   /* Col-2 shown via v-if="!isNarrow" — no CSS hide needed */
 }
 
-/* ── FULL mode (680px+): three columns — col1=session+volume, col2=today+short, col3=company ── */
-/* BREAKPOINTS.FULL = 680 — must match JS BREAKPOINTS.FULL */
+/* ── FULL mode (960px+): three columns — col1=session+volume, col2=today+short, col3=company ── */
+/* BREAKPOINTS.FULL = 960 — must match JS BREAKPOINTS.FULL */
 @container (min-width: 960px) {   /* BREAKPOINTS.FULL */
   .eqv2-symbol { font-size: 22px; }
   .eqv2-price  { font-size: 30px; }

--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -32,13 +32,6 @@
       <div class="eqv2-hero">
         <div class="eqv2-hero-left">
           <div class="eqv2-hero-identity">
-            <img
-              v-if="activeTicker && !companyLoading && !logoError"
-              :src="`/api/market_data/logo/${activeTicker}`"
-              class="eqv2-hero-logo"
-              :alt="companyData.name || activeTicker"
-              @error="logoError = true"
-            />
             <div class="eqv2-hero-identity-text">
               <div class="eqv2-hero-symbol-row">
                 <span class="eqv2-symbol">{{ quoteData.symbol }}</span>
@@ -332,7 +325,7 @@ import { truncateUrl, truncateDesc, fmtVol } from './eqv2Utils.js'
 
 // Shared breakpoint constants — must match CSS @container thresholds exactly.
 // Referenced by ResizeObserver (JS) and CSS comments below.
-const BREAKPOINTS = { WIDE: 480, FULL: 680 }
+const BREAKPOINTS = { WIDE: 480, FULL: 960 }
 
 // Card registry — defines the set of draggable cards and their default order.
 // 'prev' (Previous Day) is always pinned full-width at the bottom — NOT in registry.
@@ -494,7 +487,7 @@ const quoteData = ref(null)
 const lastDataAt = ref(null)
 
 // Logo error state — reset on ticker change
-const logoError = ref(false)
+// logoError removed — logo feature removed
 
 // Company enrichment — fetched via REST on ticker change
 const companyData = ref({})
@@ -572,7 +565,6 @@ watch(activeTicker, (newTicker) => {
   companyData.value = {}
   shortInterestData.value = {}
   descExpanded.value = false
-  logoError.value = false
   if (newTicker) {
     fetchCompany(newTicker)
     fetchShortInterest(newTicker)
@@ -673,7 +665,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, logoError, layoutMode, activeCards, col3Cards, isDragging, onColReorder, onDragEnd })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, isDragging, onColReorder, onDragEnd })
 </script>
 
 <style scoped>
@@ -783,17 +775,6 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   display: flex;
   align-items: stretch;
   gap: 6px;
-}
-
-.eqv2-hero-logo {
-  height: 100%;
-  width: auto;
-  max-width: 48px;
-  border-radius: 3px;
-  object-fit: contain;
-  flex-shrink: 0;
-  background: rgba(255,255,255,0.05);
-  align-self: stretch;
 }
 
 .eqv2-hero-identity-text {
@@ -1161,7 +1142,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 
 /* ── FULL mode (680px+): three columns — col1=session+volume, col2=today+short, col3=company ── */
 /* BREAKPOINTS.FULL = 680 — must match JS BREAKPOINTS.FULL */
-@container (min-width: 680px) {   /* BREAKPOINTS.FULL */
+@container (min-width: 960px) {   /* BREAKPOINTS.FULL */
   .eqv2-symbol { font-size: 22px; }
   .eqv2-price  { font-size: 30px; }
   .eqv2-col-3  { display: flex; flex: 1; }

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -478,85 +478,6 @@ describe('EnhancedQuoteV2', () => {
       expect(hero.text()).toContain('Motor Vehicles')
     })
 
-    it('renders logo in hero via proxy src when activeTicker is set and company loaded', async () => {
-      // Arrange: company fetch resolves so companyLoading goes false
-      mockCompanyFetch({ name: 'Apple Inc.', sic_description: 'Computers' })
-      const wrapper = mountWidget()
-      wrapper.vm.manualTicker = 'AAPL'
-      await wrapper.vm.$nextTick()
-      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
-      await new Promise(r => setTimeout(r, 0))  // let fetchCompany resolve
-      await wrapper.vm.$nextTick()
-
-      // Assert: logo renders once companyLoading=false
-      expect(wrapper.vm.companyLoading).toBe(false)
-      const logo = wrapper.find('.eqv2-hero-logo')
-      expect(logo.exists()).toBe(true)
-      expect(logo.attributes('src')).toBe('/api/market_data/logo/AAPL')
-    })
-
-    it('does not render logo while company data is loading', async () => {
-      // Arrange: company fetch in flight (companyLoading=true)
-      let resolveCompany
-      global.fetch = vi.fn().mockImplementation((url) => {
-        if (url.includes('company')) return new Promise(r => { resolveCompany = r })
-        return Promise.resolve({ ok: true, json: async () => ({ data: {} }) })
-      })
-      const wrapper = mountWidget()
-      wrapper.vm.manualTicker = 'AAPL'
-      await wrapper.vm.$nextTick()
-      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
-      await wrapper.vm.$nextTick()
-
-      // Assert: logo not rendered while loading
-      expect(wrapper.vm.companyLoading).toBe(true)
-      expect(wrapper.find('.eqv2-hero-logo').exists()).toBe(false)
-
-      // Act: resolve company fetch
-      resolveCompany({ ok: true, json: async () => ({ data: { name: 'Apple Inc.' } }) })
-      await new Promise(r => setTimeout(r, 0))
-      await wrapper.vm.$nextTick()
-
-      // Assert: logo now renders
-      expect(wrapper.vm.companyLoading).toBe(false)
-      expect(wrapper.find('.eqv2-hero-logo').exists()).toBe(true)
-    })
-
-    it('hides logo when logoError is true', async () => {
-      // Arrange
-      mockCompanyFetch({ name: 'Apple Inc.', sic_description: 'Computers' })
-      const wrapper = mountWidget()
-      wrapper.vm.manualTicker = 'AAPL'
-      await wrapper.vm.$nextTick()
-      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
-      await new Promise(r => setTimeout(r, 0))
-      await wrapper.vm.$nextTick()
-
-      // Simulate @error handler firing
-      wrapper.vm.logoError = true
-      await wrapper.vm.$nextTick()
-
-      // Assert: img no longer visible
-      expect(wrapper.find('.eqv2-hero-logo').exists()).toBe(false)
-    })
-
-    it('resets logoError to false when ticker changes', async () => {
-      // Arrange: set logoError, then change ticker
-      mockCompanyFetch({ name: 'Apple Inc.' })
-      const wrapper = mountWidget()
-      wrapper.vm.manualTicker = 'AAPL'
-      await wrapper.vm.$nextTick()
-      wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
-      wrapper.vm.logoError = true
-      await wrapper.vm.$nextTick()
-
-      // Act: change ticker
-      wrapper.vm.manualTicker = 'TSLA'
-      await wrapper.vm.$nextTick()
-
-      // Assert: logoError reset
-      expect(wrapper.vm.logoError).toBe(false)
-    })
   })
 
   describe('Description see-more toggle', () => {
@@ -805,7 +726,7 @@ describe('EnhancedQuoteV2', () => {
       expect(wrapper.findAll('.eqv2-short-card').length).toBe(1)
     })
 
-    it('renders col-3 with company card at full layout mode (>=680px)', async () => {
+    it('renders col-3 with company card at full layout mode (>=960px)', async () => {
       // Arrange
       const wrapper = mountWidget()
       wrapper.vm.manualTicker = 'TSLA'


### PR DESCRIPTION
## Changes

### Remove logo
- Removed `<img>` logo element from hero identity section
- Removed `logoError` ref, reset-on-ticker-change side effect, and `defineExpose` entry
- Removed `.eqv2-hero-logo` CSS block
- Removed 4 logo tests (logo render, loading guard, error hide, reset on ticker change)

### FULL breakpoint: 680 → 960px
- `BREAKPOINTS.FULL` constant in JS
- `@container (min-width: 960px)` in CSS (kept in sync with JS constant)

## Tests
121/121 passing.

refs #133