### PR TITLE
fix(EQv3): cap company card width to 50% in full mode only

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -1507,7 +1507,6 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   }
   .eqv3-col-1 { flex: 1; }
   .eqv3-col-2 { display: flex; flex: 1; }
-  .eqv3-company-card { max-width: 50%; }
 }
 
 /* ── FULL mode (960px+): hero left, single horizontal card row right ── */
@@ -1558,7 +1557,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
     min-width: 140px;
     align-self: stretch;
   }
-  .eqv3-full-row-draggable .eqv3-company-card { min-width: 200px; }
+  .eqv3-full-row-draggable .eqv3-company-card { min-width: 200px; max-width: 50%; }
   .eqv3-full-row-draggable .eqv3-prev-card    { min-width: 200px; }
 }
 </style>


### PR DESCRIPTION
Moves the `max-width: 50%` constraint from the wide-mode (480px) container query into the full-mode (960px) query, alongside the existing `min-width: 200px` rule on `.eqv3-full-row-draggable .eqv3-company-card`.

Narrow and wide layouts are unaffected.

112/112 tests passing.

refs #175