### PR TITLE
fix(EQv3): add min-height to columns so empty col3 has a drop target

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -1687,6 +1687,7 @@ defineExpose({ lastDataAt, isConnected, reconnecting, quoteData, manualTicker, c
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-height: 48px;  /* ensures empty columns have a drop target for vuedraggable */
 }
 
 /* Col-2 hidden at narrow */


### PR DESCRIPTION
vuedraggable cannot accept drops into a zero-height empty list — there's no DOM to drop onto. Adding `min-height: 48px` to `.eqv3-col` ensures all columns always have a visible drop zone, including col3 when it starts empty.

120/120 tests passing.

refs #183