### PR TITLE
feat(eqv3): backport full-mode horizontal layout from EQV2

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -30,20 +30,16 @@
     <div v-else class="eqv3-body">
       <!-- Price Hero -->
       <div class="eqv3-hero">
-        <div class="eqv3-hero-left">
-          <div class="eqv3-hero-identity">
-            <img v-if="logoUrl" :src="logoUrl + '?apiKey=' + config?.massiveApiKey" class="eqv3-logo" alt="Company logo" />
-            <div class="eqv3-hero-identity-text">
-              <div class="eqv3-hero-symbol-row">
-                <span class="eqv3-symbol">{{ quoteData.symbol }}</span>
-                <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv3-flame-icon" />
-              </div>
-              <span v-if="companyData.name" class="eqv3-hero-company-name">{{ companyData.name }}</span>
-              <span v-if="companyData.sic_description" class="eqv3-hero-sic">{{ companyData.sic_description }}</span>
-            </div>
+        <!-- Symbol block: symbol + flame icon + logo -->
+        <div class="eqv3-hero-symbol-block">
+          <img v-if="logoUrl" :src="logoUrl + '?apiKey=' + config?.massiveApiKey" class="eqv3-logo" alt="Company logo" />
+          <div class="eqv3-hero-symbol-row">
+            <span class="eqv3-symbol">{{ quoteData.symbol }}</span>
+            <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv3-flame-icon" />
           </div>
         </div>
-        <div class="eqv3-hero-right">
+        <!-- Price block: price + change + since-open -->
+        <div class="eqv3-hero-price-block">
           <span class="eqv3-price">${{ fmt(quoteData.close, 2) }}</span>
           <span :class="['eqv3-change-badge', changeClass]">
             {{ quoteData.change >= 0 ? '+' : '' }}{{ fmt(quoteData.change, 2) }}
@@ -59,21 +55,28 @@
             </span>
           </div>
         </div>
+        <!-- Company identity: name + sic — after price in full mode -->
+        <div class="eqv3-hero-identity-block">
+          <span v-if="companyData.name" class="eqv3-hero-company-name">{{ companyData.name }}</span>
+          <span v-if="companyData.sic_description" class="eqv3-hero-sic">{{ companyData.sic_description }}</span>
+        </div>
       </div>
 
-      <!-- Adaptive sections: flex columns at wide/full, single col at narrow -->
+      <!-- Adaptive sections -->
       <div :class="['eqv3-sections', { 'eqv3-dragging': isDragging }]">
-        <!-- Col 1: draggable card list (all cards at narrow; first half at wide/full) -->
-        <div class="eqv3-col eqv3-col-1">
+
+        <!-- FULL mode (≥960px): single horizontal draggable row — hero left, all cards right -->
+        <template v-if="layoutMode === 'full'">
           <draggable
-            :model-value="col1Cards"
+            :model-value="fullRowCards"
             group="eqv3-cards"
             item-key="id"
             :disabled="isLocked"
             handle=".eqv3-drag-handle"
+            class="eqv3-full-row-draggable"
             @start="isDragging = true"
-            @end="onDragEnd()"
-            @update:model-value="(val) => onColReorder(val, 1)"
+            @end="onFullRowDragEnd()"
+            @update:model-value="(val) => (_fullRow.value = val)"
           >
             <template #item="{ element: card }">
               <div :key="card.id" :class="['eqv3-card', `eqv3-${card.id}-card`]">
@@ -159,143 +162,227 @@
                   />
                 </template>
 
+                <!-- Previous Day -->
+                <template v-else-if="card.id === 'prev'">
+                  <div class="eqv3-prev-chips">
+                    <div class="eqv3-chip"><span class="eqv3-chip-label">O</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+                    <div class="eqv3-chip"><span class="eqv3-chip-label">H</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+                    <div class="eqv3-chip"><span class="eqv3-chip-label">L</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+                    <div class="eqv3-chip"><span class="eqv3-chip-label">C</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+                    <div class="eqv3-chip"><span class="eqv3-chip-label">Vol</span><span class="eqv3-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+                    <div class="eqv3-chip"><span class="eqv3-chip-label">VWAP</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+                  </div>
+                </template>
+
               </div>
             </template>
           </draggable>
-        </div>
+        </template>
 
-        <!-- Col 2: second half of cards at wide/full -->
-        <div v-if="!isNarrow" class="eqv3-col eqv3-col-2">
-          <draggable
-            :model-value="col2Cards"
-            group="eqv3-cards"
-            item-key="id"
-            :disabled="isLocked"
-            handle=".eqv3-drag-handle"
-            @start="isDragging = true"
-            @end="onDragEnd()"
-            @update:model-value="(val) => onColReorder(val, 2)"
-          >
-            <template #item="{ element: card }">
-              <div :key="card.id" :class="['eqv3-card', `eqv3-${card.id}-card`]">
-                <div class="eqv3-card-label">
-                  <span v-if="!isLocked" class="eqv3-drag-handle" title="Drag to reorder">⠿</span>
-                  {{ card.label }}
+        <!-- NARROW / WIDE mode: two columns + pinned Previous Day row -->
+        <template v-else>
+          <!-- Col 1: all cards at narrow; first half at wide -->
+          <div class="eqv3-col eqv3-col-1">
+            <draggable
+              :model-value="col1Cards"
+              group="eqv3-cards"
+              item-key="id"
+              :disabled="isLocked"
+              handle=".eqv3-drag-handle"
+              @start="isDragging = true"
+              @end="onDragEnd()"
+              @update:model-value="(val) => onColReorder(val, 1)"
+            >
+              <template #item="{ element: card }">
+                <div :key="card.id" :class="['eqv3-card', `eqv3-${card.id}-card`]">
+                  <div class="eqv3-card-label">
+                    <span v-if="!isLocked" class="eqv3-drag-handle" title="Drag to reorder">⠿</span>
+                    {{ card.label }}
+                  </div>
+
+                  <!-- Session H/L -->
+                  <template v-if="card.id === 'session'">
+                    <div class="eqv3-session-chips">
+                      <div class="eqv3-session-chip">
+                        <span class="eqv3-chip-label">PRE</span>
+                        <div v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null" class="eqv3-session-chip-vals">
+                          <span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span>
+                          <span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span>
+                        </div>
+                        <div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                      </div>
+                      <div class="eqv3-session-chip">
+                        <span class="eqv3-chip-label">REG</span>
+                        <div v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null" class="eqv3-session-chip-vals">
+                          <span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span>
+                          <span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span>
+                        </div>
+                        <div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                      </div>
+                      <div class="eqv3-session-chip">
+                        <span class="eqv3-chip-label">AH</span>
+                        <div v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null" class="eqv3-session-chip-vals">
+                          <span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span>
+                          <span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span>
+                        </div>
+                        <div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                      </div>
+                    </div>
+                  </template>
+
+                  <!-- Today -->
+                  <template v-else-if="card.id === 'today'">
+                    <div class="eqv3-kv-list">
+                      <div class="eqv3-kv"><span class="eqv3-k">Open</span><span class="eqv3-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">VWAP</span><span class="eqv3-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+                    </div>
+                  </template>
+
+                  <!-- Volume -->
+                  <template v-else-if="card.id === 'volume'">
+                    <div class="eqv3-kv-list">
+                      <div class="eqv3-kv"><span class="eqv3-k">Volume</span><span class="eqv3-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Avg Vol</span><span class="eqv3-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Float</span><span class="eqv3-v">{{ fmtVol(floatShares) }}</span></div>
+                    </div>
+                    <div class="eqv3-rv-row">
+                      <span class="eqv3-k">Rel. Vol</span>
+                      <div class="eqv3-rv-bar-wrap">
+                        <div class="eqv3-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div>
+                      </div>
+                      <span :class="['eqv3-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
+                    </div>
+                  </template>
+
+                  <!-- Short Interest -->
+                  <template v-else-if="card.id === 'short'">
+                    <div v-if="shortInterestLoading" class="eqv3-muted-msg">Short interest data loading...</div>
+                    <div v-else-if="allShortNull" class="eqv3-muted-msg">Short interest data unavailable</div>
+                    <div v-else class="eqv3-kv-list">
+                      <div class="eqv3-kv"><span class="eqv3-k">Short Int.</span><span class="eqv3-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Days to Cover</span><span class="eqv3-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Short Vol Ratio</span><span class="eqv3-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
+                    </div>
+                  </template>
+
+                  <!-- Company -->
+                  <template v-else-if="card.id === 'company'">
+                    <EQV2CompanyCard
+                      :loading="companyLoading"
+                      :all-null="allCompanyNull"
+                      :data="companyData"
+                      :expanded="descExpanded"
+                      @expand="descExpanded = true"
+                      @collapse="descExpanded = false"
+                    />
+                  </template>
+
                 </div>
+              </template>
+            </draggable>
+          </div>
 
-                <!-- Short Interest -->
-                <template v-if="card.id === 'short'">
-                  <div v-if="shortInterestLoading" class="eqv3-muted-msg">Short interest data loading...</div>
-                  <div v-else-if="allShortNull" class="eqv3-muted-msg">Short interest data unavailable</div>
-                  <div v-else class="eqv3-kv-list">
-                    <div class="eqv3-kv"><span class="eqv3-k">Short Int.</span><span class="eqv3-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
-                    <div class="eqv3-kv"><span class="eqv3-k">Days to Cover</span><span class="eqv3-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
-                    <div class="eqv3-kv"><span class="eqv3-k">Short Vol Ratio</span><span class="eqv3-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
+          <!-- Col 2: second half at wide -->
+          <div v-if="!isNarrow" class="eqv3-col eqv3-col-2">
+            <draggable
+              :model-value="col2Cards"
+              group="eqv3-cards"
+              item-key="id"
+              :disabled="isLocked"
+              handle=".eqv3-drag-handle"
+              @start="isDragging = true"
+              @end="onDragEnd()"
+              @update:model-value="(val) => onColReorder(val, 2)"
+            >
+              <template #item="{ element: card }">
+                <div :key="card.id" :class="['eqv3-card', `eqv3-${card.id}-card`]">
+                  <div class="eqv3-card-label">
+                    <span v-if="!isLocked" class="eqv3-drag-handle" title="Drag to reorder">⠿</span>
+                    {{ card.label }}
                   </div>
-                </template>
 
-                <!-- Company -->
-                <template v-else-if="card.id === 'company'">
-                  <EQV2CompanyCard
-                    :loading="companyLoading"
-                    :all-null="allCompanyNull"
-                    :data="companyData"
-                    :expanded="descExpanded"
-                    @expand="descExpanded = true"
-                    @collapse="descExpanded = false"
-                  />
-                </template>
-
-                <!-- Session / Today / Volume (if reordered into col-2) -->
-                <template v-else-if="card.id === 'session'">
-                  <div class="eqv3-session-chips">
-                    <div class="eqv3-session-chip"><span class="eqv3-chip-label">PRE</span>
-                      <div v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null" class="eqv3-session-chip-vals">
-                        <span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span><span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span>
-                      </div><div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                  <!-- Short Interest -->
+                  <template v-if="card.id === 'short'">
+                    <div v-if="shortInterestLoading" class="eqv3-muted-msg">Short interest data loading...</div>
+                    <div v-else-if="allShortNull" class="eqv3-muted-msg">Short interest data unavailable</div>
+                    <div v-else class="eqv3-kv-list">
+                      <div class="eqv3-kv"><span class="eqv3-k">Short Int.</span><span class="eqv3-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Days to Cover</span><span class="eqv3-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Short Vol Ratio</span><span class="eqv3-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
                     </div>
-                    <div class="eqv3-session-chip"><span class="eqv3-chip-label">REG</span>
-                      <div v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null" class="eqv3-session-chip-vals">
-                        <span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span><span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span>
-                      </div><div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
-                    </div>
-                    <div class="eqv3-session-chip"><span class="eqv3-chip-label">AH</span>
-                      <div v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null" class="eqv3-session-chip-vals">
-                        <span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span><span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span>
-                      </div><div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
-                    </div>
-                  </div>
-                </template>
-                <template v-else-if="card.id === 'today'">
-                  <div class="eqv3-kv-list">
-                    <div class="eqv3-kv"><span class="eqv3-k">Open</span><span class="eqv3-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
-                    <div class="eqv3-kv"><span class="eqv3-k">VWAP</span><span class="eqv3-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
-                  </div>
-                </template>
-                <template v-else-if="card.id === 'volume'">
-                  <div class="eqv3-kv-list">
-                    <div class="eqv3-kv"><span class="eqv3-k">Volume</span><span class="eqv3-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
-                    <div class="eqv3-kv"><span class="eqv3-k">Avg Vol</span><span class="eqv3-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
-                    <div class="eqv3-kv"><span class="eqv3-k">Float</span><span class="eqv3-v">{{ fmtVol(floatShares) }}</span></div>
-                  </div>
-                  <div class="eqv3-rv-row">
-                    <span class="eqv3-k">Rel. Vol</span>
-                    <div class="eqv3-rv-bar-wrap"><div class="eqv3-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div></div>
-                    <span :class="['eqv3-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
-                  </div>
-                </template>
+                  </template>
 
-              </div>
-            </template>
-          </draggable>
-        </div>
+                  <!-- Company -->
+                  <template v-else-if="card.id === 'company'">
+                    <EQV2CompanyCard
+                      :loading="companyLoading"
+                      :all-null="allCompanyNull"
+                      :data="companyData"
+                      :expanded="descExpanded"
+                      @expand="descExpanded = true"
+                      @collapse="descExpanded = false"
+                    />
+                  </template>
 
-        <!-- Col 3: company card only at full width (≥960px) -->
-        <div v-if="layoutMode === 'full'" class="eqv3-col eqv3-col-3">
-          <draggable
-            :model-value="col3Cards"
-            group="eqv3-cards"
-            item-key="id"
-            :disabled="isLocked"
-            handle=".eqv3-drag-handle"
-            @start="isDragging = true"
-            @end="onDragEnd()"
-            @update:model-value="(val) => onColReorder(val, 3)"
-          >
-            <template #item="{ element: card }">
-              <div :key="card.id" :class="['eqv3-card', `eqv3-${card.id}-card`]">
-                <div class="eqv3-card-label">
-                  <span v-if="!isLocked" class="eqv3-drag-handle" title="Drag to reorder">⠿</span>
-                  {{ card.label }}
+                  <!-- Session / Today / Volume (if reordered into col-2) -->
+                  <template v-else-if="card.id === 'session'">
+                    <div class="eqv3-session-chips">
+                      <div class="eqv3-session-chip"><span class="eqv3-chip-label">PRE</span>
+                        <div v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null" class="eqv3-session-chip-vals">
+                          <span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span><span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span>
+                        </div><div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                      </div>
+                      <div class="eqv3-session-chip"><span class="eqv3-chip-label">REG</span>
+                        <div v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null" class="eqv3-session-chip-vals">
+                          <span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span><span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span>
+                        </div><div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                      </div>
+                      <div class="eqv3-session-chip"><span class="eqv3-chip-label">AH</span>
+                        <div v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null" class="eqv3-session-chip-vals">
+                          <span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span><span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span>
+                        </div><div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                      </div>
+                    </div>
+                  </template>
+                  <template v-else-if="card.id === 'today'">
+                    <div class="eqv3-kv-list">
+                      <div class="eqv3-kv"><span class="eqv3-k">Open</span><span class="eqv3-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">VWAP</span><span class="eqv3-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+                    </div>
+                  </template>
+                  <template v-else-if="card.id === 'volume'">
+                    <div class="eqv3-kv-list">
+                      <div class="eqv3-kv"><span class="eqv3-k">Volume</span><span class="eqv3-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Avg Vol</span><span class="eqv3-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Float</span><span class="eqv3-v">{{ fmtVol(floatShares) }}</span></div>
+                    </div>
+                    <div class="eqv3-rv-row">
+                      <span class="eqv3-k">Rel. Vol</span>
+                      <div class="eqv3-rv-bar-wrap"><div class="eqv3-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div></div>
+                      <span :class="['eqv3-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
+                    </div>
+                  </template>
+
                 </div>
-                <!-- Col-3 only ever contains the company card -->
-                <EQV2CompanyCard
-                  :loading="companyLoading"
-                  :all-null="allCompanyNull"
-                  :data="companyData"
-                  :expanded="descExpanded"
-                  @expand="descExpanded = true"
-                  @collapse="descExpanded = false"
-                />
-              </div>
-            </template>
-          </draggable>
-        </div>
+              </template>
+            </draggable>
+          </div>
 
-        <!-- Previous Day: always full-width at bottom — NOT part of draggable list -->
-        <div class="eqv3-prev-row">
-          <div class="eqv3-card eqv3-prev-card">
-            <div class="eqv3-card-label">Previous Day</div>
-            <div class="eqv3-prev-chips">
-              <div class="eqv3-chip"><span class="eqv3-chip-label">O</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
-              <div class="eqv3-chip"><span class="eqv3-chip-label">H</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
-              <div class="eqv3-chip"><span class="eqv3-chip-label">L</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
-              <div class="eqv3-chip"><span class="eqv3-chip-label">C</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
-              <div class="eqv3-chip"><span class="eqv3-chip-label">Vol</span><span class="eqv3-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
-              <div class="eqv3-chip"><span class="eqv3-chip-label">VWAP</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+          <!-- Previous Day: always full-width at bottom — NOT part of draggable list -->
+          <div class="eqv3-prev-row">
+            <div class="eqv3-card eqv3-prev-card">
+              <div class="eqv3-card-label">Previous Day</div>
+              <div class="eqv3-prev-chips">
+                <div class="eqv3-chip"><span class="eqv3-chip-label">O</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+                <div class="eqv3-chip"><span class="eqv3-chip-label">H</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+                <div class="eqv3-chip"><span class="eqv3-chip-label">L</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+                <div class="eqv3-chip"><span class="eqv3-chip-label">C</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+                <div class="eqv3-chip"><span class="eqv3-chip-label">Vol</span><span class="eqv3-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+                <div class="eqv3-chip"><span class="eqv3-chip-label">VWAP</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+              </div>
             </div>
           </div>
-        </div>
+        </template>
       </div>
 
       <!-- Splits -->
@@ -329,10 +416,13 @@ import { fmtVol } from './eqv2Utils.js'
 const BREAKPOINTS = { WIDE: 480, FULL: 960 }
 
 // Card registry — defines the set of draggable cards and their default order.
+// At full mode (≥960px), 'prev' is a draggable card in the flat row.
+// At narrow/wide, 'prev' is pinned full-width at the bottom (excluded from column lists).
 const CARD_REGISTRY = [
-  { id: 'session', label: 'Session H/L'   },
   { id: 'today',   label: 'Today'          },
+  { id: 'prev',    label: 'Previous Day'   },
   { id: 'volume',  label: 'Volume'         },
+  { id: 'session', label: 'Session H/L'   },
   { id: 'short',   label: 'Short Interest' },
   { id: 'company', label: 'Company'        },
 ]
@@ -367,28 +457,33 @@ const activeCards = computed(() => {
   return [...saved, ...missing]
 })
 
+// Distribute activeCards (excluding 'prev') across columns at narrow/wide mode.
+// At full mode, fullRowCards is used instead — these computeds are not rendered.
 const col1Cards = computed(() => {
-  const cards = activeCards.value
+  const cards = activeCards.value.filter(c => c.id !== 'prev')
   if (isNarrow.value) return cards
-  if (layoutMode.value === 'full') return cards.filter(c => c.id !== 'today' && c.id !== 'short' && c.id !== 'company')
   return cards.slice(0, Math.ceil(cards.length / 2))
 })
 
 const col2Cards = computed(() => {
   if (isNarrow.value) return []
-  const cards = activeCards.value
-  if (layoutMode.value === 'full') return cards.filter(c => c.id === 'today' || c.id === 'short')
+  const cards = activeCards.value.filter(c => c.id !== 'prev')
   return cards.slice(Math.ceil(cards.length / 2))
 })
 
-const col3Cards = computed(() => {
+const col3Cards = computed(() => [])  // no longer used; kept for API compatibility
+
+// At full mode: single flat horizontal list of all active cards (including prev).
+const fullRowCards = computed(() => {
   if (layoutMode.value !== 'full') return []
-  return activeCards.value.filter(c => c.id === 'company')
+  return activeCards.value
 })
 
+// Mutable drag state — holds reordered cards within a drag session
 const _col1 = ref(null)
 const _col2 = ref(null)
 const _col3 = ref(null)
+const _fullRow = ref(null)
 
 const onColReorder = (newVal, colNum) => {
   if (colNum === 1) _col1.value = newVal
@@ -396,20 +491,32 @@ const onColReorder = (newVal, colNum) => {
   else _col3.value = newVal
 }
 
+// Drag end for narrow/wide column layout.
+// 'prev' is always pinned outside the draggable lists at narrow/wide, so append it
+// at the end of the saved order (its position only matters at full mode).
 const onDragEnd = async () => {
   isDragging.value = false
   await nextTick()
   await nextTick()
   const c1 = _col1.value ?? col1Cards.value
   const c2 = _col2.value ?? col2Cards.value
-  const c3 = _col3.value ?? col3Cards.value
-  const newOrder = isNarrow.value
+  const orderedNonPrev = isNarrow.value
     ? c1.map(c => c.id)
-    : [...c1, ...c2, ...c3].map(c => c.id)
+    : [...c1, ...c2].map(c => c.id)
   _col1.value = null
   _col2.value = null
   _col3.value = null
-  emit('update-settings', { ...props.settings, cardOrder: newOrder })
+  emit('update-settings', { ...props.settings, cardOrder: [...orderedNonPrev, 'prev'] })
+}
+
+// Drag end for the full-mode flat row — saves the complete ordered list including prev.
+const onFullRowDragEnd = async () => {
+  isDragging.value = false
+  await nextTick()
+  await nextTick()
+  const cards = _fullRow.value ?? fullRowCards.value
+  _fullRow.value = null
+  emit('update-settings', { ...props.settings, cardOrder: cards.map(c => c.id) })
 }
 
 let _resizeObserver = null
@@ -664,7 +771,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, isDragging, onColReorder, onDragEnd, logoUrl })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, _fullRow, logoUrl })
 </script>
 
 <style scoped>
@@ -762,18 +869,34 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   gap: 4px 12px;
 }
 
-.eqv3-hero-left {
+/* Hero blocks — narrow/wide: symbol-block left, price-block right, identity hidden or below */
+.eqv3-hero-symbol-block {
   display: flex;
-  flex-direction: column;
-  gap: 3px;
-  flex: 1;
-  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
-.eqv3-hero-identity {
+.eqv3-hero-price-block {
   display: flex;
-  align-items: stretch;
-  gap: 8px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.eqv3-hero-identity-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  width: 100%;
+}
+
+.eqv3-hero-symbol-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .eqv3-logo {
@@ -782,21 +905,6 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   object-fit: contain;
   border-radius: 4px;
   flex-shrink: 0;
-  align-self: center;
-}
-
-.eqv3-hero-identity-text {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
-  overflow: hidden;
-}
-
-.eqv3-hero-symbol-row {
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 
 .eqv3-hero-company-name {
@@ -814,14 +922,6 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.eqv3-hero-right {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 2px;
-  flex-shrink: 0;
 }
 
 .eqv3-symbol {
@@ -1071,6 +1171,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 }
 
 /* ── Sections: narrow (< 480px) — single flex column ── */
+/* Breakpoint constants — must match BREAKPOINTS in JS: WIDE=480, FULL=960 */
 .eqv3-sections {
   display: flex;
   flex-direction: column;
@@ -1083,11 +1184,21 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   gap: 8px;
 }
 
-/* Col-2 and col-3 hidden at narrow */
-.eqv3-col-2, .eqv3-col-3 { display: none; }
+/* Col-2 hidden at narrow */
+.eqv3-col-2 { display: none; }
 
-/* Previous Day always full width */
+/* Previous Day pinned row: full width at narrow/wide */
 .eqv3-prev-row { width: 100%; }
+
+/* Full-row draggable: horizontal flex, cards stretch to equal height */
+.eqv3-full-row-draggable {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
 
 /* ── WIDE mode (480px+): two flex columns ── */
 @container (min-width: 480px) {
@@ -1104,10 +1215,56 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   .eqv3-prev-row { flex-basis: 100%; }
 }
 
-/* ── FULL mode (960px+): three columns ── */
+/* ── FULL mode (960px+): hero left, single horizontal card row right ── */
 @container (min-width: 960px) {
   .eqv3-symbol { font-size: 22px; }
   .eqv3-price  { font-size: 30px; }
-  .eqv3-col-3  { display: flex; flex: 1; }
+
+  /* Body: hero on the left, sections filling remaining width */
+  .eqv3-body {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  /* Hero: fixed-width left column, full height of the row */
+  .eqv3-hero {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    justify-content: flex-start;
+    flex-shrink: 0;
+    width: 360px;
+    align-self: stretch;
+  }
+  /* Full-mode column order: symbol (1), price (2), identity (3) */
+  .eqv3-hero-symbol-block  { order: 1; }
+  .eqv3-hero-price-block   { order: 2; align-items: flex-start; width: 100%; }
+  .eqv3-hero-identity-block {
+    order: 3;
+    margin-top: 8px;
+  }
+  /* Company name + sic allowed to wrap at full mode (enough width) */
+  .eqv3-hero-company-name  { white-space: normal; }
+  .eqv3-hero-sic           { white-space: normal; }
+  .eqv3-since-open { text-align: left; }
+
+  /* Sections: fills remaining width, allows horizontal scroll if cards overflow */
+  .eqv3-sections {
+    flex: 1;
+    flex-direction: row;
+    align-items: stretch;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+  }
+
+  /* Cards in full-row draggable: no shrink, stretch to full row height */
+  .eqv3-full-row-draggable .eqv3-card {
+    flex: 0 0 auto;
+    min-width: 140px;
+    align-self: stretch;
+  }
+  .eqv3-full-row-draggable .eqv3-company-card { min-width: 200px; }
+  .eqv3-full-row-draggable .eqv3-prev-card    { min-width: 200px; }
+  .eqv3-prev-row { display: none; }
 }
 </style>

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
@@ -246,7 +246,7 @@ describe('Price hero', () => {
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
 
-    // Assert
+    // Assert: pinned prev-row at narrow has 6 chips
     const chips = wrapper.findAll('.eqv3-chip')
     expect(chips.length).toBe(6)
     const labels = chips.map(c => c.find('.eqv3-chip-label').text())
@@ -474,6 +474,9 @@ describe('Massive API — short interest and volume', () => {
 })
 
 describe('Card layout and settings', () => {
+  // CARD_REGISTRY default order: today, prev, volume, session, short, company
+  const REGISTRY_IDS = ['today', 'prev', 'volume', 'session', 'short', 'company']
+
   test('test_EnhancedQuoteV3_with_isLocked_true_expect_drag_handles_hidden', async () => {
     // Arrange
     const wrapper = mountWidget({ isLocked: true })
@@ -508,12 +511,20 @@ describe('Card layout and settings', () => {
 
     // Assert
     const ids = wrapper.vm.activeCards.map(c => c.id)
-    expect(ids).toEqual(['session', 'today', 'volume', 'short', 'company'])
+    expect(ids).toEqual(REGISTRY_IDS)
+  })
+
+  test('test_EnhancedQuoteV3_activeCards_has_6_entries_by_default', () => {
+    // Arrange / Act
+    const wrapper = mountWidget({ settings: {} })
+
+    // Assert
+    expect(wrapper.vm.activeCards.length).toBe(6)
   })
 
   test('test_EnhancedQuoteV3_with_custom_cardOrder_expect_activeCards_respects_order', () => {
-    // Arrange
-    const customOrder = ['volume', 'session', 'company', 'short', 'today']
+    // Arrange: full 6-card custom order including prev
+    const customOrder = ['volume', 'session', 'company', 'short', 'today', 'prev']
 
     // Act
     const wrapper = mountWidget({ settings: { cardOrder: customOrder } })
@@ -534,7 +545,8 @@ describe('Card layout and settings', () => {
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
 
-    // Act: simulate col1 reorder then drag end (narrow mode — all cards in col1)
+    // Act: simulate col1 reorder then drag end (narrow mode — all non-prev cards in col1)
+    // At narrow, col1Cards excludes 'prev'; onDragEnd appends 'prev' at end
     const reordered = ['today', 'session', 'volume', 'short', 'company']
     wrapper.vm.onColReorder(
       reordered.map(id => ({ id, label: id })),
@@ -543,9 +555,9 @@ describe('Card layout and settings', () => {
     await wrapper.vm.onDragEnd()
     await wrapper.vm.$nextTick()
 
-    // Assert
+    // Assert: saved order is reordered cards + 'prev' appended at end
     expect(updateSettingsCalls.length).toBe(1)
-    expect(updateSettingsCalls[0].cardOrder).toEqual(reordered)
+    expect(updateSettingsCalls[0].cardOrder).toEqual([...reordered, 'prev'])
   })
 
   test('test_EnhancedQuoteV3_with_narrow_layout_default_expect_col2_not_rendered', async () => {
@@ -563,7 +575,7 @@ describe('Card layout and settings', () => {
     expect(wrapper.find('.eqv3-col-2').exists()).toBe(false)
   })
 
-  test('test_EnhancedQuoteV3_with_full_layoutMode_expect_col3_rendered', async () => {
+  test('test_EnhancedQuoteV3_with_full_layoutMode_expect_full_row_draggable_rendered', async () => {
     // Arrange
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
@@ -575,12 +587,19 @@ describe('Card layout and settings', () => {
     wrapper.vm.layoutMode = 'full'
     await wrapper.vm.$nextTick()
 
-    // Assert
-    expect(wrapper.find('.eqv3-col-3').exists()).toBe(true)
-    expect(wrapper.vm.col3Cards.map(c => c.id)).toEqual(['company'])
+    // Assert: full-row draggable rendered (single horizontal row of all cards)
+    expect(wrapper.find('.eqv3-full-row-draggable').exists()).toBe(true)
+    // col-3 no longer exists at full mode (replaced by flat row)
+    expect(wrapper.find('.eqv3-col-3').exists()).toBe(false)
+    // col3Cards is always empty (kept for API compat)
+    expect(wrapper.vm.col3Cards).toEqual([])
+    // fullRowCards includes all 6 registry cards
+    expect(wrapper.vm.fullRowCards.map(c => c.id)).toContain('company')
+    expect(wrapper.vm.fullRowCards.map(c => c.id)).toContain('prev')
+    expect(wrapper.vm.fullRowCards.length).toBe(6)
   })
 
-  test('test_EnhancedQuoteV3_with_col3Cards_expect_empty_when_not_full_mode', async () => {
+  test('test_EnhancedQuoteV3_with_col3Cards_always_empty', async () => {
     // Arrange / Act
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
@@ -595,6 +614,82 @@ describe('Card layout and settings', () => {
     wrapper.vm.layoutMode = 'wide'
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.col3Cards).toEqual([])
+
+    // Full
+    wrapper.vm.layoutMode = 'full'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.col3Cards).toEqual([])
+  })
+
+  test('test_EnhancedQuoteV3_prev_is_in_activeCards_and_pinned_at_narrow_in_draggable_at_full', async () => {
+    // Arrange: narrow mode (default)
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await wrapper.vm.$nextTick()
+
+    // Assert at narrow: prev-row exists as pinned element
+    expect(wrapper.find('.eqv3-prev-row').exists()).toBe(true)
+    expect(wrapper.find('.eqv3-prev-card').exists()).toBe(true)
+    // prev IS in activeCards (it drives both the pinned row and the full-mode card)
+    expect(wrapper.vm.activeCards.map(c => c.id)).toContain('prev')
+
+    // At full mode: fullRowCards includes prev (it becomes a draggable card)
+    wrapper.vm.layoutMode = 'full'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.fullRowCards.map(c => c.id)).toContain('prev')
+  })
+
+  test('test_EnhancedQuoteV3_onFullRowDragEnd_emits_update_settings_with_reordered_cardOrder', async () => {
+    // Arrange
+    const updateSettingsCalls = []
+    const wrapper = mount(EnhancedQuoteV3, {
+      props: { isLocked: false, settings: {} },
+      attrs: { 'onUpdate-settings': (payload) => updateSettingsCalls.push(payload) },
+    })
+    wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    wrapper.vm.layoutMode = 'full'
+    await wrapper.vm.$nextTick()
+
+    // Act: simulate full-row drag — prev moved to first position
+    const reordered = ['prev', 'today', 'volume', 'session', 'short', 'company']
+    wrapper.vm._fullRow = reordered.map(id => ({ id, label: id }))
+    await wrapper.vm.onFullRowDragEnd()
+    await wrapper.vm.$nextTick()
+
+    // Assert: full reordered list saved including prev in its new position
+    expect(updateSettingsCalls.length).toBe(1)
+    expect(updateSettingsCalls[0].cardOrder).toEqual(reordered)
+  })
+})
+
+describe('Hero identity blocks', () => {
+  test('test_EnhancedQuoteV3_hero_uses_semantic_blocks_for_symbol_price_and_identity', async () => {
+    // Arrange
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes('/v3/reference/tickers/'))
+        return Promise.resolve({ ok: true, json: async () => ({
+          results: { name: 'Apple Inc.', sic_description: 'Electronic Computers' }
+        })})
+      return Promise.resolve({ ok: true, json: async () => ({ results: [] }) })
+    })
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'AAPL'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    // Assert: symbol in symbol-block, company info in identity-block
+    expect(wrapper.find('.eqv3-hero-symbol-block').exists()).toBe(true)
+    expect(wrapper.find('.eqv3-hero-symbol-block .eqv3-symbol').exists()).toBe(true)
+    expect(wrapper.find('.eqv3-hero-price-block').exists()).toBe(true)
+    expect(wrapper.find('.eqv3-hero-identity-block').exists()).toBe(true)
+    expect(wrapper.find('.eqv3-hero-identity-block .eqv3-hero-company-name').text()).toBe('Apple Inc.')
+    expect(wrapper.find('.eqv3-hero-identity-block .eqv3-hero-sic').text()).toBe('Electronic Computers')
   })
 })
 
@@ -635,5 +730,8 @@ describe('Exposed interface', () => {
     expect(wrapper.vm.activeCards).toBeDefined()
     expect(wrapper.vm.isDragging).toBeDefined()
     expect(wrapper.vm.logoUrl).toBeDefined()
+    expect(wrapper.vm.fullRowCards).toBeDefined()
+    expect(wrapper.vm.onFullRowDragEnd).toBeDefined()
+    expect(wrapper.vm._fullRow).toBeDefined()
   })
 })


### PR DESCRIPTION
EQV3 is being promoted as the primary widget. EQV2 is being decommissioned. This backports all layout improvements from EQV2 to EQV3.

## What changed

### Hero restructure (3 semantic blocks)
- `eqv3-hero-symbol-block` — ticker + flame icon + logo
- `eqv3-hero-price-block` — price, change badge, since-open
- `eqv3-hero-identity-block` — company name + sic

At full mode, CSS `order` properties give the correct stack: ticker → price → change → since open → (gap) → company name → sic.

### Full-mode horizontal layout (≥960px)
- `eqv3-body` becomes `flex-direction: row` — hero is a fixed 360px left column
- All cards render in a single `eqv3-full-row-draggable` horizontal row to the right
- Previous Day moves from pinned bottom row → draggable card in the flat row

### Previous Day as a card
- Added `{ id: 'prev', label: 'Previous Day' }` to `CARD_REGISTRY`
- At narrow/wide: still pinned as full-width row at bottom (filtered out of col1/col2)
- At full mode: appears as a draggable card alongside all others

### New computed/methods
- `fullRowCards` — all `activeCards` at full mode, `[]` otherwise
- `onFullRowDragEnd` — persists full card order including `prev` in its dragged position
- `col3Cards` — always `[]` (kept for API compatibility)

### Company description wrapping
Description text wraps at ~80 chars (`white-space: normal; max-width: 80ch`) — matching EQV2CompanyCard fix.

## Tests
- 153/153 passing across 8 spec files
- EQV3 spec updated: 6-card registry, full-row layout test, `prev` in activeCards, `onFullRowDragEnd` test, hero block assertions

refs #133