### PR TITLE
feat(eqv3): logo/icon toggle in edit mode

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -12,6 +12,13 @@
         @keyup.escape="inputTicker = ''"
       />
       <button class="eqv3-go-btn" @click="applyInput" @touchend.prevent="applyInput" title="Load quote">Go</button>
+      <!-- Branding toggle — only in edit mode when both URLs are available -->
+      <button
+        v-if="!isLocked && logoUrl && iconUrl"
+        class="eqv3-branding-toggle"
+        :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
+        @click="toggleBranding"
+      >{{ brandingMode === 'logo' ? '🔲 icon' : '🖼 logo' }}</button>
     </div>
 
     <!-- No ticker yet -->
@@ -30,9 +37,9 @@
     <div v-else class="eqv3-body">
       <!-- Price Hero -->
       <div class="eqv3-hero">
-        <!-- Symbol block: symbol + flame icon + logo -->
+        <!-- Symbol block: symbol + flame icon + branding (logo or icon) -->
         <div class="eqv3-hero-symbol-block">
-          <img v-if="logoUrl" :src="logoUrl + '?apiKey=' + config?.massiveApiKey" class="eqv3-logo" alt="Company logo" />
+          <img v-if="activeBrandingUrl" :src="activeBrandingUrl + '?apiKey=' + config?.massiveApiKey" class="eqv3-logo" :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'" />
           <div class="eqv3-hero-symbol-row">
             <span class="eqv3-symbol">{{ quoteData.symbol }}</span>
             <img v-if="quoteFlame" :src="quoteFlame.src" :title="quoteFlame.tooltip" class="eqv3-flame-icon" />
@@ -563,16 +570,29 @@ const companyData = ref({})
 const companyLoading = ref(false)
 const descExpanded = ref(false)
 const logoUrl = ref(null)
+const iconUrl = ref(null)
 
 // Short interest — fetched from Massive REST API
 const shortInterestData = ref({})
 const shortInterestLoading = ref(false)
+
+// Branding mode: 'logo' (default) or 'icon' — persisted in settings
+const brandingMode = computed(() => props.settings?.brandingMode ?? 'logo')
+const activeBrandingUrl = computed(() => {
+  if (brandingMode.value === 'icon') return iconUrl.value || logoUrl.value || null
+  return logoUrl.value || iconUrl.value || null
+})
+const toggleBranding = () => {
+  const next = brandingMode.value === 'logo' ? 'icon' : 'logo'
+  emit('update-settings', { ...props.settings, brandingMode: next })
+}
 
 const fetchCompany = async (symbol) => {
   if (!symbol) return
   companyLoading.value = true
   companyData.value = {}
   logoUrl.value = null
+  iconUrl.value = null
   try {
     const url = `https://api.massive.com/v3/reference/tickers/${symbol}?apiKey=${config.value?.massiveApiKey}`
     const resp = await fetch(url)
@@ -590,6 +610,7 @@ const fetchCompany = async (symbol) => {
         list_date: results.list_date ?? null,
       }
       logoUrl.value = results.branding?.logo_url ?? null
+      iconUrl.value = results.branding?.icon_url ?? null
     }
   } catch (e) {
     console.warn(`[EnhancedQuoteV3] company fetch failed for ${symbol}:`, e)
@@ -665,6 +686,7 @@ watch(activeTicker, (newTicker) => {
   companyData.value = {}
   shortInterestData.value = {}
   logoUrl.value = null
+  iconUrl.value = null
   descExpanded.value = false
   if (newTicker) {
     fetchCompany(newTicker)
@@ -756,7 +778,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, onFullRowReorder, _fullRow, logoUrl })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, onFullRowReorder, _fullRow, logoUrl, iconUrl, brandingMode, activeBrandingUrl, toggleBranding })
 </script>
 
 <style scoped>
@@ -817,6 +839,18 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   flex-shrink: 0;
 }
 .eqv3-go-btn:hover { border-color: var(--accent); color: #fff; }
+.eqv3-branding-toggle {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 4px 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+.eqv3-branding-toggle:hover { border-color: var(--accent); color: var(--text-primary); }
 
 /* ── Empty / waiting states ── */
 .eqv3-empty {

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
@@ -388,6 +388,123 @@ describe('Massive API — company data', () => {
     expect(wrapper.vm.companyData.total_employees).toBe(127855)
     expect(wrapper.vm.companyData.list_date).toBe('2010-06-29')
   })
+
+  test('test_EnhancedQuoteV3_with_default_settings_expect_logo_mode_and_logo_url_shown', async () => {
+    // Arrange: no brandingMode in settings — defaults to logo
+    mockMassiveFetch()
+    const wrapper = mountWidget()
+    wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    // Assert: brandingMode defaults to logo; activeBrandingUrl is logo_url
+    expect(wrapper.vm.brandingMode).toBe('logo')
+    expect(wrapper.vm.activeBrandingUrl).toContain('logo.svg')
+    const img = wrapper.find('.eqv3-logo')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toContain('logo.svg')
+  })
+
+  test('test_EnhancedQuoteV3_with_brandingMode_icon_expect_icon_url_shown', async () => {
+    // Arrange: settings.brandingMode = 'icon'
+    mockMassiveFetch()
+    const wrapper = mount(EnhancedQuoteV3, {
+      props: { isLocked: false, settings: { brandingMode: 'icon' } },
+      global: { stubs: { draggable: { template: '<div><slot name="item" v-for="e in list" :element="e" /></div>', props: ['modelValue', 'list'] } } },
+    })
+    wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    // Assert: activeBrandingUrl is icon_url
+    expect(wrapper.vm.brandingMode).toBe('icon')
+    expect(wrapper.vm.activeBrandingUrl).toContain('icon.png')
+    const img = wrapper.find('.eqv3-logo')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toContain('icon.png')
+  })
+
+  test('test_EnhancedQuoteV3_toggleBranding_emits_update_settings_with_new_brandingMode', async () => {
+    // Arrange
+    const updateSettingsCalls = []
+    mockMassiveFetch()
+    const wrapper = mount(EnhancedQuoteV3, {
+      props: { isLocked: false, settings: { brandingMode: 'logo' } },
+      attrs: { 'onUpdate-settings': (payload) => updateSettingsCalls.push(payload) },
+      global: { stubs: { draggable: { template: '<div><slot name="item" v-for="e in list" :element="e" /></div>', props: ['modelValue', 'list'] } } },
+    })
+    wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    // Act: toggle from logo → icon
+    wrapper.vm.toggleBranding()
+
+    // Assert: emits with brandingMode: 'icon'
+    expect(updateSettingsCalls.length).toBe(1)
+    expect(updateSettingsCalls[0].brandingMode).toBe('icon')
+
+    // Act: simulate prop update + toggle back icon → logo
+    await wrapper.setProps({ settings: { brandingMode: 'icon' } })
+    wrapper.vm.toggleBranding()
+    expect(updateSettingsCalls[1].brandingMode).toBe('logo')
+  })
+
+  test('test_EnhancedQuoteV3_branding_toggle_button_visible_only_when_unlocked_and_both_urls_present', async () => {
+    // Arrange: unlocked, both urls available
+    mockMassiveFetch()
+    const wrapper = mount(EnhancedQuoteV3, {
+      props: { isLocked: false, settings: {} },
+      global: { stubs: { draggable: { template: '<div><slot name="item" v-for="e in list" :element="e" /></div>', props: ['modelValue', 'list'] } } },
+    })
+    wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    // Assert: toggle visible when unlocked + both URLs present
+    expect(wrapper.find('.eqv3-branding-toggle').exists()).toBe(true)
+
+    // Lock the widget — toggle should disappear
+    await wrapper.setProps({ isLocked: true })
+    expect(wrapper.find('.eqv3-branding-toggle').exists()).toBe(false)
+  })
+
+  test('test_EnhancedQuoteV3_branding_toggle_hidden_when_only_one_url_available', async () => {
+    // Arrange: only logo_url, no icon_url
+    const tickerLogoOnly = {
+      results: {
+        name: 'Tesla Inc.',
+        sic_description: 'Motor Vehicles',
+        branding: {
+          logo_url: 'https://api.massive.com/v1/reference/company-branding/tsla/logo.svg',
+          // no icon_url
+        },
+      },
+    }
+    mockMassiveFetch({ ticker: tickerLogoOnly })
+    const wrapper = mount(EnhancedQuoteV3, {
+      props: { isLocked: false, settings: {} },
+      global: { stubs: { draggable: { template: '<div><slot name="item" v-for="e in list" :element="e" /></div>', props: ['modelValue', 'list'] } } },
+    })
+    wrapper.vm.manualTicker = 'TSLA'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    // Assert: toggle hidden (only one url available)
+    expect(wrapper.find('.eqv3-branding-toggle').exists()).toBe(false)
+    // But logo still renders
+    expect(wrapper.find('.eqv3-logo').exists()).toBe(true)
+  })
 })
 
 describe('Massive API — short interest and volume', () => {

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
@@ -412,7 +412,6 @@ describe('Massive API — company data', () => {
     mockMassiveFetch()
     const wrapper = mount(EnhancedQuoteV3, {
       props: { isLocked: false, settings: { brandingMode: 'icon' } },
-      global: { stubs: { draggable: { template: '<div><slot name="item" v-for="e in list" :element="e" /></div>', props: ['modelValue', 'list'] } } },
     })
     wrapper.vm.manualTicker = 'TSLA'
     await wrapper.vm.$nextTick()
@@ -435,7 +434,6 @@ describe('Massive API — company data', () => {
     const wrapper = mount(EnhancedQuoteV3, {
       props: { isLocked: false, settings: { brandingMode: 'logo' } },
       attrs: { 'onUpdate-settings': (payload) => updateSettingsCalls.push(payload) },
-      global: { stubs: { draggable: { template: '<div><slot name="item" v-for="e in list" :element="e" /></div>', props: ['modelValue', 'list'] } } },
     })
     wrapper.vm.manualTicker = 'TSLA'
     await wrapper.vm.$nextTick()
@@ -461,7 +459,6 @@ describe('Massive API — company data', () => {
     mockMassiveFetch()
     const wrapper = mount(EnhancedQuoteV3, {
       props: { isLocked: false, settings: {} },
-      global: { stubs: { draggable: { template: '<div><slot name="item" v-for="e in list" :element="e" /></div>', props: ['modelValue', 'list'] } } },
     })
     wrapper.vm.manualTicker = 'TSLA'
     await wrapper.vm.$nextTick()
@@ -492,7 +489,6 @@ describe('Massive API — company data', () => {
     mockMassiveFetch({ ticker: tickerLogoOnly })
     const wrapper = mount(EnhancedQuoteV3, {
       props: { isLocked: false, settings: {} },
-      global: { stubs: { draggable: { template: '<div><slot name="item" v-for="e in list" :element="e" /></div>', props: ['modelValue', 'list'] } } },
     })
     wrapper.vm.manualTicker = 'TSLA'
     await wrapper.vm.$nextTick()
@@ -955,6 +951,10 @@ describe('Exposed interface', () => {
     expect(wrapper.vm.activeCards).toBeDefined()
     expect(wrapper.vm.isDragging).toBeDefined()
     expect(wrapper.vm.logoUrl).toBeDefined()
+    expect(wrapper.vm.iconUrl).toBeDefined()
+    expect(wrapper.vm.brandingMode).toBeDefined()
+    expect(wrapper.vm.activeBrandingUrl).toBeDefined()
+    expect(wrapper.vm.toggleBranding).toBeDefined()
     expect(wrapper.vm.fullRowCards).toBeDefined()
     expect(wrapper.vm.onFullRowDragEnd).toBeDefined()
     expect(wrapper.vm.onFullRowReorder).toBeDefined()


### PR DESCRIPTION
Store `icon_url` from the Massive branding response alongside `logo_url`. Add a toggle in the controls bar (visible only when unlocked + both URLs present) to switch between them.

## How it works

- `brandingMode` computed reads `settings.brandingMode` (default `'logo'`)
- `activeBrandingUrl` picks logo or icon URL based on mode, with fallback to the other if unavailable
- Toggle button appears in the ticker input bar when `!isLocked && logoUrl && iconUrl`
- Clicking emits `update-settings` with new `brandingMode` — persisted per-widget alongside `cardOrder`
- Toggle hidden when locked, or when only one branding URL is available

## Tests

5 new tests: default logo mode, icon mode rendering, toggle emit (logo→icon→logo), visibility guard (locked hides toggle), single-URL guard (toggle hidden when icon missing).

97/97 passing.

refs #133