### PR TITLE
Revert "fix(EQv3): cap company card width to 50% in wide mode (#179)"

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -1507,7 +1507,6 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   }
   .eqv3-col-1 { flex: 1; }
   .eqv3-col-2 { display: flex; flex: 1; }
-  .eqv3-company-card { max-width: 50%; }
 }
 
 /* ── FULL mode (960px+): hero left, single horizontal card row right ── */


### PR DESCRIPTION
Reverts #179. The `max-width: 50%` constraint was placed in the wide-mode container query, which broke narrow/wide layouts. Reverting cleanly until a targeted full-mode-only fix is designed.

refs #175