### PR TITLE
fix(EQv3): cap company card width to 50% in wide mode

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -1507,6 +1507,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   }
   .eqv3-col-1 { flex: 1; }
   .eqv3-col-2 { display: flex; flex: 1; }
+  .eqv3-company-card { max-width: 50%; }
 }
 
 /* ── FULL mode (960px+): hero left, single horizontal card row right ── */


### PR DESCRIPTION
Company card in wide mode was stretching to full column width (~half the widget), making it wider than the hero. Added `max-width: 50%` to `.eqv3-company-card` inside the `@container (min-width: 480px)` block.

112/112 tests passing.

refs #175