### PR TITLE
feat(EQv3): three-column medium layout and sticky per-column card order

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -388,7 +388,7 @@
                           </draggable>
           </div>
 
-          <!-- Col 2: second half at wide -->
+          <!-- Col 2: visible at wide and medium -->
           <div v-if="!isNarrow" class="eqv3-col eqv3-col-2">
             <draggable
               :model-value="col2Cards"
@@ -544,6 +544,166 @@
                           </draggable>
           </div>
 
+          <!-- Col 3: visible at medium only -->
+          <div v-if="layoutMode === 'medium'" class="eqv3-col eqv3-col-3">
+            <draggable
+              :model-value="col3Cards"
+              group="eqv3-cards"
+              item-key="id"
+              :disabled="isLocked"
+              handle=".eqv3-drag-handle"
+              @start="isDragging = true"
+              @end="onDragEnd()"
+              @update:model-value="(val) => onColReorder(val, 3)"
+            >
+              <template #item="{ element: card }">
+                <div :key="card.id" :class="['eqv3-card', `eqv3-${card.id}-card`]">
+                  <div class="eqv3-card-label">
+                    <span v-if="!isLocked" class="eqv3-drag-handle" title="Drag to reorder">⠿</span>
+                    {{ card.label }}
+                    <span v-if="!isLocked" class="eqv3-card-controls">
+                      <button :class="['eqv3-card-toggle', { 'eqv3-card-toggle--active': hiddenCardIds.has(card.id) }]" :title="hiddenCardIds.has(card.id) ? 'Show card' : 'Hide card'" @click.stop="toggleCardVisibility(card.id)">{{ hiddenCardIds.has(card.id) ? 'show' : 'hide' }}</button>
+                      <button v-if="card.chipsCapable" :class="['eqv3-card-toggle', { 'eqv3-card-toggle--active': chipCardIds.has(card.id) }]" :title="chipCardIds.has(card.id) ? 'Normal mode' : 'Chips mode'" @click.stop="toggleCardChips(card.id)">{{ chipCardIds.has(card.id) ? 'chips' : 'list' }}</button>
+                    </span>
+                  </div>
+
+                  <!-- Session H/L -->
+                  <template v-if="card.id === 'session'">
+                    <template v-if="chipCardIds.has('session')">
+                      <div class="eqv3-session-chips">
+                        <div class="eqv3-session-chip"><span class="eqv3-chip-label">PRE</span>
+                          <div v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null" class="eqv3-session-chip-vals"><span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span><span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span></div>
+                          <div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                        </div>
+                        <div class="eqv3-session-chip"><span class="eqv3-chip-label">REG</span>
+                          <div v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null" class="eqv3-session-chip-vals"><span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span><span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span></div>
+                          <div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                        </div>
+                        <div class="eqv3-session-chip"><span class="eqv3-chip-label">AH</span>
+                          <div v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null" class="eqv3-session-chip-vals"><span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span><span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span></div>
+                          <div v-else class="eqv3-session-chip-vals eqv3-muted-val">—</div>
+                        </div>
+                      </div>
+                    </template>
+                    <template v-else>
+                      <div class="eqv3-kv-list">
+                        <div class="eqv3-kv"><span class="eqv3-k">Pre High</span><span class="eqv3-v">{{ quoteData.pre_market_high != null ? '$' + fmt(quoteData.pre_market_high, 2) : '—' }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Pre Low</span><span class="eqv3-v">{{ quoteData.pre_market_low != null ? '$' + fmt(quoteData.pre_market_low, 2) : '—' }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Reg High</span><span class="eqv3-v">{{ quoteData.regular_session_high != null ? '$' + fmt(quoteData.regular_session_high, 2) : '—' }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Reg Low</span><span class="eqv3-v">{{ quoteData.regular_session_low != null ? '$' + fmt(quoteData.regular_session_low, 2) : '—' }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">AH High</span><span class="eqv3-v">{{ quoteData.after_hours_high != null ? '$' + fmt(quoteData.after_hours_high, 2) : '—' }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">AH Low</span><span class="eqv3-v">{{ quoteData.after_hours_low != null ? '$' + fmt(quoteData.after_hours_low, 2) : '—' }}</span></div>
+                      </div>
+                    </template>
+                  </template>
+
+                  <!-- Today -->
+                  <template v-else-if="card.id === 'today'">
+                    <template v-if="chipCardIds.has('today')">
+                      <div class="eqv3-chip-row">
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">O</span><span class="eqv3-chip-val">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">VWAP</span><span class="eqv3-chip-val">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+                      </div>
+                    </template>
+                    <template v-else>
+                      <div class="eqv3-kv-list">
+                        <div class="eqv3-kv"><span class="eqv3-k">Open</span><span class="eqv3-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">VWAP</span><span class="eqv3-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+                      </div>
+                    </template>
+                  </template>
+
+                  <!-- Volume -->
+                  <template v-else-if="card.id === 'volume'">
+                    <template v-if="chipCardIds.has('volume')">
+                      <div class="eqv3-chip-row">
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">Vol</span><span class="eqv3-chip-val">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">Avg</span><span class="eqv3-chip-val">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">Float</span><span class="eqv3-chip-val">{{ fmtVol(floatShares) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">RVol</span><span :class="['eqv3-chip-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span></div>
+                      </div>
+                    </template>
+                    <template v-else>
+                      <div class="eqv3-kv-list">
+                        <div class="eqv3-kv"><span class="eqv3-k">Volume</span><span class="eqv3-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Avg Vol</span><span class="eqv3-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Float</span><span class="eqv3-v">{{ fmtVol(floatShares) }}</span></div>
+                      </div>
+                      <div class="eqv3-rv-row">
+                        <span class="eqv3-k">Rel. Vol</span>
+                        <div class="eqv3-rv-bar-wrap"><div class="eqv3-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div></div>
+                        <span :class="['eqv3-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
+                      </div>
+                    </template>
+                  </template>
+
+                  <!-- Short Interest -->
+                  <template v-else-if="card.id === 'short'">
+                    <template v-if="chipCardIds.has('short')">
+                      <div v-if="shortInterestLoading" class="eqv3-muted-msg">Short interest data loading...</div>
+                      <div v-else-if="allShortNull" class="eqv3-muted-msg">Short interest data unavailable</div>
+                      <div v-else class="eqv3-chip-row">
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">SI</span><span class="eqv3-chip-val">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">DTC</span><span class="eqv3-chip-val">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">SVR</span><span class="eqv3-chip-val">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
+                      </div>
+                    </template>
+                    <template v-else>
+                      <div v-if="shortInterestLoading" class="eqv3-muted-msg">Short interest data loading...</div>
+                      <div v-else-if="allShortNull" class="eqv3-muted-msg">Short interest data unavailable</div>
+                      <div v-else class="eqv3-kv-list">
+                        <div class="eqv3-kv"><span class="eqv3-k">Short Int.</span><span class="eqv3-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Days to Cover</span><span class="eqv3-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Short Vol Ratio</span><span class="eqv3-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
+                      </div>
+                    </template>
+                  </template>
+
+                  <!-- Company -->
+                  <template v-else-if="card.id === 'company'">
+                    <EQV3CompanyCard
+                      :loading="companyLoading"
+                      :all-null="allCompanyNull"
+                      :data="companyData"
+                      :expanded="descExpanded"
+                      @expand="descExpanded = true"
+                      @collapse="descExpanded = false"
+                    />
+                  </template>
+
+                  <!-- Previous Day -->
+                  <template v-else-if="card.id === 'prev'">
+                    <template v-if="chipCardIds.has('prev')">
+                      <div class="eqv3-chip-row">
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">O</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">H</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">L</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">C</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">Vol</span><span class="eqv3-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+                        <div class="eqv3-chip"><span class="eqv3-chip-label">VWAP</span><span class="eqv3-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+                      </div>
+                    </template>
+                    <template v-else>
+                      <div class="eqv3-kv-list">
+                        <div class="eqv3-kv"><span class="eqv3-k">Open</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">High</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Low</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Close</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">Volume</span><span class="eqv3-v">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+                        <div class="eqv3-kv"><span class="eqv3-k">VWAP</span><span class="eqv3-v">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+                      </div>
+                    </template>
+                  </template>
+
+                </div>
+              </template>
+                          </draggable>
+          </div>
+
+        </template>
+
+        <!-- Hidden cards tray
+
         </template>
 
         <!-- Hidden cards tray — edit mode only; shows cards the user has hidden so they can re-show them -->
@@ -584,7 +744,7 @@ import EQV3CompanyCard from './EQV3CompanyCard.vue'
 import { fmtVol } from './eqv3Utils.js'
 
 // Shared breakpoint constants — must match CSS @container thresholds exactly.
-const BREAKPOINTS = { WIDE: 360, FULL: 1024 }
+const BREAKPOINTS = { WIDE: 360, MEDIUM: 720, FULL: 1024 }
 
 // Card registry — defines the set of draggable cards and their default order.
 // chipsCapable: whether the card supports a chip render mode (company excluded).
@@ -617,14 +777,32 @@ const isNarrow = computed(() => layoutMode.value === 'narrow')
 // ── Draggable card order ──
 const isDragging = ref(false)
 
+// ── Settings migration shim ──
+// Converts legacy flat `cardOrder` to nested `columns` shape on first load.
+// Fires immediately (watch immediate:true) and is idempotent (guard on columns present).
+watch(() => props.settings, (settings) => {
+  if (!settings) return
+  if (Array.isArray(settings.columns)) return  // already migrated
+  if (!Array.isArray(settings.cardOrder) || settings.cardOrder.length === 0) return
+  const ids = settings.cardOrder
+  const mid = Math.ceil(ids.length / 2)
+  const migrated = { ...settings, columns: [ids.slice(0, mid), ids.slice(mid), []] }
+  delete migrated.cardOrder
+  emit('update-settings', migrated)
+}, { immediate: true })
+
 const activeCards = computed(() => {
-  const order = props.settings?.cardOrder
-  if (!Array.isArray(order) || order.length === 0) return [...CARD_REGISTRY]
-  const saved = order
-    .map(id => CARD_REGISTRY.find(c => c.id === id))
-    .filter(Boolean)
-  const missing = CARD_REGISTRY.filter(c => !order.includes(c.id))
-  return [...saved, ...missing]
+  // Derive flat ordered list from columns (new shape) or CARD_REGISTRY default.
+  const cols = props.settings?.columns
+  if (Array.isArray(cols)) {
+    const allIds = cols.flat()
+    if (allIds.length > 0) {
+      const saved = allIds.map(id => CARD_REGISTRY.find(c => c.id === id)).filter(Boolean)
+      const missing = CARD_REGISTRY.filter(c => !allIds.includes(c.id))
+      return [...saved, ...missing]
+    }
+  }
+  return [...CARD_REGISTRY]
 })
 
 // ── Card visibility and render-mode toggles ──
@@ -660,19 +838,42 @@ const toggleCardChips = (cardId) => {
   emit('update-settings', { ...props.settings, chipCards: [...chips] })
 }
 
-// Distribute visibleCards across columns at narrow/wide mode.
-// At full mode, fullRowCards is used instead — these computeds are not rendered.
+// colCards(n): returns visible cards assigned to column n (0-indexed).
+// Reads from settings.columns[n]; unknown IDs and hidden cards are excluded.
+// Unassigned registry cards (not in any column) silently append to col0 (col1).
+const _colCards = (colIndex) => computed(() => {
+  const cols = props.settings?.columns
+  if (!Array.isArray(cols)) return colIndex === 0 ? visibleCards.value : []
+  const col = cols[colIndex] ?? []
+  const ids = new Set(col)
+  const result = col
+    .map(id => CARD_REGISTRY.find(c => c.id === id))
+    .filter(c => c && !hiddenCardIds.value.has(c.id))
+  // Unassigned cards fall into col0 only
+  if (colIndex === 0) {
+    const allAssigned = new Set(cols.flat())
+    const unassigned = CARD_REGISTRY.filter(c => !allAssigned.has(c.id) && !hiddenCardIds.value.has(c.id))
+    return [...result, ...unassigned]
+  }
+  return result
+})
+
+// col1Cards: at narrow, flattens all columns so no cards disappear.
 const col1Cards = computed(() => {
-  if (isNarrow.value) return visibleCards.value
-  return visibleCards.value.slice(0, Math.ceil(visibleCards.value.length / 2))
+  if (isNarrow.value) {
+    const cols = props.settings?.columns
+    if (!Array.isArray(cols)) return visibleCards.value
+    const allIds = cols.flat()
+    const seen = new Set()
+    return allIds
+      .map(id => CARD_REGISTRY.find(c => c.id === id))
+      .filter(c => c && !hiddenCardIds.value.has(c.id) && !seen.has(c.id) && seen.add(c.id))
+  }
+  return _colCards(0).value
 })
 
-const col2Cards = computed(() => {
-  if (isNarrow.value) return []
-  return visibleCards.value.slice(Math.ceil(visibleCards.value.length / 2))
-})
-
-const col3Cards = computed(() => [])  // no longer used; kept for API compatibility
+const col2Cards = computed(() => isNarrow.value ? [] : _colCards(1).value)
+const col3Cards = computed(() => layoutMode.value === 'medium' ? _colCards(2).value : [])
 
 // At full mode: single flat horizontal list of visible cards.
 const fullRowCards = computed(() => {
@@ -692,27 +893,32 @@ const onColReorder = (newVal, colNum) => {
   else _col3.value = newVal
 }
 
-// Drag end for narrow/wide column layout.
+// Drag end for narrow/wide/medium column layout.
 const onDragEnd = async () => {
   isDragging.value = false
   await nextTick()
   await nextTick()
-  const c1 = _col1.value ?? col1Cards.value
-  const c2 = _col2.value ?? col2Cards.value
-  const ordered = isNarrow.value
-    ? c1.map(c => c.id)
-    : [...c1, ...c2].map(c => c.id)
+  const c1 = (_col1.value ?? col1Cards.value).map(c => c.id)
+  const c2 = (_col2.value ?? col2Cards.value).map(c => c.id)
+  const c3 = (_col3.value ?? col3Cards.value).map(c => c.id)
   _col1.value = null
   _col2.value = null
   _col3.value = null
-  emit('update-settings', { ...props.settings, cardOrder: ordered })
+  const columns = isNarrow.value
+    ? [c1, [], []]
+    : layoutMode.value === 'medium'
+      ? [c1, c2, c3]
+      : [c1, c2, []]
+  emit('update-settings', { ...props.settings, columns })
 }
 
 // Full-mode flat row reorder — fires from @update:model-value (after vuedraggable updates the list).
 // NOTE: vuedraggable fires @end before @update:model-value, so we cannot read the new order in @end.
 // Drive the emit from @update:model-value directly to guarantee we have the updated list.
+// Full-mode reorder collapses all cards into col1 (destructive but intentional —
+// user controls auto-save; see design doc decision #3).
 const onFullRowReorder = (newVal) => {
-  emit('update-settings', { ...props.settings, cardOrder: newVal.map(c => c.id) })
+  emit('update-settings', { ...props.settings, columns: [newVal.map(c => c.id), [], []] })
 }
 
 // Kept for defineExpose / test compatibility — no longer drives full-row emit.
@@ -724,6 +930,7 @@ onMounted(() => {
   _resizeObserver = new ResizeObserver((entries) => {
     const width = entries[0]?.contentRect.width ?? 0
     if (width >= BREAKPOINTS.FULL) layoutMode.value = 'full'
+    else if (width >= BREAKPOINTS.MEDIUM) layoutMode.value = 'medium'
     else if (width >= BREAKPOINTS.WIDE) layoutMode.value = 'wide'
     else layoutMode.value = 'narrow'
   })
@@ -989,7 +1196,7 @@ const rvBarColor = computed(() => {
   return '#22c55e'
 })
 
-defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, visibleCards, hiddenCards, hiddenCardIds, chipCardIds, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, onFullRowReorder, _fullRow, logoUrl, iconUrl, brandingMode, activeBrandingUrl, toggleBranding, toggleCardVisibility, toggleCardChips })
+defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, layoutMode, activeCards, visibleCards, hiddenCards, hiddenCardIds, chipCardIds, col1Cards, col2Cards, col3Cards, fullRowCards, isDragging, onColReorder, onDragEnd, onFullRowDragEnd, onFullRowReorder, _fullRow, logoUrl, iconUrl, brandingMode, activeBrandingUrl, toggleBranding, toggleCardVisibility, toggleCardChips })
 </script>
 
 <style scoped>
@@ -1469,7 +1676,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 }
 
 /* ── Sections: narrow (< 360px) — single flex column ── */
-/* Breakpoint constants — must match BREAKPOINTS in JS: WIDE=360, FULL=1024 */
+/* Breakpoint constants — must match BREAKPOINTS in JS: WIDE=360, MEDIUM=720, FULL=1024 */
 .eqv3-sections {
   display: flex;
   flex-direction: column;
@@ -1484,6 +1691,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
 
 /* Col-2 hidden at narrow */
 .eqv3-col-2 { display: none; }
+.eqv3-col-3 { display: none; }
 
 /* Full-row draggable: horizontal flex, cards stretch to equal height */
 .eqv3-full-row-draggable {
@@ -1507,6 +1715,11 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   }
   .eqv3-col-1 { flex: 1; }
   .eqv3-col-2 { display: flex; flex: 1; }
+}
+
+/* ── MEDIUM mode (720px+): three flex columns, hero on top ── */
+@container (min-width: 720px) {
+  .eqv3-col-3 { display: flex; flex: 1; }
 }
 
 /* ── FULL mode (1024px+): hero left, single horizontal card row right ── */

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
@@ -661,18 +661,19 @@ describe('Card layout and settings', () => {
     expect(wrapper.vm.activeCards.length).toBe(6)
   })
 
-  test('test_EnhancedQuoteV3_with_custom_cardOrder_expect_activeCards_respects_order', () => {
-    // Arrange: full 6-card custom order including prev
-    const customOrder = ['volume', 'session', 'company', 'short', 'today', 'prev']
+  test('test_EnhancedQuoteV3_with_custom_columns_expect_activeCards_respects_order', () => {
+    // Arrange: custom column assignment; flat order is col0 + col1 + col2
+    const columns = [['volume', 'session'], ['company', 'short'], ['today', 'prev']]
+    const expectedOrder = ['volume', 'session', 'company', 'short', 'today', 'prev']
 
     // Act
-    const wrapper = mountWidget({ settings: { cardOrder: customOrder } })
+    const wrapper = mountWidget({ settings: { columns } })
 
     // Assert
-    expect(wrapper.vm.activeCards.map(c => c.id)).toEqual(customOrder)
+    expect(wrapper.vm.activeCards.map(c => c.id)).toEqual(expectedOrder)
   })
 
-  test('test_EnhancedQuoteV3_with_onDragEnd_expect_update_settings_emitted_with_cardOrder', async () => {
+  test('test_EnhancedQuoteV3_with_onDragEnd_expect_update_settings_emitted_with_columns', async () => {
     // Arrange
     const updateSettingsCalls = []
     const wrapper = mount(EnhancedQuoteV3, {
@@ -684,7 +685,7 @@ describe('Card layout and settings', () => {
     wrapper.vm.quoteData = { ...SAMPLE_QUOTE }
     await wrapper.vm.$nextTick()
 
-    // Act: simulate col1 reorder then drag end (narrow mode — all cards in col1 including prev)
+    // Act: simulate col1 reorder then drag end (narrow mode — all cards in col1)
     const reordered = ['today', 'session', 'prev', 'volume', 'short', 'company']
     wrapper.vm.onColReorder(
       reordered.map(id => ({ id, label: id })),
@@ -693,9 +694,13 @@ describe('Card layout and settings', () => {
     await wrapper.vm.onDragEnd()
     await wrapper.vm.$nextTick()
 
-    // Assert: saved order reflects the reordered list directly (no special-casing for prev)
-    expect(updateSettingsCalls.length).toBe(1)
-    expect(updateSettingsCalls[0].cardOrder).toEqual(reordered)
+    // Assert: narrow mode emits columns: [reordered, [], []]
+    // (The first emit may be from the migration shim; find the onDragEnd emit)
+    const dragEmit = updateSettingsCalls.find(c => Array.isArray(c.columns))
+    expect(dragEmit).toBeDefined()
+    expect(dragEmit.columns[0]).toEqual(reordered)
+    expect(dragEmit.columns[1]).toEqual([])
+    expect(dragEmit.columns[2]).toEqual([])
   })
 
   test('test_EnhancedQuoteV3_with_narrow_layout_default_expect_col2_not_rendered', async () => {
@@ -778,11 +783,10 @@ describe('Card layout and settings', () => {
     expect(wrapper.vm.fullRowCards.map(c => c.id)).toContain('prev')
   })
 
-  test('test_EnhancedQuoteV3_onFullRowReorder_emits_update_settings_with_reordered_cardOrder', async () => {
+  test('test_EnhancedQuoteV3_onFullRowReorder_emits_update_settings_with_columns_collapsed_to_col1', async () => {
     // Arrange
-    // vuedraggable fires @update:model-value (onFullRowReorder) AFTER @end,
-    // so the emit is driven directly from the updated list rather than reading
-    // a stale _fullRow ref set in @end.
+    // Full-mode reorder collapses all cards into col1 (intentional — see design doc decision #3).
+    // vuedraggable fires @update:model-value (onFullRowReorder) AFTER @end.
     const updateSettingsCalls = []
     const wrapper = mount(EnhancedQuoteV3, {
       props: { isLocked: false, settings: {} },
@@ -798,9 +802,12 @@ describe('Card layout and settings', () => {
     const reordered = ['prev', 'today', 'volume', 'session', 'short', 'company']
     wrapper.vm.onFullRowReorder(reordered.map(id => ({ id, label: id })))
 
-    // Assert: full reordered list saved including prev in its new position
-    expect(updateSettingsCalls.length).toBe(1)
-    expect(updateSettingsCalls[0].cardOrder).toEqual(reordered)
+    // Assert: emits columns: [reordered, [], []] — all cards in col1, col2/col3 empty
+    const emitted = updateSettingsCalls.find(c => Array.isArray(c.columns))
+    expect(emitted).toBeDefined()
+    expect(emitted.columns[0]).toEqual(reordered)
+    expect(emitted.columns[1]).toEqual([])
+    expect(emitted.columns[2]).toEqual([])
   })
 })
 
@@ -1133,5 +1140,141 @@ describe('Exposed interface', () => {
     expect(wrapper.vm.onFullRowDragEnd).toBeDefined()
     expect(wrapper.vm.onFullRowReorder).toBeDefined()
     expect(wrapper.vm._fullRow).toBeDefined()
+    expect(wrapper.vm.col1Cards).toBeDefined()
+    expect(wrapper.vm.col2Cards).toBeDefined()
+    expect(wrapper.vm.col3Cards).toBeDefined()
+  })
+})
+
+describe('Three-column layout and settings migration', () => {
+  test('test_EnhancedQuoteV3_migration_shim_with_flat_cardOrder_expect_columns_emitted', async () => {
+    // Arrange: old flat cardOrder shape
+    const updateSettingsCalls = []
+    const cardOrder = ['today', 'prev', 'volume', 'session', 'short', 'company']
+
+    // Act: mount with legacy settings — watch(immediate) fires migration shim
+    mount(EnhancedQuoteV3, {
+      props: { isLocked: true, settings: { cardOrder } },
+      attrs: { 'onUpdate-settings': (payload) => updateSettingsCalls.push(payload) },
+    })
+    await nextTick()
+
+    // Assert: shim emits columns shape with cardOrder removed
+    expect(updateSettingsCalls.length).toBeGreaterThanOrEqual(1)
+    const migrated = updateSettingsCalls[0]
+    expect(Array.isArray(migrated.columns)).toBe(true)
+    expect(migrated.columns[0]).toEqual(['today', 'prev', 'volume'])
+    expect(migrated.columns[1]).toEqual(['session', 'short', 'company'])
+    expect(migrated.columns[2]).toEqual([])
+    expect(migrated.cardOrder).toBeUndefined()
+  })
+
+  test('test_EnhancedQuoteV3_migration_shim_with_columns_present_expect_no_emit', async () => {
+    // Arrange: already-migrated settings
+    const updateSettingsCalls = []
+    const columns = [['today', 'prev'], ['volume', 'session'], ['short', 'company']]
+
+    // Act
+    mount(EnhancedQuoteV3, {
+      props: { isLocked: true, settings: { columns } },
+      attrs: { 'onUpdate-settings': (payload) => updateSettingsCalls.push(payload) },
+    })
+    await nextTick()
+
+    // Assert: no migration emit (shim is idempotent)
+    expect(updateSettingsCalls.length).toBe(0)
+  })
+
+  test('test_EnhancedQuoteV3_col3Cards_with_medium_layoutMode_expect_col3_contents', async () => {
+    // Arrange: columns assigned, layoutMode forced to medium
+    const columns = [['today', 'prev'], ['volume', 'session'], ['short', 'company']]
+    const wrapper = mountWidget({ settings: { columns } })
+
+    // Act
+    wrapper.vm.layoutMode = 'medium'
+    await nextTick()
+
+    // Assert: col3Cards reflects columns[2]
+    expect(wrapper.vm.col3Cards.map(c => c.id)).toEqual(['short', 'company'])
+  })
+
+  test('test_EnhancedQuoteV3_col3Cards_with_non_medium_layoutMode_expect_empty', async () => {
+    // Arrange
+    const columns = [['today', 'prev'], ['volume', 'session'], ['short', 'company']]
+    const wrapper = mountWidget({ settings: { columns } })
+
+    // Act: wide mode
+    wrapper.vm.layoutMode = 'wide'
+    await nextTick()
+
+    // Assert: col3Cards is empty outside medium mode
+    expect(wrapper.vm.col3Cards).toEqual([])
+  })
+
+  test('test_EnhancedQuoteV3_col1Cards_with_narrow_layoutMode_expect_all_columns_flattened', async () => {
+    // Arrange: cards spread across three columns
+    const columns = [['today'], ['volume'], ['short']]
+    const wrapper = mountWidget({ settings: { columns } })
+
+    // Act: narrow is the default layoutMode
+    await nextTick()
+
+    // Assert: col1Cards flattens all columns so no cards disappear at narrow width
+    const ids = wrapper.vm.col1Cards.map(c => c.id)
+    expect(ids).toContain('today')
+    expect(ids).toContain('volume')
+    expect(ids).toContain('short')
+  })
+
+  test('test_EnhancedQuoteV3_onDragEnd_with_medium_mode_col1_to_col3_expect_col2_unchanged', async () => {
+    // Arrange: cross-column drag from col1 to col3 — col2 must be preserved (Bishop #1)
+    const updateSettingsCalls = []
+    const columns = [['today', 'prev'], ['volume', 'session'], ['short', 'company']]
+    const wrapper = mount(EnhancedQuoteV3, {
+      props: { isLocked: false, settings: { columns } },
+      attrs: { 'onUpdate-settings': (payload) => updateSettingsCalls.push(payload) },
+    })
+    wrapper.vm.layoutMode = 'medium'
+    await nextTick()
+
+    // Act: drag 'today' from col1 to col3; col2 (_col2) is never updated (null → falls back to col2Cards)
+    wrapper.vm.onColReorder([{ id: 'prev', label: 'Previous Day' }], 1)  // col1 lost 'today'
+    wrapper.vm.onColReorder([{ id: 'short', label: 'Short Interest' }, { id: 'company', label: 'Company' }, { id: 'today', label: 'Today' }], 3)  // col3 gained 'today'
+    // _col2 is NOT updated — simulates col2 being untouched in a cross-col drag
+    await wrapper.vm.onDragEnd()
+    await nextTick()
+
+    // Assert: col2 contents (from col2Cards fallback) are unchanged in emitted columns[1]
+    const emitted = updateSettingsCalls.find(c => Array.isArray(c.columns))
+    expect(emitted).toBeDefined()
+    expect(emitted.columns[1]).toEqual(['volume', 'session'])  // col2 preserved
+    expect(emitted.columns[0]).toEqual(['prev'])
+    expect(emitted.columns[2]).toEqual(['short', 'company', 'today'])
+  })
+
+  test('test_EnhancedQuoteV3_col3_hidden_card_with_narrow_fallback_expect_absent', async () => {
+    // Arrange: 'short' assigned to col3 AND hidden — Bishop #5
+    const columns = [['today', 'prev'], ['volume', 'session'], ['short', 'company']]
+    const wrapper = mountWidget({ settings: { columns, hiddenCards: ['short'] } })
+
+    // Act: narrow mode — col1Cards flattens all columns
+    await nextTick()
+
+    // Assert: 'short' is absent from narrow flatten because it is hidden
+    const ids = wrapper.vm.col1Cards.map(c => c.id)
+    expect(ids).not.toContain('short')
+    expect(ids).toContain('company')  // other col3 card is present
+  })
+
+  test('test_EnhancedQuoteV3_unassigned_card_with_columns_shape_expect_appended_to_col1', async () => {
+    // Arrange: columns present but 'short' is not assigned to any column
+    const columns = [['today', 'prev'], ['volume', 'session'], ['company']]
+    const wrapper = mountWidget({ settings: { columns } })
+    wrapper.vm.layoutMode = 'wide'
+    await nextTick()
+
+    // Assert: unassigned 'short' appears in col1Cards
+    const ids = wrapper.vm.col1Cards.map(c => c.id)
+    expect(ids).toContain('short')
   })
 })


### PR DESCRIPTION
Implements the design approved in `Projects/EnhancedQuoteV3-Three-Column-Design.md` (Tom-approved, Bishop-reviewed).

## Changes

### New breakpoint
`MEDIUM: 720` added to `BREAKPOINTS`. Layout modes: narrow (<360px) → wide (360–719px) → **medium (720–1023px)** → full (≥1024px).

### Settings shape migration
`cardOrder` (flat array) is replaced by `columns` (nested array):
```json
{ "columns": [["today", "prev"], ["volume", "session"], ["short", "company"]] }
```
A `watch({ immediate: true })` migration shim converts legacy saves on first load. Idempotent — no-ops if `columns` is already present.

### Sticky per-column card assignment
- `col1Cards` / `col2Cards` / `col3Cards` read from `settings.columns[n]`
- Unassigned registry cards silently append to col1
- Cross-column drag updates all three columns in `onDragEnd`
- Full-mode reorder collapses all cards to col1 (intentional — user controls auto-save)

### Narrow fallback
`col1Cards` flattens all three columns at narrow width so no cards disappear when the widget is squeezed.

### col3 template
Three-column draggable block (identical card rendering to col1/col2), shown only when `layoutMode === 'medium'`.

### `defineExpose`
`col1Cards` and `col2Cards` added (previously internal-only).

## Tests
120/120 passing. 8 new tests:
- Migration shim (flat → columns, idempotent guard)
- col3Cards (medium mode, non-medium empty)
- col1Cards narrow flatten
- Cross-col drag col1→col3 with col2 preserved (Bishop #1)
- Hidden card in col3 absent from narrow flatten (Bishop #5)
- Unassigned card falls to col1
- Exposed API assertions for col1Cards / col2Cards / col3Cards

refs #183