### PR TITLE
fix(EQv3): fix cross-column drag by emitting from onColReorder not onDragEnd

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -887,17 +887,20 @@ const _col2 = ref(null)
 const _col3 = ref(null)
 const _fullRow = ref(null)
 
-const onColReorder = (newVal, colNum) => {
+// onColReorder is called by @update:model-value, which fires AFTER @end per vuedraggable's
+// event order. For cross-column drags it fires once per affected column. We accumulate
+// the new column state here and schedule a single coalesced emit via nextTick.
+let _emitScheduled = false
+const onColReorder = async (newVal, colNum) => {
   if (colNum === 1) _col1.value = newVal
   else if (colNum === 2) _col2.value = newVal
   else _col3.value = newVal
-}
 
-// Drag end for narrow/wide/medium column layout.
-const onDragEnd = async () => {
-  isDragging.value = false
-  await nextTick()
-  await nextTick()
+  if (_emitScheduled) return
+  _emitScheduled = true
+  await nextTick()  // yield — lets any second @update:model-value (cross-col) run first
+  _emitScheduled = false
+
   const c1 = (_col1.value ?? col1Cards.value).map(c => c.id)
   const c2 = (_col2.value ?? col2Cards.value).map(c => c.id)
   const c3 = (_col3.value ?? col3Cards.value).map(c => c.id)
@@ -911,6 +914,10 @@ const onDragEnd = async () => {
       : [c1, c2, []]
   emit('update-settings', { ...props.settings, columns })
 }
+
+// onDragEnd: only updates isDragging. Emit is driven by onColReorder (@update:model-value)
+// which fires after @end — same pattern as onFullRowReorder in full mode.
+const onDragEnd = () => { isDragging.value = false }
 
 // Full-mode flat row reorder — fires from @update:model-value (after vuedraggable updates the list).
 // NOTE: vuedraggable fires @end before @update:model-value, so we cannot read the new order in @end.


### PR DESCRIPTION
## Root cause

vuedraggable fires `@end` **before** `@update:model-value`. The previous implementation relied on `@end` (`onDragEnd`) to emit the updated column state, but `_col1/2/3` were always `null` at that point because `onColReorder` (`@update:model-value`) hadn't fired yet. Cross-column drags always fell back to stale `props.settings.columns`, so the second drag saw the same pre-drag state and appeared stuck.

## Fix

Move the emit into `onColReorder` (`@update:model-value`) — the same pattern already used by `onFullRowReorder` in full mode. For cross-column drags, vuedraggable fires `@update:model-value` twice (once per affected column); a `nextTick` debounce coalesces both fires into a single emit with the correct final state of all three columns.

`onDragEnd` is now a single-line `isDragging = false` setter.

## Tests

120/120 passing — no test changes needed; existing tests call `onColReorder` directly and await `nextTick`, which aligns with the new async behavior.

refs #183