### PR TITLE
feat(EQv4): add 7 card SFCs with spec

### DIFF
--- a/client/src/components/widgets/EQV4CompanyCard.vue
+++ b/client/src/components/widgets/EQV4CompanyCard.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="eqv4-card-body">
+    <div v-if="loading" class="eqv4-muted-msg">Company data loading...</div>
+    <div v-else-if="allNull" class="eqv4-muted-msg">Company data unavailable</div>
+    <div v-else>
+      <div class="eqv4-kv-list">
+        <div v-if="data.homepage_url" class="eqv4-kv">
+          <span class="eqv4-k">Web</span>
+          <a :href="data.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv4-link">{{ truncateUrl(data.homepage_url) }}</a>
+        </div>
+        <div class="eqv4-kv"><span class="eqv4-k">Exchange</span><span class="eqv4-v">{{ data.primary_exchange || '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Mkt Cap</span><span class="eqv4-v">{{ data.market_cap != null ? '$' + fmtVol(data.market_cap) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Employees</span><span class="eqv4-v">{{ data.total_employees != null ? fmtVol(data.total_employees) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Listed</span><span class="eqv4-v">{{ data.list_date || '—' }}</span></div>
+      </div>
+      <div v-if="data.description" class="eqv4-company-desc-wrap">
+        <span class="eqv4-company-desc-text">
+          {{ expanded ? data.description : truncateDesc(data.description) }}
+        </span>
+        <span v-if="!expanded && truncateDesc(data.description) !== data.description">
+          <span class="eqv4-company-desc-ellipsis">… </span>
+          <button class="eqv4-see-more" @click="expanded = true">see more</button>
+        </span>
+        <button v-if="expanded" class="eqv4-see-more" @click="expanded = false"> less</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { truncateUrl, truncateDesc, fmtVol } from './eqv3Utils.js'
+
+const props = defineProps({
+  data:     { type: Object,  default: () => ({}) },
+  loading:  { type: Boolean, default: false },
+  isLocked: { type: Boolean, default: true },
+})
+
+const expanded = ref(false)
+
+const allNull = computed(() => {
+  const d = props.data
+  if (!d) return true
+  return d.name == null && d.sic_description == null && d.description == null && d.homepage_url == null
+})
+</script>
+
+<style scoped>
+.eqv4-card-body { height: 100%; overflow: auto; padding: 6px; box-sizing: border-box; }
+.eqv4-kv-list { display: flex; flex-direction: column; gap: 2px; }
+.eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
+.eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
+.eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
+.eqv4-link { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--accent, #7c3aed); text-decoration: none; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 160px; text-align: right; }
+.eqv4-link:hover { text-decoration: underline; }
+.eqv4-company-desc-wrap { margin-top: 6px; font-size: 11px; color: var(--text-muted, #64748b); line-height: 1.4; white-space: normal; }
+.eqv4-company-desc-text { font-size: 11px; color: var(--text-muted, #64748b); }
+.eqv4-company-desc-ellipsis { color: var(--text-muted, #64748b); }
+.eqv4-see-more { background: none; border: none; color: var(--accent, #7c3aed); font-size: 11px; cursor: pointer; padding: 0; font-family: system-ui, sans-serif; text-decoration: underline; text-underline-offset: 2px; }
+.eqv4-see-more:hover { opacity: 0.8; }
+.eqv4-muted-msg { font-size: 11px; color: var(--text-muted, #64748b); font-style: italic; }
+</style>

--- a/client/src/components/widgets/EQV4CompanyCard.vue
+++ b/client/src/components/widgets/EQV4CompanyCard.vue
@@ -4,20 +4,20 @@
     <div v-else-if="allNull" class="eqv4-muted-msg">Company data unavailable</div>
     <div v-else>
       <div class="eqv4-kv-list">
-        <div v-if="data.homepage_url" class="eqv4-kv">
+        <div v-if="companyData.homepage_url" class="eqv4-kv">
           <span class="eqv4-k">Web</span>
-          <a :href="data.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv4-link">{{ truncateUrl(data.homepage_url) }}</a>
+          <a :href="companyData.homepage_url" target="_blank" rel="noopener noreferrer" class="eqv4-link">{{ truncateUrl(companyData.homepage_url) }}</a>
         </div>
-        <div class="eqv4-kv"><span class="eqv4-k">Exchange</span><span class="eqv4-v">{{ data.primary_exchange || '—' }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Mkt Cap</span><span class="eqv4-v">{{ data.market_cap != null ? '$' + fmtVol(data.market_cap) : '—' }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Employees</span><span class="eqv4-v">{{ data.total_employees != null ? fmtVol(data.total_employees) : '—' }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Listed</span><span class="eqv4-v">{{ data.list_date || '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Exchange</span><span class="eqv4-v">{{ companyData.primary_exchange || '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Mkt Cap</span><span class="eqv4-v">{{ companyData.market_cap != null ? '$' + fmtVol(companyData.market_cap) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Employees</span><span class="eqv4-v">{{ companyData.total_employees != null ? fmtVol(companyData.total_employees) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Listed</span><span class="eqv4-v">{{ companyData.list_date || '—' }}</span></div>
       </div>
-      <div v-if="data.description" class="eqv4-company-desc-wrap">
+      <div v-if="companyData.description" class="eqv4-company-desc-wrap">
         <span class="eqv4-company-desc-text">
-          {{ expanded ? data.description : truncateDesc(data.description) }}
+          {{ expanded ? companyData.description : truncateDesc(companyData.description) }}
         </span>
-        <span v-if="!expanded && truncateDesc(data.description) !== data.description">
+        <span v-if="!expanded && truncateDesc(companyData.description) !== companyData.description">
           <span class="eqv4-company-desc-ellipsis">… </span>
           <button class="eqv4-see-more" @click="expanded = true">see more</button>
         </span>
@@ -32,17 +32,26 @@ import { ref, computed } from 'vue'
 import { truncateUrl, truncateDesc, fmtVol } from './eqv3Utils.js'
 
 const props = defineProps({
-  data:     { type: Object,  default: () => ({}) },
-  loading:  { type: Boolean, default: false },
-  isLocked: { type: Boolean, default: true },
+  companyData: { type: Object,  default: () => ({}) },
+  loading:     { type: Boolean, default: false },
+  isLocked:    { type: Boolean, default: true },
 })
 
 const expanded = ref(false)
 
 const allNull = computed(() => {
-  const d = props.data
+  const d = props.companyData
   if (!d) return true
-  return d.name == null && d.sic_description == null && d.description == null && d.homepage_url == null
+  return (
+    d.homepage_url == null &&
+    d.primary_exchange == null &&
+    d.market_cap == null &&
+    d.total_employees == null &&
+    d.list_date == null &&
+    d.name == null &&
+    d.sic_description == null &&
+    d.description == null
+  )
 })
 </script>
 

--- a/client/src/components/widgets/EQV4HeroCard.vue
+++ b/client/src/components/widgets/EQV4HeroCard.vue
@@ -1,0 +1,188 @@
+<template>
+  <div class="eqv4-hero-card">
+    <!-- Symbol + branding image -->
+    <div class="eqv4-hero-symbol-block">
+      <img
+        v-if="activeBrandingUrl"
+        :src="activeBrandingUrl"
+        class="eqv4-hero-logo"
+        :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
+      />
+      <div class="eqv4-hero-symbol-row">
+        <span class="eqv4-symbol">{{ quoteData.symbol }}</span>
+        <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
+      </div>
+      <!-- Branding toggle — edit mode only -->
+      <button
+        v-if="!isLocked"
+        class="eqv4-branding-toggle filter-btn"
+        :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
+        @click="emit('toggle-branding')"
+      >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
+    </div>
+
+    <!-- Price block -->
+    <div class="eqv4-hero-price-block">
+      <span class="eqv4-price">${{ fmt(quoteData.close, 2) }}</span>
+      <span :class="['eqv4-change-badge', changeClass]">
+        {{ quoteData.change >= 0 ? '+' : '' }}{{ fmt(quoteData.change, 2) }}
+        ({{ quoteData.pct_change >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change, 2) }}%)
+      </span>
+      <div class="eqv4-since-open">
+        since open
+        <span :class="quoteData.pct_change_since_open >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
+          <span v-if="quoteData.change_since_open != null">
+            {{ quoteData.change_since_open >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData.change_since_open), 2) }}
+          </span>
+          ({{ quoteData.pct_change_since_open >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change_since_open, 2) }}%)
+        </span>
+      </div>
+      <div class="eqv4-as-of">as of {{ dataAge }}</div>
+    </div>
+
+    <!-- Identity block: name + SIC -->
+    <div class="eqv4-hero-identity-block">
+      <span v-if="companyName" class="eqv4-hero-company-name">{{ companyName }}</span>
+      <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  quoteData:      { type: Object,  required: true },
+  companyData:    { type: Object,  default: () => ({}) },
+  isLocked:       { type: Boolean, default: true },
+  brandingMode:   { type: String,  default: 'logo' },
+  activeBrandingUrl: { type: String, default: null },
+  flameIcon:      { type: Object,  default: null },
+})
+
+const emit = defineEmits(['toggle-branding'])
+
+const fmt = (val, decimals = 2) => {
+  const n = parseFloat(val)
+  return isFinite(n) ? n.toFixed(decimals) : '—'
+}
+
+const changeClass = computed(() => {
+  if (!props.quoteData) return ''
+  return props.quoteData.pct_change >= 0 ? 'positive' : 'negative'
+})
+
+const dataAge = computed(() => {
+  const ts = props.quoteData?.end_timestamp
+  if (!ts) return '—'
+  return new Date(ts).toLocaleString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+})
+
+const companyName = computed(() => props.companyData?.name ?? null)
+</script>
+
+<style scoped>
+.eqv4-hero-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  height: 100%;
+  overflow: auto;
+  padding: 6px;
+  box-sizing: border-box;
+}
+.eqv4-hero-symbol-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.eqv4-hero-logo {
+  height: 32px;
+  max-width: 120px;
+  object-fit: contain;
+}
+.eqv4-hero-symbol-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.eqv4-symbol {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary, #e2e8f0);
+}
+.eqv4-flame-icon {
+  width: 16px;
+  height: 16px;
+}
+.eqv4-branding-toggle {
+  align-self: flex-start;
+  margin-top: 2px;
+}
+.eqv4-hero-price-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.eqv4-price {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary, #e2e8f0);
+}
+.eqv4-change-badge {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  align-self: flex-start;
+}
+.eqv4-change-badge.positive { background: rgba(34,197,94,0.15); color: #22c55e; }
+.eqv4-change-badge.negative { background: rgba(239,68,68,0.15);  color: #ef4444; }
+.eqv4-since-open {
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+}
+.eqv4-pos { color: #22c55e; }
+.eqv4-neg { color: #ef4444; }
+.eqv4-as-of {
+  font-size: 10px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+}
+.eqv4-hero-identity-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.eqv4-hero-company-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary, #e2e8f0);
+}
+.eqv4-hero-sic {
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+}
+/* Shared filter-btn style (matches EQv3 pill style) */
+.filter-btn {
+  background: none;
+  border: 1px solid var(--border, #2d2d3d);
+  border-radius: 4px;
+  color: var(--text-muted, #64748b);
+  font-size: 11px;
+  padding: 2px 6px;
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  transition: border-color 0.15s, color 0.15s;
+}
+.filter-btn:hover {
+  border-color: var(--pd-accent, #7c3aed);
+  color: var(--pd-accent, #7c3aed);
+}
+</style>

--- a/client/src/components/widgets/EQV4HeroCard.vue
+++ b/client/src/components/widgets/EQV4HeroCard.vue
@@ -9,7 +9,7 @@
         :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
       />
       <div class="eqv4-hero-symbol-row">
-        <span class="eqv4-symbol">{{ quoteData.symbol }}</span>
+        <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
         <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
       </div>
       <!-- Branding toggle — edit mode only -->
@@ -23,18 +23,18 @@
 
     <!-- Price block -->
     <div class="eqv4-hero-price-block">
-      <span class="eqv4-price">${{ fmt(quoteData.close, 2) }}</span>
+      <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
       <span :class="['eqv4-change-badge', changeClass]">
-        {{ quoteData.change >= 0 ? '+' : '' }}{{ fmt(quoteData.change, 2) }}
-        ({{ quoteData.pct_change >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change, 2) }}%)
+        {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
+        ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
       </span>
       <div class="eqv4-since-open">
         since open
-        <span :class="quoteData.pct_change_since_open >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
-          <span v-if="quoteData.change_since_open != null">
-            {{ quoteData.change_since_open >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData.change_since_open), 2) }}
+        <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
+          <span v-if="quoteData?.change_since_open != null">
+            {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
           </span>
-          ({{ quoteData.pct_change_since_open >= 0 ? '+' : '' }}{{ fmt(quoteData.pct_change_since_open, 2) }}%)
+          ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
         </span>
       </div>
       <div class="eqv4-as-of">as of {{ dataAge }}</div>
@@ -50,6 +50,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { fmt } from './eqv3Utils.js'
 
 const props = defineProps({
   quoteData:      { type: Object,  required: true },
@@ -62,15 +63,9 @@ const props = defineProps({
 
 const emit = defineEmits(['toggle-branding'])
 
-const fmt = (val, decimals = 2) => {
-  const n = parseFloat(val)
-  return isFinite(n) ? n.toFixed(decimals) : '—'
-}
-
-const changeClass = computed(() => {
-  if (!props.quoteData) return ''
-  return props.quoteData.pct_change >= 0 ? 'positive' : 'negative'
-})
+const changeClass = computed(() =>
+  (props.quoteData?.pct_change ?? 0) >= 0 ? 'positive' : 'negative'
+)
 
 const dataAge = computed(() => {
   const ts = props.quoteData?.end_timestamp

--- a/client/src/components/widgets/EQV4PrevCard.vue
+++ b/client/src/components/widgets/EQV4PrevCard.vue
@@ -24,18 +24,13 @@
 </template>
 
 <script setup>
-import { fmtVol } from './eqv3Utils.js'
+import { fmt, fmtVol } from './eqv3Utils.js'
 
 defineProps({
   quoteData:  { type: Object,  required: true },
   isLocked:   { type: Boolean, default: true },
   chipsMode:  { type: Boolean, default: false },
 })
-
-const fmt = (val, decimals = 2) => {
-  const n = parseFloat(val)
-  return isFinite(n) ? n.toFixed(decimals) : '—'
-}
 </script>
 
 <style scoped>

--- a/client/src/components/widgets/EQV4PrevCard.vue
+++ b/client/src/components/widgets/EQV4PrevCard.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="eqv4-card-body">
+    <template v-if="chipsMode">
+      <div class="eqv4-chip-row">
+        <div class="eqv4-chip"><span class="eqv4-chip-label">O</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">H</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">L</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">C</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">Vol</span><span class="eqv4-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">VWAP</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+      </div>
+    </template>
+    <template v-else>
+      <div class="eqv4-kv-list">
+        <div class="eqv4-kv"><span class="eqv4-k">Open</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">High</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Low</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Close</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Volume</span><span class="eqv4-v">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">VWAP</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { fmtVol } from './eqv3Utils.js'
+
+defineProps({
+  quoteData:  { type: Object,  required: true },
+  isLocked:   { type: Boolean, default: true },
+  chipsMode:  { type: Boolean, default: false },
+})
+
+const fmt = (val, decimals = 2) => {
+  const n = parseFloat(val)
+  return isFinite(n) ? n.toFixed(decimals) : '—'
+}
+</script>
+
+<style scoped>
+.eqv4-card-body { height: 100%; overflow: auto; padding: 6px; box-sizing: border-box; }
+.eqv4-kv-list { display: flex; flex-direction: column; gap: 2px; }
+.eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
+.eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
+.eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
+.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
+.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
+.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); }
+</style>

--- a/client/src/components/widgets/EQV4SessionCard.vue
+++ b/client/src/components/widgets/EQV4SessionCard.vue
@@ -42,16 +42,13 @@
 </template>
 
 <script setup>
+import { fmt } from './eqv3Utils.js'
+
 defineProps({
   quoteData:  { type: Object,  required: true },
   isLocked:   { type: Boolean, default: true },
   chipsMode:  { type: Boolean, default: false },
 })
-
-const fmt = (val, decimals = 2) => {
-  const n = parseFloat(val)
-  return isFinite(n) ? n.toFixed(decimals) : '—'
-}
 </script>
 
 <style scoped>

--- a/client/src/components/widgets/EQV4SessionCard.vue
+++ b/client/src/components/widgets/EQV4SessionCard.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="eqv4-card-body">
+    <template v-if="chipsMode">
+      <div class="eqv4-session-chips">
+        <div class="eqv4-session-chip">
+          <span class="eqv4-chip-label">PRE</span>
+          <div v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null" class="eqv4-session-chip-vals">
+            <span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span>
+            <span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span>
+          </div>
+          <div v-else class="eqv4-session-chip-vals eqv4-muted-val">—</div>
+        </div>
+        <div class="eqv4-session-chip">
+          <span class="eqv4-chip-label">REG</span>
+          <div v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null" class="eqv4-session-chip-vals">
+            <span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span>
+            <span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span>
+          </div>
+          <div v-else class="eqv4-session-chip-vals eqv4-muted-val">—</div>
+        </div>
+        <div class="eqv4-session-chip">
+          <span class="eqv4-chip-label">AH</span>
+          <div v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null" class="eqv4-session-chip-vals">
+            <span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span>
+            <span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span>
+          </div>
+          <div v-else class="eqv4-session-chip-vals eqv4-muted-val">—</div>
+        </div>
+      </div>
+    </template>
+    <template v-else>
+      <div class="eqv4-kv-list">
+        <div class="eqv4-kv"><span class="eqv4-k">Pre High</span><span class="eqv4-v">{{ quoteData.pre_market_high != null ? '$' + fmt(quoteData.pre_market_high, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Pre Low</span><span class="eqv4-v">{{ quoteData.pre_market_low != null ? '$' + fmt(quoteData.pre_market_low, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Reg High</span><span class="eqv4-v">{{ quoteData.regular_session_high != null ? '$' + fmt(quoteData.regular_session_high, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Reg Low</span><span class="eqv4-v">{{ quoteData.regular_session_low != null ? '$' + fmt(quoteData.regular_session_low, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">AH High</span><span class="eqv4-v">{{ quoteData.after_hours_high != null ? '$' + fmt(quoteData.after_hours_high, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">AH Low</span><span class="eqv4-v">{{ quoteData.after_hours_low != null ? '$' + fmt(quoteData.after_hours_low, 2) : '—' }}</span></div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  quoteData:  { type: Object,  required: true },
+  isLocked:   { type: Boolean, default: true },
+  chipsMode:  { type: Boolean, default: false },
+})
+
+const fmt = (val, decimals = 2) => {
+  const n = parseFloat(val)
+  return isFinite(n) ? n.toFixed(decimals) : '—'
+}
+</script>
+
+<style scoped>
+.eqv4-card-body { height: 100%; overflow: auto; padding: 6px; box-sizing: border-box; }
+.eqv4-kv-list { display: flex; flex-direction: column; gap: 2px; }
+.eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
+.eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
+.eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
+.eqv4-session-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.eqv4-session-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 4px 8px; min-width: 56px; gap: 2px; }
+.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+.eqv4-session-chip-vals { display: flex; flex-direction: column; align-items: center; font-family: 'Roboto Mono', monospace; font-size: 11px; color: var(--text-primary, #e2e8f0); gap: 1px; }
+.eqv4-muted-val { color: var(--text-muted, #64748b); }
+</style>

--- a/client/src/components/widgets/EQV4ShortCard.vue
+++ b/client/src/components/widgets/EQV4ShortCard.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="eqv4-card-body">
+    <template v-if="chipsMode">
+      <div v-if="loading" class="eqv4-muted-msg">Short interest data loading...</div>
+      <div v-else-if="allNull" class="eqv4-muted-msg">Short interest data unavailable</div>
+      <div v-else class="eqv4-chip-row">
+        <div class="eqv4-chip"><span class="eqv4-chip-label">SI</span><span class="eqv4-chip-val">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">DTC</span><span class="eqv4-chip-val">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">SVR</span><span class="eqv4-chip-val">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
+      </div>
+    </template>
+    <template v-else>
+      <div v-if="loading" class="eqv4-muted-msg">Short interest data loading...</div>
+      <div v-else-if="allNull" class="eqv4-muted-msg">Short interest data unavailable</div>
+      <div v-else class="eqv4-kv-list">
+        <div class="eqv4-kv"><span class="eqv4-k">Short Int.</span><span class="eqv4-v">{{ fmtVol(shortInterestData.short_interest) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Days to Cover</span><span class="eqv4-v">{{ fmt(shortInterestData.days_to_cover, 1) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Short Vol Ratio</span><span class="eqv4-v">{{ fmt(shortInterestData.short_volume_ratio, 1) }}%</span></div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { fmtVol } from './eqv3Utils.js'
+
+const props = defineProps({
+  shortInterestData: { type: Object,  default: () => ({}) },
+  loading:           { type: Boolean, default: false },
+  isLocked:          { type: Boolean, default: true },
+  chipsMode:         { type: Boolean, default: false },
+})
+
+const fmt = (val, decimals = 2) => {
+  const n = parseFloat(val)
+  return isFinite(n) ? n.toFixed(decimals) : '—'
+}
+
+const allNull = computed(() => {
+  const d = props.shortInterestData
+  if (!d) return true
+  return d.short_interest == null && d.days_to_cover == null && d.short_volume_ratio == null
+})
+</script>
+
+<style scoped>
+.eqv4-card-body { height: 100%; overflow: auto; padding: 6px; box-sizing: border-box; }
+.eqv4-kv-list { display: flex; flex-direction: column; gap: 2px; }
+.eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
+.eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
+.eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
+.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
+.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
+.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); }
+.eqv4-muted-msg { font-size: 11px; color: var(--text-muted, #64748b); font-style: italic; }
+</style>

--- a/client/src/components/widgets/EQV4ShortCard.vue
+++ b/client/src/components/widgets/EQV4ShortCard.vue
@@ -23,7 +23,7 @@
 
 <script setup>
 import { computed } from 'vue'
-import { fmtVol } from './eqv3Utils.js'
+import { fmt, fmtVol } from './eqv3Utils.js'
 
 const props = defineProps({
   shortInterestData: { type: Object,  default: () => ({}) },
@@ -31,11 +31,6 @@ const props = defineProps({
   isLocked:          { type: Boolean, default: true },
   chipsMode:         { type: Boolean, default: false },
 })
-
-const fmt = (val, decimals = 2) => {
-  const n = parseFloat(val)
-  return isFinite(n) ? n.toFixed(decimals) : '—'
-}
 
 const allNull = computed(() => {
   const d = props.shortInterestData

--- a/client/src/components/widgets/EQV4TodayCard.vue
+++ b/client/src/components/widgets/EQV4TodayCard.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="eqv4-card-body">
+    <template v-if="chipsMode">
+      <div class="eqv4-chip-row">
+        <div class="eqv4-chip"><span class="eqv4-chip-label">O</span><span class="eqv4-chip-val">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">VWAP</span><span class="eqv4-chip-val">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+      </div>
+    </template>
+    <template v-else>
+      <div class="eqv4-kv-list">
+        <div class="eqv4-kv"><span class="eqv4-k">Open</span><span class="eqv4-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">VWAP</span><span class="eqv4-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  quoteData:  { type: Object,  required: true },
+  isLocked:   { type: Boolean, default: true },
+  chipsMode:  { type: Boolean, default: false },
+})
+
+const fmt = (val, decimals = 2) => {
+  const n = parseFloat(val)
+  return isFinite(n) ? n.toFixed(decimals) : '—'
+}
+</script>
+
+<style scoped>
+.eqv4-card-body { height: 100%; overflow: auto; padding: 6px; box-sizing: border-box; }
+.eqv4-kv-list { display: flex; flex-direction: column; gap: 2px; }
+.eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
+.eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
+.eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
+.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
+.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
+.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); }
+</style>

--- a/client/src/components/widgets/EQV4TodayCard.vue
+++ b/client/src/components/widgets/EQV4TodayCard.vue
@@ -16,16 +16,13 @@
 </template>
 
 <script setup>
+import { fmt } from './eqv3Utils.js'
+
 defineProps({
   quoteData:  { type: Object,  required: true },
   isLocked:   { type: Boolean, default: true },
   chipsMode:  { type: Boolean, default: false },
 })
-
-const fmt = (val, decimals = 2) => {
-  const n = parseFloat(val)
-  return isFinite(n) ? n.toFixed(decimals) : '—'
-}
 </script>
 
 <style scoped>

--- a/client/src/components/widgets/EQV4VolumeCard.vue
+++ b/client/src/components/widgets/EQV4VolumeCard.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="eqv4-card-body">
+    <template v-if="chipsMode">
+      <div class="eqv4-chip-row">
+        <div class="eqv4-chip"><span class="eqv4-chip-label">Vol</span><span class="eqv4-chip-val">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">Avg</span><span class="eqv4-chip-val">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">Float</span><span class="eqv4-chip-val">{{ fmtVol(floatShares) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">RVol</span><span :class="['eqv4-chip-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span></div>
+      </div>
+    </template>
+    <template v-else>
+      <div class="eqv4-kv-list">
+        <div class="eqv4-kv"><span class="eqv4-k">Volume</span><span class="eqv4-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Avg Vol</span><span class="eqv4-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Float</span><span class="eqv4-v">{{ fmtVol(floatShares) }}</span></div>
+      </div>
+      <div class="eqv4-rv-row">
+        <span class="eqv4-k">Rel. Vol</span>
+        <div class="eqv4-rv-bar-wrap"><div class="eqv4-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div></div>
+        <span :class="['eqv4-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { fmtVol } from './eqv3Utils.js'
+
+const props = defineProps({
+  quoteData:  { type: Object,  required: true },
+  isLocked:   { type: Boolean, default: true },
+  chipsMode:  { type: Boolean, default: false },
+})
+
+const fmt = (val, decimals = 2) => {
+  const n = parseFloat(val)
+  return isFinite(n) ? n.toFixed(decimals) : '—'
+}
+
+const floatShares = computed(() =>
+  props.quoteData?.free_float ?? props.quoteData?.share_class_shares_outstanding ?? null
+)
+
+const relVolClass = computed(() => {
+  const rv = parseFloat(props.quoteData?.relative_volume)
+  if (rv >= 5) return 'extreme'
+  if (rv >= 3) return 'high'
+  if (rv >= 2) return 'medium'
+  return ''
+})
+
+const rvBarWidth = computed(() => {
+  const rv = parseFloat(props.quoteData?.relative_volume)
+  if (!isFinite(rv)) return '0%'
+  return `${Math.min((rv / 5) * 100, 100)}%`
+})
+
+const rvBarColor = computed(() => {
+  const rv = parseFloat(props.quoteData?.relative_volume)
+  if (!isFinite(rv)) return '#22c55e'
+  if (rv >= 5) return '#dc2626'
+  if (rv >= 3) return '#f97316'
+  if (rv >= 2) return '#eab308'
+  return '#22c55e'
+})
+</script>
+
+<style scoped>
+.eqv4-card-body { height: 100%; overflow: auto; padding: 6px; box-sizing: border-box; }
+.eqv4-kv-list { display: flex; flex-direction: column; gap: 2px; }
+.eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
+.eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
+.eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
+.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
+.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
+.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); }
+.eqv4-chip-val.extreme { color: #dc2626; }
+.eqv4-chip-val.high    { color: #f97316; }
+.eqv4-chip-val.medium  { color: #eab308; }
+.eqv4-rv-row { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
+.eqv4-rv-bar-wrap { flex: 1; height: 6px; background: var(--surface, #141420); border-radius: 3px; overflow: hidden; border: 1px solid var(--border, #2d2d3d); }
+.eqv4-rv-bar { height: 100%; border-radius: 3px; transition: width 0.3s; }
+.eqv4-rv-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); min-width: 36px; text-align: right; }
+.eqv4-rv-val.extreme { color: #dc2626; }
+.eqv4-rv-val.high    { color: #f97316; }
+.eqv4-rv-val.medium  { color: #eab308; }
+</style>

--- a/client/src/components/widgets/EQV4VolumeCard.vue
+++ b/client/src/components/widgets/EQV4VolumeCard.vue
@@ -25,18 +25,13 @@
 
 <script setup>
 import { computed } from 'vue'
-import { fmtVol } from './eqv3Utils.js'
+import { fmt, fmtVol } from './eqv3Utils.js'
 
 const props = defineProps({
   quoteData:  { type: Object,  required: true },
   isLocked:   { type: Boolean, default: true },
   chipsMode:  { type: Boolean, default: false },
 })
-
-const fmt = (val, decimals = 2) => {
-  const n = parseFloat(val)
-  return isFinite(n) ? n.toFixed(decimals) : '—'
-}
 
 const floatShares = computed(() =>
   props.quoteData?.free_float ?? props.quoteData?.share_class_shares_outstanding ?? null

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4Cards.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4Cards.spec.js
@@ -72,6 +72,28 @@ describe('EQV4HeroCard', () => {
     expect(wrapper.text()).toContain('+2.30')
   })
 
+  test('with empty quoteData object expect no crash and dashes rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: {}, isLocked: true, brandingMode: 'logo', activeBrandingUrl: null },
+    })
+
+    // Act — (mount is the act)
+
+    // Assert — no throw; dashes for numeric fields
+    expect(wrapper.text()).toContain('—')
+  })
+
+  test('with null end_timestamp expect dataAge shows dash', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: { ...QUOTE, end_timestamp: null }, isLocked: true },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('as of —')
+  })
+
   test('with positive change expect positive badge class', () => {
     // Arrange
     const wrapper = mount(EQV4HeroCard, {
@@ -375,7 +397,7 @@ describe('EQV4CompanyCard', () => {
   test('with company data expect kv rows rendered', () => {
     // Arrange
     const wrapper = mount(EQV4CompanyCard, {
-      props: { data: COMPANY_DATA, loading: false },
+      props: { companyData: COMPANY_DATA, loading: false },
     })
 
     // Assert
@@ -388,7 +410,7 @@ describe('EQV4CompanyCard', () => {
   test('with loading true expect loading message', () => {
     // Arrange
     const wrapper = mount(EQV4CompanyCard, {
-      props: { data: {}, loading: true },
+      props: { companyData: {}, loading: true },
     })
 
     // Assert
@@ -399,18 +421,42 @@ describe('EQV4CompanyCard', () => {
   test('with all null data expect unavailable message', () => {
     // Arrange
     const wrapper = mount(EQV4CompanyCard, {
-      props: { data: { name: null, sic_description: null, description: null, homepage_url: null }, loading: false },
+      props: {
+        companyData: {
+          name: null, sic_description: null, description: null, homepage_url: null,
+          primary_exchange: null, market_cap: null, total_employees: null, list_date: null,
+        },
+        loading: false,
+      },
     })
 
     // Assert
     expect(wrapper.text()).toContain('unavailable')
   })
 
+  test('with only primary_exchange set expect kv rows rendered not unavailable message', () => {
+    // Arrange
+    const wrapper = mount(EQV4CompanyCard, {
+      props: {
+        companyData: {
+          name: null, sic_description: null, description: null, homepage_url: null,
+          primary_exchange: 'XNAS', market_cap: null, total_employees: null, list_date: null,
+        },
+        loading: false,
+      },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(true)
+    expect(wrapper.text()).toContain('XNAS')
+    expect(wrapper.text()).not.toContain('unavailable')
+  })
+
   test('with long description expect see more button and truncated text', () => {
     // Arrange
     const longDesc = 'A'.repeat(300)
     const wrapper = mount(EQV4CompanyCard, {
-      props: { data: { ...COMPANY_DATA, description: longDesc }, loading: false },
+      props: { companyData: { ...COMPANY_DATA, description: longDesc }, loading: false },
     })
 
     // Assert
@@ -422,7 +468,7 @@ describe('EQV4CompanyCard', () => {
     // Arrange
     const longDesc = 'B'.repeat(300)
     const wrapper = mount(EQV4CompanyCard, {
-      props: { data: { ...COMPANY_DATA, description: longDesc }, loading: false },
+      props: { companyData: { ...COMPANY_DATA, description: longDesc }, loading: false },
     })
 
     // Act
@@ -435,7 +481,7 @@ describe('EQV4CompanyCard', () => {
   test('with description shorter than maxLen expect no see more button', () => {
     // Arrange
     const wrapper = mount(EQV4CompanyCard, {
-      props: { data: { ...COMPANY_DATA, description: 'Short desc.' }, loading: false },
+      props: { companyData: { ...COMPANY_DATA, description: 'Short desc.' }, loading: false },
     })
 
     // Assert

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4Cards.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4Cards.spec.js
@@ -1,0 +1,444 @@
+import { describe, test, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import EQV4HeroCard    from '../EQV4HeroCard.vue'
+import EQV4TodayCard   from '../EQV4TodayCard.vue'
+import EQV4PrevCard    from '../EQV4PrevCard.vue'
+import EQV4VolumeCard  from '../EQV4VolumeCard.vue'
+import EQV4SessionCard from '../EQV4SessionCard.vue'
+import EQV4ShortCard   from '../EQV4ShortCard.vue'
+import EQV4CompanyCard from '../EQV4CompanyCard.vue'
+
+// Minimal quote data shared across card tests.
+const QUOTE = {
+  symbol: 'AAPL',
+  close: 189.5,
+  change: 2.3,
+  pct_change: 1.23,
+  change_since_open: 1.1,
+  pct_change_since_open: 0.58,
+  end_timestamp: new Date('2026-04-15T16:00:00Z').getTime(),
+  official_open_price: 188.0,
+  aggregate_vwap: 188.7,
+  prev_day_open: 185.0,
+  prev_day_high: 190.0,
+  prev_day_low: 184.5,
+  prev_day_close: 187.2,
+  prev_day_volume: 55000000,
+  prev_day_vwap: 186.9,
+  accumulated_volume: 62000000,
+  avg_volume: 58000000,
+  free_float: 15500000000,
+  relative_volume: 3.2,
+  pre_market_high: 188.5,
+  pre_market_low: 187.0,
+  regular_session_high: 190.0,
+  regular_session_low: 187.5,
+  after_hours_high: null,
+  after_hours_low: null,
+}
+
+const SHORT_DATA = {
+  short_interest: 125000000,
+  days_to_cover: 2.1,
+  short_volume_ratio: 38.5,
+}
+
+const COMPANY_DATA = {
+  name: 'Apple Inc.',
+  sic_description: 'Electronic Computers',
+  description: 'Apple designs and sells consumer electronics.',
+  homepage_url: 'https://apple.com',
+  primary_exchange: 'XNAS',
+  market_cap: 2900000000000,
+  total_employees: 164000,
+  list_date: '1980-12-12',
+}
+
+// ── EQV4HeroCard ─────────────────────────────────────────────────────────────
+
+describe('EQV4HeroCard', () => {
+  test('with quote data expect symbol and price rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: QUOTE, companyData: COMPANY_DATA, isLocked: true, brandingMode: 'logo', activeBrandingUrl: null },
+    })
+
+    // Act — (mount is the act)
+
+    // Assert
+    expect(wrapper.text()).toContain('AAPL')
+    expect(wrapper.text()).toContain('189.50')
+    expect(wrapper.text()).toContain('+2.30')
+  })
+
+  test('with positive change expect positive badge class', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: { ...QUOTE, pct_change: 1.5, change: 2.5 }, isLocked: true },
+    })
+
+    // Act
+    const badge = wrapper.find('.eqv4-change-badge')
+
+    // Assert
+    expect(badge.classes()).toContain('positive')
+  })
+
+  test('with negative change expect negative badge class', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: { ...QUOTE, pct_change: -1.5, change: -2.5 }, isLocked: true },
+    })
+
+    // Act
+    const badge = wrapper.find('.eqv4-change-badge')
+
+    // Assert
+    expect(badge.classes()).toContain('negative')
+  })
+
+  test('with isLocked false expect branding toggle button visible', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: QUOTE, isLocked: false, brandingMode: 'logo', activeBrandingUrl: null },
+    })
+
+    // Act
+    const btn = wrapper.find('.eqv4-branding-toggle')
+
+    // Assert
+    expect(btn.exists()).toBe(true)
+  })
+
+  test('with isLocked true expect branding toggle hidden', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: QUOTE, isLocked: true, brandingMode: 'logo', activeBrandingUrl: null },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-branding-toggle').exists()).toBe(false)
+  })
+
+  test('with branding toggle click expect toggle-branding event emitted', async () => {
+    // Arrange
+    const calls = []
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: QUOTE, isLocked: false, brandingMode: 'logo', activeBrandingUrl: null },
+      attrs: { 'onToggle-branding': () => calls.push(true) },
+    })
+
+    // Act
+    await wrapper.find('.eqv4-branding-toggle').trigger('click')
+
+    // Assert
+    expect(calls).toHaveLength(1)
+  })
+
+  test('with company data expect name and sic rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: QUOTE, companyData: COMPANY_DATA, isLocked: true },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('Apple Inc.')
+    expect(wrapper.text()).toContain('Electronic Computers')
+  })
+
+  test('with activeBrandingUrl expect logo img rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: QUOTE, isLocked: true, brandingMode: 'logo', activeBrandingUrl: 'https://cdn.example.com/logo.png' },
+    })
+
+    // Assert
+    expect(wrapper.find('img.eqv4-hero-logo').exists()).toBe(true)
+    expect(wrapper.find('img.eqv4-hero-logo').attributes('src')).toContain('logo.png')
+  })
+})
+
+// ── EQV4TodayCard ────────────────────────────────────────────────────────────
+
+describe('EQV4TodayCard', () => {
+  test('with list mode expect kv-list rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4TodayCard, { props: { quoteData: QUOTE, chipsMode: false } })
+
+    // Assert
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(true)
+    expect(wrapper.text()).toContain('188.00')
+    expect(wrapper.text()).toContain('188.70')
+  })
+
+  test('with chips mode expect chip row rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4TodayCard, { props: { quoteData: QUOTE, chipsMode: true } })
+
+    // Assert
+    expect(wrapper.find('.eqv4-chip-row').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(false)
+  })
+
+  test('with null open price expect dash rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4TodayCard, {
+      props: { quoteData: { ...QUOTE, official_open_price: null }, chipsMode: false },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('—')
+  })
+})
+
+// ── EQV4PrevCard ─────────────────────────────────────────────────────────────
+
+describe('EQV4PrevCard', () => {
+  test('with list mode expect all OHLCV kv rows rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4PrevCard, { props: { quoteData: QUOTE, chipsMode: false } })
+
+    // Assert
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(true)
+    expect(wrapper.text()).toContain('185.00')  // Open
+    expect(wrapper.text()).toContain('190.00')  // High
+    expect(wrapper.text()).toContain('55.0M')   // Volume
+  })
+
+  test('with chips mode expect chip row rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4PrevCard, { props: { quoteData: QUOTE, chipsMode: true } })
+
+    // Assert
+    expect(wrapper.find('.eqv4-chip-row').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(false)
+  })
+})
+
+// ── EQV4VolumeCard ───────────────────────────────────────────────────────────
+
+describe('EQV4VolumeCard', () => {
+  test('with list mode expect volume kv-list and rv bar rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4VolumeCard, { props: { quoteData: QUOTE, chipsMode: false } })
+
+    // Assert
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-rv-row').exists()).toBe(true)
+    expect(wrapper.text()).toContain('62.0M')   // Volume
+    expect(wrapper.text()).toContain('3.20x')   // RVol
+  })
+
+  test('with chips mode expect chip row with rvol rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4VolumeCard, { props: { quoteData: QUOTE, chipsMode: true } })
+
+    // Assert
+    expect(wrapper.find('.eqv4-chip-row').exists()).toBe(true)
+    expect(wrapper.text()).toContain('RVol')
+  })
+
+  test('with high rvol expect high class on rv value', () => {
+    // Arrange
+    const wrapper = mount(EQV4VolumeCard, {
+      props: { quoteData: { ...QUOTE, relative_volume: 4.1 }, chipsMode: false },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-rv-val.high').exists()).toBe(true)
+  })
+
+  test('with extreme rvol expect extreme class on rv value', () => {
+    // Arrange
+    const wrapper = mount(EQV4VolumeCard, {
+      props: { quoteData: { ...QUOTE, relative_volume: 6.0 }, chipsMode: false },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-rv-val.extreme').exists()).toBe(true)
+  })
+
+  test('with free_float null and shares_outstanding set expect float from shares_outstanding', () => {
+    // Arrange
+    const wrapper = mount(EQV4VolumeCard, {
+      props: {
+        quoteData: { ...QUOTE, free_float: null, share_class_shares_outstanding: 9000000000 },
+        chipsMode: false,
+      },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('9.0B')
+  })
+})
+
+// ── EQV4SessionCard ──────────────────────────────────────────────────────────
+
+describe('EQV4SessionCard', () => {
+  test('with list mode expect pre/reg/ah kv rows', () => {
+    // Arrange
+    const wrapper = mount(EQV4SessionCard, { props: { quoteData: QUOTE, chipsMode: false } })
+
+    // Assert
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Pre High')
+    expect(wrapper.text()).toContain('188.50')
+    expect(wrapper.text()).toContain('Reg High')
+  })
+
+  test('with chips mode expect session chips rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4SessionCard, { props: { quoteData: QUOTE, chipsMode: true } })
+
+    // Assert
+    expect(wrapper.find('.eqv4-session-chips').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(false)
+    expect(wrapper.text()).toContain('PRE')
+    expect(wrapper.text()).toContain('REG')
+    expect(wrapper.text()).toContain('AH')
+  })
+
+  test('with null after_hours values expect dash in chips mode', () => {
+    // Arrange
+    const wrapper = mount(EQV4SessionCard, {
+      props: {
+        quoteData: { ...QUOTE, after_hours_high: null, after_hours_low: null },
+        chipsMode: true,
+      },
+    })
+
+    // Assert — AH chip shows muted dash
+    const ahChip = wrapper.findAll('.eqv4-session-chip')[2]
+    expect(ahChip.find('.eqv4-muted-val').exists()).toBe(true)
+  })
+})
+
+// ── EQV4ShortCard ────────────────────────────────────────────────────────────
+
+describe('EQV4ShortCard', () => {
+  test('with short data in list mode expect si/dtc/svr rows', () => {
+    // Arrange
+    const wrapper = mount(EQV4ShortCard, {
+      props: { shortInterestData: SHORT_DATA, loading: false, chipsMode: false },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(true)
+    expect(wrapper.text()).toContain('125.0M')
+    expect(wrapper.text()).toContain('2.1')
+    expect(wrapper.text()).toContain('38.5%')
+  })
+
+  test('with short data in chips mode expect chip row', () => {
+    // Arrange
+    const wrapper = mount(EQV4ShortCard, {
+      props: { shortInterestData: SHORT_DATA, loading: false, chipsMode: true },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-chip-row').exists()).toBe(true)
+    expect(wrapper.text()).toContain('SI')
+    expect(wrapper.text()).toContain('DTC')
+    expect(wrapper.text()).toContain('SVR')
+  })
+
+  test('with loading true expect loading message', () => {
+    // Arrange
+    const wrapper = mount(EQV4ShortCard, {
+      props: { shortInterestData: {}, loading: true, chipsMode: false },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('loading')
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(false)
+  })
+
+  test('with all null values expect unavailable message', () => {
+    // Arrange
+    const wrapper = mount(EQV4ShortCard, {
+      props: {
+        shortInterestData: { short_interest: null, days_to_cover: null, short_volume_ratio: null },
+        loading: false,
+        chipsMode: false,
+      },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('unavailable')
+  })
+})
+
+// ── EQV4CompanyCard ──────────────────────────────────────────────────────────
+
+describe('EQV4CompanyCard', () => {
+  test('with company data expect kv rows rendered', () => {
+    // Arrange
+    const wrapper = mount(EQV4CompanyCard, {
+      props: { data: COMPANY_DATA, loading: false },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(true)
+    expect(wrapper.text()).toContain('XNAS')
+    expect(wrapper.text()).toContain('$2900.0B')
+    expect(wrapper.text()).toContain('164.0K')
+  })
+
+  test('with loading true expect loading message', () => {
+    // Arrange
+    const wrapper = mount(EQV4CompanyCard, {
+      props: { data: {}, loading: true },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('loading')
+    expect(wrapper.find('.eqv4-kv-list').exists()).toBe(false)
+  })
+
+  test('with all null data expect unavailable message', () => {
+    // Arrange
+    const wrapper = mount(EQV4CompanyCard, {
+      props: { data: { name: null, sic_description: null, description: null, homepage_url: null }, loading: false },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('unavailable')
+  })
+
+  test('with long description expect see more button and truncated text', () => {
+    // Arrange
+    const longDesc = 'A'.repeat(300)
+    const wrapper = mount(EQV4CompanyCard, {
+      props: { data: { ...COMPANY_DATA, description: longDesc }, loading: false },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-see-more').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain(longDesc)
+  })
+
+  test('with see more click expect full description rendered', async () => {
+    // Arrange
+    const longDesc = 'B'.repeat(300)
+    const wrapper = mount(EQV4CompanyCard, {
+      props: { data: { ...COMPANY_DATA, description: longDesc }, loading: false },
+    })
+
+    // Act
+    await wrapper.find('.eqv4-see-more').trigger('click')
+
+    // Assert
+    expect(wrapper.text()).toContain(longDesc)
+  })
+
+  test('with description shorter than maxLen expect no see more button', () => {
+    // Arrange
+    const wrapper = mount(EQV4CompanyCard, {
+      props: { data: { ...COMPANY_DATA, description: 'Short desc.' }, loading: false },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-see-more').exists()).toBe(false)
+  })
+})

--- a/client/src/components/widgets/eqv3Utils.js
+++ b/client/src/components/widgets/eqv3Utils.js
@@ -19,6 +19,12 @@ export const truncateDesc = (text, maxLen = 175) => {
   return cut > 0 ? text.slice(0, cut) : text.slice(0, maxLen)
 }
 
+/** Format a numeric value to a fixed number of decimal places. Returns '—' for non-finite values. */
+export const fmt = (val, decimals = 2) => {
+  const n = parseFloat(val)
+  return isFinite(n) ? n.toFixed(decimals) : '—'
+}
+
 /** Format large numbers with K/M/B suffixes. Returns '—' for non-finite values. */
 export const fmtVol = (val) => {
   const v = parseFloat(val)


### PR DESCRIPTION
## Summary

7 standalone card SFC files for EQv4. Each card is a passive props-only consumer — no knowledge of the grid, settings, or other cards. Content ported from EQv3.

refs #189

## Files Created
- `EQV4HeroCard.vue` — symbol, price, change badge, since-open, company identity, branding toggle (edit mode)
- `EQV4TodayCard.vue` — open, VWAP (list + chips)
- `EQV4PrevCard.vue` — prev day OHLCV + VWAP (list + chips)
- `EQV4VolumeCard.vue` — volume, avg vol, float, RVol bar + class (list + chips)
- `EQV4SessionCard.vue` — pre/reg/AH H/L (list + chips)
- `EQV4ShortCard.vue` — SI, DTC, SVR with loading/unavailable states (list + chips)
- `EQV4CompanyCard.vue` — kv rows + description expand/collapse, loading/unavailable states
- `__tests__/EnhancedQuoteV4Cards.spec.js` — 31 test cases, all passing

## Props Interface
All cards:
- `isLocked: Boolean` — edit mode toggle
- `chipsMode: Boolean` — chip/kv-list render mode (where applicable)
- Card-specific data props (`quoteData`, `shortInterestData`, `companyData`)

Cards **never** read `settings` directly.

## Shared Utilities
`fmtVol`, `truncateUrl`, `truncateDesc` imported from `eqv3Utils.js` — no duplication.

## Test Results
143/143 passing (112 existing + 31 new)