### PR TITLE
fix(EQv3): reduce hero width from 360px to 200px in full mode

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -1527,7 +1527,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
     align-items: flex-start;
     justify-content: flex-start;
     flex-shrink: 0;
-    width: 360px;
+    width: 200px;
     align-self: stretch;
   }
   /* Full-mode column order: symbol (1), price (2), identity (3) */


### PR DESCRIPTION
Sets `.eqv3-hero` `width` to `200px` (down from `360px`) in the full-mode container query.

112/112 tests passing.

refs #175