### PR TITLE
feat: apply Phantom Dark theme tokens to app chrome

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -23,8 +23,8 @@ onMounted(() => {
 
 body {
   font-family: system-ui, -apple-system, sans-serif;
-  background: #0a0a0a;
-  color: #e0e0e0;
+  background: var(--pd-bg);
+  color: var(--pd-text);
 }
 
 #app {

--- a/client/src/assets/base.css
+++ b/client/src/assets/base.css
@@ -21,33 +21,30 @@
   --vt-c-text-dark-2: rgba(235, 235, 235, 0.64);
 }
 
-/* semantic color variables for this project */
+/* ── Phantom Dark theme tokens ── */
 :root {
-  --color-background: var(--vt-c-white);
-  --color-background-soft: var(--vt-c-white-soft);
-  --color-background-mute: var(--vt-c-white-mute);
+  --pd-bg:           #0d0d12;
+  --pd-surface:      #141420;
+  --pd-surface-2:    #1a1a2e;
+  --pd-border:       #1e1e2e;
+  --pd-border-hover: #2e2e4e;
+  --pd-text:         #e2e2f0;
+  --pd-text-muted:   #afafaf;
+  --pd-accent:       #7c3aed;
+  --pd-accent-hover: #6d28d9;
+  --pd-positive:     #22c55e;
+  --pd-negative:     #ef4444;
 
-  --color-border: var(--vt-c-divider-light-2);
-  --color-border-hover: var(--vt-c-divider-light-1);
-
-  --color-heading: var(--vt-c-text-light-1);
-  --color-text: var(--vt-c-text-light-1);
+  /* map Vue scaffold semantic vars to Phantom Dark */
+  --color-background:      var(--pd-bg);
+  --color-background-soft: var(--pd-surface);
+  --color-background-mute: var(--pd-surface-2);
+  --color-border:          var(--pd-border);
+  --color-border-hover:    var(--pd-border-hover);
+  --color-heading:         var(--pd-text);
+  --color-text:            var(--pd-text);
 
   --section-gap: 160px;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-background: var(--vt-c-black);
-    --color-background-soft: var(--vt-c-black-soft);
-    --color-background-mute: var(--vt-c-black-mute);
-
-    --color-border: var(--vt-c-divider-dark-2);
-    --color-border-hover: var(--vt-c-divider-dark-1);
-
-    --color-heading: var(--vt-c-text-dark-1);
-    --color-text: var(--vt-c-text-dark-2);
-  }
 }
 
 *,

--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -833,8 +833,8 @@ onBeforeUnmount(() => {
 
 .dashboard-header {
   padding: 2px 4px;
-  background: #1a1a1a;
-  border-bottom: 1px solid #2a2a2a;
+  background: var(--pd-surface-2);
+  border-bottom: 1px solid var(--pd-border);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -844,7 +844,7 @@ onBeforeUnmount(() => {
 .dashboard-header h1 {
   font-size: 20px;
   font-weight: 600;
-  color: #fff;
+  color: var(--pd-text);
 }
 
 .layout-controls {
@@ -868,10 +868,10 @@ onBeforeUnmount(() => {
 
 .select-trigger {
   padding: 6px 12px;
-  background: #2d2d2d;
-  border: 1px solid #444;
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border);
   border-radius: 4px;
-  color: #fff;
+  color: var(--pd-text);
   font-size: 13px;
   cursor: pointer;
   display: flex;
@@ -882,16 +882,16 @@ onBeforeUnmount(() => {
 }
 
 .select-trigger:hover {
-  background: #3d3d3d;
+  background: var(--pd-surface-2);
 }
 
 .select-trigger.active {
-  border-color: #4ade80;
-  background: #3d3d3d;
+  border-color: var(--pd-accent);
+  background: var(--pd-surface-2);
 }
 
 .select-trigger .placeholder {
-  color: #666;
+  color: var(--pd-text-muted);
 }
 
 .select-trigger .arrow {
@@ -908,21 +908,21 @@ onBeforeUnmount(() => {
   top: calc(100% + 4px);
   left: 0;
   right: 0;
-  background: #2d2d2d;
-  border: 1px solid #444;
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border);
   border-radius: 4px;
   max-height: 300px;
   overflow-y: auto;
   z-index: 100;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
 }
 
 .select-option {
   padding: 8px 12px;
-  color: #fff;
+  color: var(--pd-text);
   font-size: 13px;
   cursor: pointer;
-  border-bottom: 1px solid #1a1a1a;
+  border-bottom: 1px solid var(--pd-border);
   transition: background 0.1s;
   display: flex;
   justify-content: space-between;
@@ -940,7 +940,7 @@ onBeforeUnmount(() => {
   background: transparent;
   border: 1px solid transparent;
   border-radius: 3px;
-  color: #94a3b8;
+  color: var(--pd-text-muted);
   cursor: pointer;
   font-size: 14px;
   line-height: 1;
@@ -949,9 +949,9 @@ onBeforeUnmount(() => {
 }
 
 .option-preview-btn:hover {
-  background: #1a1a1a;
-  border-color: #3b82f6;
-  color: #3b82f6;
+  background: var(--pd-bg);
+  border-color: var(--pd-accent);
+  color: var(--pd-accent);
 }
 
 .select-option:last-child {
@@ -959,32 +959,32 @@ onBeforeUnmount(() => {
 }
 
 .select-option:hover:not(.disabled) {
-  background: #3d3d3d;
+  background: var(--pd-surface-2);
 }
 
 .select-option.selected {
-  background: #1e3a2e;
-  color: #4ade80;
+  background: rgba(124, 58, 237, 0.15);
+  color: var(--pd-accent);
 }
 
 .select-option.disabled {
-  color: #666;
+  color: var(--pd-text-muted);
   cursor: default;
 }
 
 .btn-icon {
   padding: 4px 8px;
-  background: #2d2d2d;
-  border: 1px solid #444;
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border);
   border-radius: 4px;
-  color: #fff;
+  color: var(--pd-text);
   cursor: pointer;
   font-size: 16px;
   line-height: 1;
 }
 
 .btn-icon:hover:not(:disabled) {
-  background: #3d3d3d;
+  background: var(--pd-surface-2);
 }
 
 .btn-icon:disabled {
@@ -999,9 +999,9 @@ onBeforeUnmount(() => {
 
 .auto-save-indicator {
   font-size: 12px;
-  color: #94a3b8;
+  color: var(--pd-text-muted);
   padding: 4px 8px;
-  background: rgba(148, 163, 184, 0.1);
+  background: rgba(175, 175, 175, 0.08);
   border-radius: 4px;
 }
 

--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -52,9 +52,9 @@ const selectWidget = (widgetType) => {
 }
 
 .menu-toggle {
-  background: #2d2d2d;
-  color: #fff;
-  border: 1px solid #444;
+  background: var(--pd-surface);
+  color: var(--pd-text);
+  border: 1px solid var(--pd-border);
   padding: 2px 6px;
   border-radius: 6px;
   cursor: pointer;
@@ -63,13 +63,14 @@ const selectWidget = (widgetType) => {
 }
 
 .menu-toggle:hover {
-  background: #3d3d3d;
+  background: var(--pd-surface-2);
+  border-color: var(--pd-accent);
 }
 
 .menu-panel {
   margin-top: 8px;
-  background: #1e1e1e;
-  border: 1px solid #333;
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border);
   border-radius: 2px;
   padding: 2px;
   display: flex;
@@ -79,9 +80,9 @@ const selectWidget = (widgetType) => {
 }
 
 .widget-button {
-  background: #2d2d2d;
-  border: 1px solid #333;
-  color: #fff;
+  background: var(--pd-surface-2);
+  border: 1px solid var(--pd-border);
+  color: var(--pd-text);
   padding: 2px;
   border-radius: 4px;
   cursor: pointer;
@@ -93,6 +94,7 @@ const selectWidget = (widgetType) => {
 }
 
 .widget-button:hover {
-  background: #3d3d3d;
+  background: var(--pd-bg);
+  border-color: var(--pd-accent);
 }
 </style>

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -169,8 +169,8 @@ const freshnessIcon = computed(() => {
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: #1e1e1e;
-  border: 1px solid #333;
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border);
   border-radius: 4px;
   overflow: hidden;
   touch-action: none;
@@ -181,8 +181,8 @@ const freshnessIcon = computed(() => {
   justify-content: space-between;
   align-items: center;
   padding: 2px 4px;
-  background: #2d2d2d;
-  border-bottom: 1px solid #333;
+  background: var(--pd-surface-2);
+  border-bottom: 1px solid var(--pd-border);
   cursor: move;
   gap: 6px;
   /* Smooth transition when link color applied */
@@ -192,17 +192,17 @@ const freshnessIcon = computed(() => {
 .widget-title {
   font-size: 14px;
   font-weight: 600;
-  color: #fff;
+  color: var(--pd-text);
   flex: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .widget-title--input {
-  background: #2a2a2a;
-  border: 1px solid #555;
+  background: var(--pd-surface);
+  border: 1px solid var(--pd-border-hover);
   border-radius: 3px;
-  color: #fff;
+  color: var(--pd-text);
   padding: 1px 4px;
   outline: none;
   min-width: 0;
@@ -235,8 +235,8 @@ const freshnessIcon = computed(() => {
 .color-swatch--active { border: 2px solid #fff; transform: scale(1.2); }
 
 .color-swatch--none {
-  background: #333;
-  color: #666;
+  background: var(--pd-surface-2);
+  color: var(--pd-text-muted);
   font-size: 10px;
 }
 .color-swatch--none.color-swatch--active { color: #aaa; }
@@ -252,7 +252,7 @@ const freshnessIcon = computed(() => {
 .close-btn {
   background: none;
   border: none;
-  color: #999;
+  color: var(--pd-text-muted);
   cursor: pointer;
   font-size: 16px;
   padding: 0;
@@ -264,7 +264,7 @@ const freshnessIcon = computed(() => {
   border-radius: 3px;
   flex-shrink: 0;
 }
-.close-btn:hover { background: #3d3d3d; color: #fff; }
+.close-btn:hover { background: var(--pd-surface-2); color: var(--pd-text); }
 
 .widget-content {
   flex: 1;


### PR DESCRIPTION
Unifies the app chrome with EQV3's Phantom Dark palette so the widget doesn't look like an oddity.

## What changed

**`base.css`** — defines `--pd-*` custom properties (bg, surface, surface-2, border, border-hover, text, text-muted, accent, positive, negative) and maps the Vue scaffold `--color-*` vars to them. One place to change the palette.

**`App.vue`** — body bg/text use tokens.

**`WidgetWrapper.vue`** — widget shell, header bar, title, rename input, close button, color swatch none-state all use tokens.

**`DashboardGrid.vue`** — toolbar, layout selector trigger/dropdown/options, icon buttons, auto-save indicator all use tokens. Accent: `#4ade80` → `var(--pd-accent)` (violet). Selected state: green-tinted → violet-tinted.

**`WidgetMenu.vue`** — toggle button, panel, widget buttons use tokens.

## Out of scope
Other widgets (GenericScannerTable, Quote, news) are all dark and blend fine. Comprehensive widget theming is a separate effort.

91/91 tests passing.

refs #133