### PR TITLE
feat(EQv3): make Previous Day a uniform draggable card in all layouts

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -152,7 +152,7 @@
                   />
                 </template>
 
-                <!-- Previous Day — kv-list at full mode, chips at narrow/wide -->
+                <!-- Previous Day — kv-list in all layouts -->
                 <template v-else-if="card.id === 'prev'">
                   <div class="eqv3-kv-list">
                     <div class="eqv3-kv"><span class="eqv3-k">Open</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
@@ -169,7 +169,7 @@
           </draggable>
         </template>
 
-        <!-- NARROW / WIDE mode: two columns + pinned Previous Day row -->
+        <!-- NARROW / WIDE mode: two columns -->
         <template v-else>
           <!-- Col 1: all cards at narrow; first half at wide -->
           <div class="eqv3-col eqv3-col-1">
@@ -255,6 +255,18 @@
                     </div>
                   </template>
 
+                  <!-- Previous Day -->
+                  <template v-else-if="card.id === 'prev'">
+                    <div class="eqv3-kv-list">
+                      <div class="eqv3-kv"><span class="eqv3-k">Open</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">High</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Low</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Close</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Volume</span><span class="eqv3-v">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">VWAP</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+                    </div>
+                  </template>
+
                   <!-- Company -->
                   <template v-else-if="card.id === 'company'">
                     <EQV3CompanyCard
@@ -314,6 +326,18 @@
                     />
                   </template>
 
+                  <!-- Previous Day (if reordered into col-2) -->
+                  <template v-else-if="card.id === 'prev'">
+                    <div class="eqv3-kv-list">
+                      <div class="eqv3-kv"><span class="eqv3-k">Open</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">High</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Low</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Close</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">Volume</span><span class="eqv3-v">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+                      <div class="eqv3-kv"><span class="eqv3-k">VWAP</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+                    </div>
+                  </template>
+
                   <!-- Session / Today / Volume (if reordered into col-2) -->
                   <template v-else-if="card.id === 'session'">
                     <div class="eqv3-session-chips">
@@ -358,20 +382,6 @@
             </draggable>
           </div>
 
-          <!-- Previous Day: always full-width at bottom — NOT part of draggable list -->
-          <div class="eqv3-prev-row">
-            <div class="eqv3-card eqv3-prev-card">
-              <div class="eqv3-card-label">Previous Day</div>
-              <div class="eqv3-prev-chips">
-                <div class="eqv3-chip"><span class="eqv3-chip-label">O</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
-                <div class="eqv3-chip"><span class="eqv3-chip-label">H</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
-                <div class="eqv3-chip"><span class="eqv3-chip-label">L</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
-                <div class="eqv3-chip"><span class="eqv3-chip-label">C</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
-                <div class="eqv3-chip"><span class="eqv3-chip-label">Vol</span><span class="eqv3-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
-                <div class="eqv3-chip"><span class="eqv3-chip-label">VWAP</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
-              </div>
-            </div>
-          </div>
         </template>
       </div>
 
@@ -404,8 +414,7 @@ import { fmtVol } from './eqv3Utils.js'
 const BREAKPOINTS = { WIDE: 480, FULL: 960 }
 
 // Card registry — defines the set of draggable cards and their default order.
-// At full mode (≥960px), 'prev' is a draggable card in the flat row.
-// At narrow/wide, 'prev' is pinned full-width at the bottom (excluded from column lists).
+// 'prev' is a regular draggable card in all layouts.
 const CARD_REGISTRY = [
   { id: 'today',   label: 'Today'          },
   { id: 'prev',    label: 'Previous Day'   },
@@ -445,18 +454,16 @@ const activeCards = computed(() => {
   return [...saved, ...missing]
 })
 
-// Distribute activeCards (excluding 'prev') across columns at narrow/wide mode.
+// Distribute activeCards across columns at narrow/wide mode.
 // At full mode, fullRowCards is used instead — these computeds are not rendered.
 const col1Cards = computed(() => {
-  const cards = activeCards.value.filter(c => c.id !== 'prev')
-  if (isNarrow.value) return cards
-  return cards.slice(0, Math.ceil(cards.length / 2))
+  if (isNarrow.value) return activeCards.value
+  return activeCards.value.slice(0, Math.ceil(activeCards.value.length / 2))
 })
 
 const col2Cards = computed(() => {
   if (isNarrow.value) return []
-  const cards = activeCards.value.filter(c => c.id !== 'prev')
-  return cards.slice(Math.ceil(cards.length / 2))
+  return activeCards.value.slice(Math.ceil(activeCards.value.length / 2))
 })
 
 const col3Cards = computed(() => [])  // no longer used; kept for API compatibility
@@ -480,21 +487,19 @@ const onColReorder = (newVal, colNum) => {
 }
 
 // Drag end for narrow/wide column layout.
-// 'prev' is always pinned outside the draggable lists at narrow/wide, so append it
-// at the end of the saved order (its position only matters at full mode).
 const onDragEnd = async () => {
   isDragging.value = false
   await nextTick()
   await nextTick()
   const c1 = _col1.value ?? col1Cards.value
   const c2 = _col2.value ?? col2Cards.value
-  const orderedNonPrev = isNarrow.value
+  const ordered = isNarrow.value
     ? c1.map(c => c.id)
     : [...c1, ...c2].map(c => c.id)
   _col1.value = null
   _col2.value = null
   _col3.value = null
-  emit('update-settings', { ...props.settings, cardOrder: [...orderedNonPrev, 'prev'] })
+  emit('update-settings', { ...props.settings, cardOrder: ordered })
 }
 
 // Full-mode flat row reorder — fires from @update:model-value (after vuedraggable updates the list).
@@ -1110,12 +1115,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 .eqv3-rv-val.high    { color: #f97316; font-weight: 600; }
 .eqv3-rv-val.medium  { color: #eab308; }
 
-/* ── Previous Day chips ── */
-.eqv3-prev-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
+
 .eqv3-chip {
   display: flex;
   flex-direction: column;
@@ -1205,9 +1205,6 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 /* Col-2 hidden at narrow */
 .eqv3-col-2 { display: none; }
 
-/* Previous Day pinned row: full width at narrow/wide */
-.eqv3-prev-row { width: 100%; }
-
 /* Full-row draggable: horizontal flex, cards stretch to equal height */
 .eqv3-full-row-draggable {
   display: flex;
@@ -1230,7 +1227,6 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   }
   .eqv3-col-1 { flex: 1; }
   .eqv3-col-2 { display: flex; flex: 1; }
-  .eqv3-prev-row { flex-basis: 100%; }
 }
 
 /* ── FULL mode (960px+): hero left, single horizontal card row right ── */
@@ -1283,6 +1279,5 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   }
   .eqv3-full-row-draggable .eqv3-company-card { min-width: 200px; }
   .eqv3-full-row-draggable .eqv3-prev-card    { min-width: 200px; }
-  .eqv3-prev-row { display: none; }
 }
 </style>

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
@@ -240,8 +240,8 @@ describe('Price hero', () => {
     expect(badge.text()).toContain('-3.50')
   })
 
-  test('test_EnhancedQuoteV3_with_quote_data_expect_previous_day_chips_rendered', async () => {
-    // Arrange
+  test('test_EnhancedQuoteV3_with_quote_data_expect_previous_day_kv_list_rendered_in_col', async () => {
+    // Arrange: narrow mode (default) — prev card is now a regular draggable card in col1
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
     await wrapper.vm.$nextTick()
@@ -250,16 +250,17 @@ describe('Price hero', () => {
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
 
-    // Assert: pinned prev-row at narrow has 6 chips
-    const chips = wrapper.findAll('.eqv3-chip')
-    expect(chips.length).toBe(6)
-    const labels = chips.map(c => c.find('.eqv3-chip-label').text())
-    expect(labels).toContain('O')
-    expect(labels).toContain('H')
-    expect(labels).toContain('L')
-    expect(labels).toContain('C')
-    expect(labels).toContain('Vol')
-    expect(labels).toContain('VWAP')
+    // Assert: prev card rendered as kv-list inside the column draggable (no pinned row)
+    expect(wrapper.find('.eqv3-prev-row').exists()).toBe(false)
+    const prevCard = wrapper.find('.eqv3-prev-card')
+    expect(prevCard.exists()).toBe(true)
+    const kvLabels = prevCard.findAll('.eqv3-k').map(el => el.text())
+    expect(kvLabels).toContain('Open')
+    expect(kvLabels).toContain('High')
+    expect(kvLabels).toContain('Low')
+    expect(kvLabels).toContain('Close')
+    expect(kvLabels).toContain('Volume')
+    expect(kvLabels).toContain('VWAP')
   })
 })
 
@@ -683,9 +684,8 @@ describe('Card layout and settings', () => {
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
 
-    // Act: simulate col1 reorder then drag end (narrow mode — all non-prev cards in col1)
-    // At narrow, col1Cards excludes 'prev'; onDragEnd appends 'prev' at end
-    const reordered = ['today', 'session', 'volume', 'short', 'company']
+    // Act: simulate col1 reorder then drag end (narrow mode — all cards in col1 including prev)
+    const reordered = ['today', 'session', 'prev', 'volume', 'short', 'company']
     wrapper.vm.onColReorder(
       reordered.map(id => ({ id, label: id })),
       1
@@ -693,9 +693,9 @@ describe('Card layout and settings', () => {
     await wrapper.vm.onDragEnd()
     await wrapper.vm.$nextTick()
 
-    // Assert: saved order is reordered cards + 'prev' appended at end
+    // Assert: saved order reflects the reordered list directly (no special-casing for prev)
     expect(updateSettingsCalls.length).toBe(1)
-    expect(updateSettingsCalls[0].cardOrder).toEqual([...reordered, 'prev'])
+    expect(updateSettingsCalls[0].cardOrder).toEqual(reordered)
   })
 
   test('test_EnhancedQuoteV3_with_narrow_layout_default_expect_col2_not_rendered', async () => {
@@ -759,7 +759,7 @@ describe('Card layout and settings', () => {
     expect(wrapper.vm.col3Cards).toEqual([])
   })
 
-  test('test_EnhancedQuoteV3_prev_is_in_activeCards_and_pinned_at_narrow_in_draggable_at_full', async () => {
+  test('test_EnhancedQuoteV3_prev_is_draggable_in_all_layouts', async () => {
     // Arrange: narrow mode (default)
     const wrapper = mountWidget()
     wrapper.vm.manualTicker = 'TSLA'
@@ -767,13 +767,12 @@ describe('Card layout and settings', () => {
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
 
-    // Assert at narrow: prev-row exists as pinned element
-    expect(wrapper.find('.eqv3-prev-row').exists()).toBe(true)
-    expect(wrapper.find('.eqv3-prev-card').exists()).toBe(true)
-    // prev IS in activeCards (it drives both the pinned row and the full-mode card)
+    // Assert at narrow: prev is in activeCards and rendered as a regular card, no pinned row
+    expect(wrapper.find('.eqv3-prev-row').exists()).toBe(false)
     expect(wrapper.vm.activeCards.map(c => c.id)).toContain('prev')
+    expect(wrapper.find('.eqv3-prev-card').exists()).toBe(true)
 
-    // At full mode: fullRowCards includes prev (it becomes a draggable card)
+    // At full mode: prev is also in fullRowCards
     wrapper.vm.layoutMode = 'full'
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.fullRowCards.map(c => c.id)).toContain('prev')
@@ -880,9 +879,11 @@ describe('Full mode — chips-to-kv-list rendering', () => {
     // layoutMode defaults to narrow
     await wrapper.vm.$nextTick()
 
-    // Assert: chips still present in col-1 at narrow
+    // Assert: session chips still present in col-1 at narrow
     expect(wrapper.find('.eqv3-session-chips').exists()).toBe(true)
-    expect(wrapper.find('.eqv3-prev-row .eqv3-prev-chips').exists()).toBe(true)
+    // prev card rendered as kv-list (no chips) inside the column draggable
+    expect(wrapper.find('.eqv3-prev-row').exists()).toBe(false)
+    expect(wrapper.find('.eqv3-prev-card').exists()).toBe(true)
     // And full-row draggable does not exist at narrow
     expect(wrapper.find('.eqv3-full-row-draggable').exists()).toBe(false)
   })


### PR DESCRIPTION
## Summary

Previous Day was the only card with layout-specific special-casing. In narrow/wide it was pinned as a full-width chip row outside the draggable lists. In full mode it was already a regular draggable card.

This PR removes all that special-casing: Previous Day is now just another draggable card in every layout.

## Changes

**Template**
- Removed pinned `eqv3-prev-row` div and chip layout from narrow/wide template
- Added `prev` card kv-list rendering to col1 and col2 draggable item templates (matches existing full-mode rendering)

**Script**
- Removed `filter(c => c.id !== 'prev')` from `col1Cards` / `col2Cards`
- Simplified `onDragEnd`: dropped `orderedNonPrev` + append-prev logic; saves the full reordered list directly

**CSS**
- Removed `.eqv3-prev-row` rules (width, flex-basis at wide, `display: none` at full mode)
- Removed `.eqv3-prev-chips` (chip layout gone)

99/99 tests passing.

refs #133