### PR TITLE
fix(EQv3): align card-toggle active state fallback with --pd-accent token

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -1247,8 +1247,8 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   line-height: 1.4;
 }
 .eqv3-card-toggle:hover { background: #1a1a1a; color: #aaa; }
-.eqv3-card-toggle--active { border-color: var(--pd-accent, #60a5fa); color: var(--pd-accent, #60a5fa); }
-.eqv3-card-toggle--active:hover { background: rgba(96,165,250,0.08); }
+.eqv3-card-toggle--active { border-color: var(--pd-accent, #7c3aed); color: var(--pd-accent, #7c3aed); }
+.eqv3-card-toggle--active:hover { background: rgba(124,58,237,0.08); }
 
 /* ── Generic chip row (today, volume, short, prev chips mode) ── */
 .eqv3-chip-row {


### PR DESCRIPTION
Fallback color in `.eqv3-card-toggle--active` was `#60a5fa` (blue) but the actual `--pd-accent` token is `#7c3aed` (violet). Aligns fallback and hover background rgba to match.

- `border-color` / `color` fallback: `#60a5fa` → `#7c3aed`
- Hover `background`: `rgba(96,165,250,0.08)` → `rgba(124,58,237,0.08)`

112/112 tests passing.

refs #177