### PR TITLE
fix(eqv2,eqv3): full-row drag snap-back on drop

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV2.vue
+++ b/client/src/components/widgets/EnhancedQuoteV2.vue
@@ -74,8 +74,8 @@
             handle=".eqv2-drag-handle"
             class="eqv2-full-row-draggable"
             @start="isDragging = true"
-            @end="onFullRowDragEnd()"
-            @update:model-value="(val) => (_fullRow.value = val)"
+            @end="isDragging = false"
+            @update:model-value="onFullRowReorder"
           >
             <template #item="{ element: card }">
               <div :key="card.id" :class="['eqv2-card', `eqv2-${card.id}-card`]">
@@ -516,14 +516,15 @@ const onDragEnd = async () => {
 }
 
 // Drag end for the full-mode flat row — saves the complete ordered list including prev.
-const onFullRowDragEnd = async () => {
-  isDragging.value = false
-  await nextTick()
-  await nextTick()
-  const cards = _fullRow.value ?? fullRowCards.value
-  _fullRow.value = null
-  emit('update-settings', { ...props.settings, cardOrder: cards.map(c => c.id) })
+// Full-mode flat row reorder — fires from @update:model-value (after vuedraggable updates the list).
+// NOTE: vuedraggable fires @end before @update:model-value, so we cannot read the new order in @end.
+// Drive the emit from @update:model-value directly to guarantee we have the updated list.
+const onFullRowReorder = (newVal) => {
+  emit('update-settings', { ...props.settings, cardOrder: newVal.map(c => c.id) })
 }
+
+// Kept for defineExpose / test compatibility — no longer drives full-row emit.
+const onFullRowDragEnd = () => { isDragging.value = false }
 
 let _resizeObserver = null
 onMounted(() => {
@@ -764,7 +765,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, _fullRow })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, onFullRowReorder, _fullRow })
 </script>
 
 <style scoped>

--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -75,8 +75,8 @@
             handle=".eqv3-drag-handle"
             class="eqv3-full-row-draggable"
             @start="isDragging = true"
-            @end="onFullRowDragEnd()"
-            @update:model-value="(val) => (_fullRow.value = val)"
+            @end="isDragging = false"
+            @update:model-value="onFullRowReorder"
           >
             <template #item="{ element: card }">
               <div :key="card.id" :class="['eqv3-card', `eqv3-${card.id}-card`]">
@@ -509,15 +509,15 @@ const onDragEnd = async () => {
   emit('update-settings', { ...props.settings, cardOrder: [...orderedNonPrev, 'prev'] })
 }
 
-// Drag end for the full-mode flat row — saves the complete ordered list including prev.
-const onFullRowDragEnd = async () => {
-  isDragging.value = false
-  await nextTick()
-  await nextTick()
-  const cards = _fullRow.value ?? fullRowCards.value
-  _fullRow.value = null
-  emit('update-settings', { ...props.settings, cardOrder: cards.map(c => c.id) })
+// Full-mode flat row reorder — fires from @update:model-value (after vuedraggable updates the list).
+// NOTE: vuedraggable fires @end before @update:model-value, so we cannot read the new order in @end.
+// Drive the emit from @update:model-value directly to guarantee we have the updated list.
+const onFullRowReorder = (newVal) => {
+  emit('update-settings', { ...props.settings, cardOrder: newVal.map(c => c.id) })
 }
+
+// Kept for defineExpose / test compatibility — no longer drives full-row emit.
+const onFullRowDragEnd = () => { isDragging.value = false }
 
 let _resizeObserver = null
 onMounted(() => {
@@ -771,7 +771,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, _fullRow, logoUrl })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, onFullRowReorder, _fullRow, logoUrl })
 </script>
 
 <style scoped>

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV2.spec.js
@@ -956,8 +956,11 @@ describe('EnhancedQuoteV2', () => {
       )
     })
 
-    it('onFullRowDragEnd emits update-settings with reordered full-row cardOrder including prev', async () => {
+    it('onFullRowReorder emits update-settings with reordered full-row cardOrder including prev', async () => {
       // Arrange
+      // vuedraggable fires @update:model-value (onFullRowReorder) AFTER @end,
+      // so the emit is driven directly from the updated list rather than reading
+      // a stale _fullRow ref set in @end.
       const updateSettingsCalls = []
       const wrapper = mount(EnhancedQuoteV2, {
         props: { isLocked: false, settings: {} },
@@ -969,11 +972,9 @@ describe('EnhancedQuoteV2', () => {
       wrapper.vm.layoutMode = 'full'
       await wrapper.vm.$nextTick()
 
-      // Act: simulate full-row drag — prev moved to first position
+      // Act: simulate vuedraggable @update:model-value — prev moved to first position
       const reordered = ['prev', 'today', 'volume', 'session', 'short', 'company']
-      wrapper.vm._fullRow = reordered.map(id => ({ id, label: id }))
-      await wrapper.vm.onFullRowDragEnd()
-      await wrapper.vm.$nextTick()
+      wrapper.vm.onFullRowReorder(reordered.map(id => ({ id, label: id })))
 
       // Assert: full reordered list saved including prev in its new position
       expect(updateSettingsCalls.length).toBe(1)

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
@@ -641,8 +641,11 @@ describe('Card layout and settings', () => {
     expect(wrapper.vm.fullRowCards.map(c => c.id)).toContain('prev')
   })
 
-  test('test_EnhancedQuoteV3_onFullRowDragEnd_emits_update_settings_with_reordered_cardOrder', async () => {
+  test('test_EnhancedQuoteV3_onFullRowReorder_emits_update_settings_with_reordered_cardOrder', async () => {
     // Arrange
+    // vuedraggable fires @update:model-value (onFullRowReorder) AFTER @end,
+    // so the emit is driven directly from the updated list rather than reading
+    // a stale _fullRow ref set in @end.
     const updateSettingsCalls = []
     const wrapper = mount(EnhancedQuoteV3, {
       props: { isLocked: false, settings: {} },
@@ -654,11 +657,9 @@ describe('Card layout and settings', () => {
     wrapper.vm.layoutMode = 'full'
     await wrapper.vm.$nextTick()
 
-    // Act: simulate full-row drag — prev moved to first position
+    // Act: simulate vuedraggable @update:model-value — prev moved to first position
     const reordered = ['prev', 'today', 'volume', 'session', 'short', 'company']
-    wrapper.vm._fullRow = reordered.map(id => ({ id, label: id }))
-    await wrapper.vm.onFullRowDragEnd()
-    await wrapper.vm.$nextTick()
+    wrapper.vm.onFullRowReorder(reordered.map(id => ({ id, label: id })))
 
     // Assert: full reordered list saved including prev in its new position
     expect(updateSettingsCalls.length).toBe(1)
@@ -732,6 +733,7 @@ describe('Exposed interface', () => {
     expect(wrapper.vm.logoUrl).toBeDefined()
     expect(wrapper.vm.fullRowCards).toBeDefined()
     expect(wrapper.vm.onFullRowDragEnd).toBeDefined()
+    expect(wrapper.vm.onFullRowReorder).toBeDefined()
     expect(wrapper.vm._fullRow).toBeDefined()
   })
 })


### PR DESCRIPTION
Fixes the full-row drag snap-back bug reported in issue #162.

## Problem

In full mode (≥960px), dragging cards in the horizontal row appeared to work visually but snapped back to the original order on drop. The reorder was not persisted.

## Root Cause

See issue #162 for full analysis. Short version: vuedraggable fires events in order `@start → @end → @update:model-value`. The old code read `_fullRow` in `@end`, but `_fullRow` is only set by `@update:model-value` — which hadn't fired yet. So the emitted `cardOrder` was always the pre-drag original.

## Fix

Drive the emit from a new `onFullRowReorder` handler bound directly to `@update:model-value`. This receives the already-updated list from vuedraggable with no timing issues. `onFullRowDragEnd` is retained (resets `isDragging` only) for API compat.

Applies to both EQV2 and EQV3 since both had the same implementation.

## Tests

Updated `onFullRowDragEnd` test → `onFullRowReorder` test in both spec files. 153/153 passing.

refs #133
refs #162