### PR TITLE
feat: restore enhanced-quote type alias — backward compat with saved layouts

### DIFF
--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -34,7 +34,7 @@ const availableWidgets = [
   { type: 'news-feed', label: 'News Feed', icon: '📰' },
   { type: 'company-news', label: 'Company News', icon: '🗞️' },
   { type: 'quote', label: 'Quote', icon: '⚡' },
-  { type: 'enhanced-quote-v3', label: 'Enhanced Quote', icon: '✨' },
+  { type: 'enhanced-quote', label: 'Enhanced Quote', icon: '✨' },
 ]
 
 const selectWidget = (widgetType) => {

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -91,7 +91,8 @@ const widgetComponents = {
   'company-news': CompanyNews,
   'news-feed':   NewsFeed,
   'quote':           Quote,
-  'enhanced-quote-v3': EnhancedQuoteV3,
+  'enhanced-quote':    EnhancedQuoteV3,
+  'enhanced-quote-v3': EnhancedQuoteV3,  // backward-compat alias
 }
 
 const widgetComponent = computed(() => widgetComponents[props.widgetType])


### PR DESCRIPTION
Saved layouts using `enhanced-quote` (the original V1 type string) rendered nothing after EQV1/EQV2 were decommissioned in PR #163.

## Fix

Register `'enhanced-quote'` in `WidgetWrapper` pointing to `EnhancedQuoteV3` — existing layouts load without any reconfiguration.

`WidgetMenu` updated to emit `'enhanced-quote'` for new additions. `'enhanced-quote-v3'` kept as a backward-compat alias so any layouts saved after PR #163 also continue to work.

97/97 tests passing.

refs #133