### PR TITLE
feat(EQv4): add EnhancedQuoteV4 root widget and EQV4CardPicker

### DIFF
--- a/client/src/components/widgets/EQV4CardPicker.vue
+++ b/client/src/components/widgets/EQV4CardPicker.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="eqv4-picker">
+    <button class="eqv4-picker-btn filter-btn" @click="open = !open">+ Add card</button>
+    <div v-if="open" class="eqv4-picker-dropdown">
+      <button
+        v-for="card in absentCards"
+        :key="card.id"
+        class="eqv4-picker-item"
+        @click="select(card.id)"
+      >{{ card.label }}</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineProps({
+  absentCards: { type: Array, required: true },
+})
+
+const emit = defineEmits(['add-card'])
+const open = ref(false)
+
+const select = (cardId) => {
+  open.value = false
+  emit('add-card', cardId)
+}
+</script>
+
+<style scoped>
+.eqv4-picker { position: relative; }
+.filter-btn {
+  background: none;
+  border: 1px solid var(--border, #2d2d3d);
+  border-radius: 4px;
+  color: var(--text-muted, #64748b);
+  font-size: 11px;
+  padding: 3px 8px;
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  transition: border-color 0.15s, color 0.15s;
+}
+.filter-btn:hover {
+  border-color: var(--pd-accent, #7c3aed);
+  color: var(--pd-accent, #7c3aed);
+}
+.eqv4-picker-dropdown {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  background: var(--surface, #141420);
+  border: 1px solid var(--border, #2d2d3d);
+  border-radius: 4px;
+  min-width: 140px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 4px;
+}
+.eqv4-picker-item {
+  background: none;
+  border: none;
+  color: var(--text-primary, #e2e8f0);
+  font-size: 12px;
+  padding: 5px 8px;
+  cursor: pointer;
+  text-align: left;
+  border-radius: 3px;
+  font-family: system-ui, sans-serif;
+}
+.eqv4-picker-item:hover {
+  background: var(--bg, #0d0d12);
+  color: var(--pd-accent, #7c3aed);
+}
+</style>

--- a/client/src/components/widgets/EnhancedQuoteV4.vue
+++ b/client/src/components/widgets/EnhancedQuoteV4.vue
@@ -1,0 +1,632 @@
+<template>
+  <div class="eqv4-widget" ref="widgetEl">
+    <!-- Ticker input bar — always visible -->
+    <div class="eqv4-controls">
+      <input
+        v-model="inputTicker"
+        class="eqv4-input"
+        placeholder="Enter ticker (e.g. AAPL)"
+        maxlength="10"
+        spellcheck="false"
+        @keyup.enter="applyInput"
+        @keyup.escape="inputTicker = ''"
+      />
+      <button class="eqv4-go-btn" @click="applyInput" @touchend.prevent="applyInput" title="Load quote">Go</button>
+    </div>
+
+    <!-- No ticker yet -->
+    <div v-if="!activeTicker" class="eqv4-empty">
+      <span class="eqv4-empty-icon">⚡</span>
+      <span class="eqv4-empty-text">Enter a ticker above, or link to a scanner and click a row</span>
+    </div>
+
+    <!-- Ticker set, waiting for data -->
+    <div v-else-if="!quoteData" class="eqv4-empty">
+      <span class="eqv4-empty-icon">⏳</span>
+      <span class="eqv4-empty-text">Waiting for data for <strong>{{ activeTicker }}</strong>...</span>
+    </div>
+
+    <!-- Quote data available -->
+    <div v-else class="eqv4-body">
+      <GridLayout
+        v-model:layout="internalLayout"
+        :col-num="gridCols"
+        :row-height="gridRowHeight"
+        :margin="[5, 5]"
+        :is-draggable="!isLocked"
+        :is-resizable="!isLocked"
+        :vertical-compact="false"
+        :use-css-transforms="true"
+        @layout-updated="onLayoutUpdated"
+      >
+        <GridItem
+          v-for="item in internalLayout"
+          :key="item.i"
+          :x="item.x" :y="item.y" :w="item.w" :h="item.h" :i="item.i"
+          class="eqv4-grid-item"
+        >
+          <!-- Card header: label + X button in edit mode -->
+          <div class="eqv4-card-header">
+            <span class="eqv4-card-label">{{ cardLabel(item.i) }}</span>
+            <button
+              v-if="!isLocked"
+              class="eqv4-card-remove"
+              title="Remove card"
+              @click="removeCard(item.i)"
+            >✕</button>
+          </div>
+
+          <!-- Card body: dynamic component by card id -->
+          <component
+            :is="cardComponent(item.i)"
+            :quote-data="quoteData"
+            :company-data="companyData"
+            :short-interest-data="shortInterestData"
+            :loading="item.i === 'short' ? shortInterestLoading : (item.i === 'company' ? companyLoading : false)"
+            :is-locked="isLocked"
+            :chips-mode="chipCardIds.has(item.i)"
+            :branding-mode="brandingMode"
+            :active-branding-url="activeBrandingUrl"
+            :flame-icon="flameIcon"
+            @toggle-branding="toggleBranding"
+            class="eqv4-card-component"
+          />
+        </GridItem>
+      </GridLayout>
+
+      <!-- Edit mode: add card + grid config -->
+      <div v-if="!isLocked" class="eqv4-edit-bar">
+        <EQV4CardPicker
+          v-if="absentCards.length > 0"
+          :absent-cards="absentCards"
+          @add-card="addCard"
+        />
+        <div class="eqv4-grid-config">
+          <label class="eqv4-config-label">
+            Cols
+            <input
+              type="number"
+              :value="gridCols"
+              min="1" max="24"
+              class="eqv4-config-input"
+              @change="onGridColsChange"
+            />
+          </label>
+          <label class="eqv4-config-label">
+            Row H
+            <input
+              type="number"
+              :value="gridRowHeight"
+              min="20" max="120"
+              class="eqv4-config-input"
+              @change="onGridRowHeightChange"
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { GridLayout, GridItem } from 'vue3-grid-layout-next'
+import { useWidgetBus, getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useConfig } from '@/composables/useConfig.js'
+import EQV4HeroCard    from './EQV4HeroCard.vue'
+import EQV4TodayCard   from './EQV4TodayCard.vue'
+import EQV4PrevCard    from './EQV4PrevCard.vue'
+import EQV4VolumeCard  from './EQV4VolumeCard.vue'
+import EQV4SessionCard from './EQV4SessionCard.vue'
+import EQV4ShortCard   from './EQV4ShortCard.vue'
+import EQV4CompanyCard from './EQV4CompanyCard.vue'
+import EQV4CardPicker  from './EQV4CardPicker.vue'
+
+// ── Card registry ────────────────────────────────────────────────────────────
+const CARD_REGISTRY = [
+  { id: 'hero',    label: 'Hero',           component: EQV4HeroCard,    defaultW: 6, defaultH: 3 },
+  { id: 'today',   label: 'Today',          component: EQV4TodayCard,   defaultW: 2, defaultH: 2 },
+  { id: 'prev',    label: 'Previous Day',   component: EQV4PrevCard,    defaultW: 2, defaultH: 2 },
+  { id: 'volume',  label: 'Volume',         component: EQV4VolumeCard,  defaultW: 2, defaultH: 2 },
+  { id: 'session', label: 'Session H/L',    component: EQV4SessionCard, defaultW: 3, defaultH: 3 },
+  { id: 'short',   label: 'Short Interest', component: EQV4ShortCard,   defaultW: 3, defaultH: 2 },
+  { id: 'company', label: 'Company',        component: EQV4CompanyCard, defaultW: 3, defaultH: 3 },
+]
+
+const CARD_MAP = Object.fromEntries(CARD_REGISTRY.map(c => [c.id, c]))
+
+const DEFAULT_CARDS = [
+  { id: 'hero',    x: 0, y: 0, w: 6, h: 3 },
+  { id: 'today',   x: 0, y: 3, w: 2, h: 2 },
+  { id: 'prev',    x: 2, y: 3, w: 2, h: 2 },
+  { id: 'volume',  x: 4, y: 3, w: 2, h: 2 },
+  { id: 'session', x: 0, y: 5, w: 3, h: 3 },
+  { id: 'short',   x: 3, y: 5, w: 3, h: 2 },
+  { id: 'company', x: 3, y: 7, w: 3, h: 3 },
+]
+
+// ── Props / emits ────────────────────────────────────────────────────────────
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+  isMobile:  { type: Boolean, default: false },
+  settings:  { type: Object,  default: () => ({}) },
+})
+
+const emit = defineEmits(['update-settings'])
+
+// ── Config ───────────────────────────────────────────────────────────────────
+const { config } = useConfig()
+
+// ── Widget bus ───────────────────────────────────────────────────────────────
+const { activeTickers, setActiveTicker } = useWidgetBus()
+
+// ── Settings helpers ─────────────────────────────────────────────────────────
+const gridCols = computed(() => props.settings?.gridCols ?? 6)
+const gridRowHeight = computed(() => props.settings?.gridRowHeight ?? 40)
+const chipCardIds = computed(() => new Set(props.settings?.chipCards ?? []))
+const brandingMode = computed(() => props.settings?.brandingMode ?? 'logo')
+
+const settingsCards = computed(() => {
+  const c = props.settings?.cards
+  return Array.isArray(c) && c.length > 0 ? c : null
+})
+
+// ── Grid layout ──────────────────────────────────────────────────────────────
+// Derived from settings.cards (or default). GridLayout needs `i` field; we use card id as i.
+const gridLayout = computed(() =>
+  (settingsCards.value ?? DEFAULT_CARDS).map(card => ({ ...card, i: card.id }))
+)
+
+// Internal mutable layout ref — v-model:layout for GridLayout reactivity.
+// Kept in sync with gridLayout computed on settings change.
+const internalLayout = ref(gridLayout.value.map(c => ({ ...c })))
+
+watch(gridLayout, (newLayout) => {
+  internalLayout.value = newLayout.map(c => ({ ...c }))
+}, { deep: true })
+
+// Emit default layout on first render if settings.cards is absent/empty.
+// Do this after mount to avoid emitting during parent setup.
+const emittedDefault = ref(false)
+watch(settingsCards, (cards) => {
+  if (cards === null && !emittedDefault.value) {
+    emittedDefault.value = true
+    emit('update-settings', {
+      ...props.settings,
+      gridCols: gridCols.value,
+      gridRowHeight: gridRowHeight.value,
+      chipCards: props.settings?.chipCards ?? [],
+      brandingMode: brandingMode.value,
+      cards: DEFAULT_CARDS,
+    })
+  }
+}, { immediate: true })
+
+// @layout-updated fires on dragend/resizeend only (not on every drag tick).
+// Persist new positions via update-settings.
+const onLayoutUpdated = (newLayout) => {
+  emit('update-settings', {
+    ...props.settings,
+    cards: newLayout.map(({ i, ...rest }) => ({ ...rest, id: i })),
+  })
+}
+
+// ── Card helpers ─────────────────────────────────────────────────────────────
+const cardLabel = (id) => CARD_MAP[id]?.label ?? id
+const cardComponent = (id) => CARD_MAP[id]?.component ?? null
+
+const activeCardIds = computed(() =>
+  new Set((settingsCards.value ?? DEFAULT_CARDS).map(c => c.id))
+)
+
+const absentCards = computed(() =>
+  CARD_REGISTRY.filter(c => !activeCardIds.value.has(c.id))
+)
+
+// ── Add card: first-fit row-major scan ───────────────────────────────────────
+const addCard = (cardId) => {
+  const def = CARD_MAP[cardId]
+  if (!def) return
+  const current = settingsCards.value ?? DEFAULT_CARDS
+  const cols = gridCols.value
+
+  // Build occupied set: all (x, y) cells taken by placed cards.
+  const occupied = new Set()
+  for (const card of current) {
+    for (let row = card.y; row < card.y + card.h; row++) {
+      for (let col = card.x; col < card.x + card.w; col++) {
+        occupied.add(`${col},${row}`)
+      }
+    }
+  }
+
+  // Scan row-major for first position where the card fits without overlap.
+  const maxY = current.reduce((m, c) => Math.max(m, c.y + c.h), 0)
+  let placed = null
+
+  outer:
+  for (let y = 0; y <= maxY; y++) {
+    for (let x = 0; x <= cols - def.defaultW; x++) {
+      let fits = true
+      for (let dy = 0; dy < def.defaultH && fits; dy++) {
+        for (let dx = 0; dx < def.defaultW && fits; dx++) {
+          if (occupied.has(`${x + dx},${y + dy}`)) fits = false
+        }
+      }
+      if (fits) {
+        placed = { id: cardId, x, y, w: def.defaultW, h: def.defaultH }
+        break outer
+      }
+    }
+  }
+
+  // Fallback: append below all placed cards.
+  if (!placed) {
+    placed = { id: cardId, x: 0, y: maxY, w: def.defaultW, h: def.defaultH }
+  }
+
+  emit('update-settings', {
+    ...props.settings,
+    cards: [...current, placed],
+  })
+}
+
+// ── Remove card ───────────────────────────────────────────────────────────────
+const removeCard = (cardId) => {
+  const current = settingsCards.value ?? DEFAULT_CARDS
+  emit('update-settings', {
+    ...props.settings,
+    cards: current.filter(c => c.id !== cardId),
+  })
+}
+
+// ── Grid config ───────────────────────────────────────────────────────────────
+const onGridColsChange = (e) => {
+  const val = Math.max(1, Math.min(24, parseInt(e.target.value, 10) || 1))
+  emit('update-settings', { ...props.settings, gridCols: val })
+}
+
+const onGridRowHeightChange = (e) => {
+  const val = Math.max(20, Math.min(120, parseInt(e.target.value, 10) || 40))
+  emit('update-settings', { ...props.settings, gridRowHeight: val })
+}
+
+// ── Ticker input ─────────────────────────────────────────────────────────────
+const inputTicker = ref('')
+const manualTicker = ref('')
+const busTicker = computed(() =>
+  props.linkColor ? (activeTickers[props.linkColor] || null) : null
+)
+const activeTicker = computed(() => busTicker.value || manualTicker.value || null)
+
+const applyInput = () => {
+  const t = inputTicker.value.trim().toUpperCase()
+  if (!t) return
+  manualTicker.value = t
+  inputTicker.value = ''
+  if (props.linkColor) {
+    setActiveTicker(props.linkColor, t)
+  }
+}
+
+watch(busTicker, (t) => {
+  if (t) manualTicker.value = ''
+})
+
+// ── Quote data ───────────────────────────────────────────────────────────────
+const quoteData = ref(null)
+const lastDataAt = ref(null)
+
+// ── Company data ─────────────────────────────────────────────────────────────
+const companyData = ref({})
+const companyLoading = ref(false)
+const logoUrl = ref(null)
+const iconUrl = ref(null)
+
+const fetchCompany = async (symbol) => {
+  if (!symbol) return
+  companyLoading.value = true
+  companyData.value = {}
+  logoUrl.value = null
+  iconUrl.value = null
+  try {
+    const url = `https://api.massive.com/v3/reference/tickers/${symbol}?apiKey=${config.value?.massiveApiKey}`
+    const resp = await fetch(url)
+    if (resp.ok) {
+      const json = await resp.json()
+      const results = json.results || {}
+      companyData.value = {
+        name: results.name ?? null,
+        sic_description: results.sic_description ?? null,
+        description: results.description ?? null,
+        homepage_url: results.homepage_url ?? null,
+        primary_exchange: results.primary_exchange ?? null,
+        market_cap: results.market_cap ?? null,
+        total_employees: results.total_employees ?? null,
+        list_date: results.list_date ?? null,
+      }
+      logoUrl.value = results.branding?.logo_url ?? null
+      iconUrl.value = results.branding?.icon_url ?? null
+    }
+  } catch (e) {
+    console.warn(`[EnhancedQuoteV4] company fetch failed for ${symbol}:`, e)
+  } finally {
+    companyLoading.value = false
+  }
+}
+
+// ── Short interest data ───────────────────────────────────────────────────────
+const shortInterestData = ref({})
+const shortInterestLoading = ref(false)
+
+const fetchShortData = async (symbol) => {
+  if (!symbol) return
+  shortInterestLoading.value = true
+  shortInterestData.value = {}
+  const key = config.value?.massiveApiKey
+  try {
+    const [siResp, svResp] = await Promise.all([
+      fetch(`https://api.massive.com/stocks/v1/short-interest?ticker=${symbol}&limit=1&sort=settlement_date.desc&apiKey=${key}`),
+      fetch(`https://api.massive.com/stocks/v1/short-volume?ticker=${symbol}&limit=1&sort=date.desc&apiKey=${key}`),
+    ])
+    const siJson = siResp.ok ? await siResp.json() : {}
+    const svJson = svResp.ok ? await svResp.json() : {}
+    const si = siJson.results?.[0] ?? {}
+    const sv = svJson.results?.[0] ?? {}
+    shortInterestData.value = {
+      short_interest: si.short_interest ?? null,
+      days_to_cover: si.days_to_cover ?? null,
+      avg_daily_volume: si.avg_daily_volume ?? null,
+      settlement_date: si.settlement_date ?? null,
+      short_volume_ratio: sv.short_volume_ratio ?? null,
+      short_volume: sv.short_volume ?? null,
+      total_volume: sv.total_volume ?? null,
+    }
+  } catch (e) {
+    console.warn(`[EnhancedQuoteV4] short data fetch failed for ${symbol}:`, e)
+  } finally {
+    shortInterestLoading.value = false
+  }
+}
+
+// ── WDS WebSocket ─────────────────────────────────────────────────────────────
+const currentFeed = ref('')
+
+const { wsUrl, authKey, feedName, cacheKey, isConnected, reconnecting, getCache, subscribe, unsubscribe, connect: wdsConnect } = useWebSocketClient({
+  wsUrl: '',
+  authKey: '',
+  feedName: '',
+  cacheKey: '',
+  onData: (data) => {
+    if (!data || (data.symbol && data.symbol !== activeTicker.value)) return
+    quoteData.value = data
+    lastDataAt.value = Date.now()
+  },
+  autoConnect: false,
+})
+
+watch(config, (cfg) => {
+  if (cfg?.wsEndpoint && cfg?.apiKey) {
+    wsUrl.value = cfg.wsEndpoint
+    authKey.value = cfg.apiKey
+    if (!isConnected.value) {
+      wdsConnect()
+    }
+  }
+}, { immediate: true })
+
+watch(activeTicker, (newTicker) => {
+  if (currentFeed.value) {
+    feedName.value = currentFeed.value
+    cacheKey.value = ''
+    unsubscribe()
+    currentFeed.value = ''
+  }
+  quoteData.value = null
+  companyData.value = {}
+  shortInterestData.value = {}
+  logoUrl.value = null
+  iconUrl.value = null
+  if (newTicker) {
+    fetchCompany(newTicker)
+    fetchShortData(newTicker)
+    const feed = `daily_range:${newTicker}`
+    feedName.value = feed
+    cacheKey.value = feed
+    currentFeed.value = feed
+    if (isConnected.value) {
+      subscribe()
+      getCache()
+    }
+  }
+})
+
+watch(isConnected, (connected) => {
+  if (connected && currentFeed.value) {
+    feedName.value = currentFeed.value
+    cacheKey.value = currentFeed.value
+    subscribe()
+    getCache()
+  }
+})
+
+// ── Flame icon ────────────────────────────────────────────────────────────────
+const flameIcon = computed(() => {
+  if (!activeTicker.value) return null
+  const variant = getFlameVariant(activeTicker.value)
+  if (!variant) return null
+  return { src: variant, tooltip: getFlameTooltip(activeTicker.value) }
+})
+
+// ── Branding ──────────────────────────────────────────────────────────────────
+const activeBrandingUrl = computed(() => {
+  if (!config.value?.massiveApiKey) return null
+  const key = config.value.massiveApiKey
+  if (brandingMode.value === 'icon') {
+    return iconUrl.value ? `${iconUrl.value}?apiKey=${key}` : (logoUrl.value ? `${logoUrl.value}?apiKey=${key}` : null)
+  }
+  return logoUrl.value ? `${logoUrl.value}?apiKey=${key}` : (iconUrl.value ? `${iconUrl.value}?apiKey=${key}` : null)
+})
+
+const toggleBranding = () => {
+  const next = brandingMode.value === 'logo' ? 'icon' : 'logo'
+  emit('update-settings', { ...props.settings, brandingMode: next })
+}
+
+// ── defineExpose ──────────────────────────────────────────────────────────────
+defineExpose({
+  lastDataAt,
+  isConnected,
+  reconnecting,
+  quoteData,
+  manualTicker,
+  companyData,
+  companyLoading,
+  shortInterestData,
+  shortInterestLoading,
+  gridLayout,
+  gridCols,
+  gridRowHeight,
+  chipCardIds,
+  addCard,
+  removeCard,
+  activeCardIds,
+})
+</script>
+
+<style scoped>
+.eqv4-widget {
+  --bg: #0d0d12;
+  --surface: #141420;
+  --border: #2d2d3d;
+  --text-primary: #e2e8f0;
+  --text-muted: #64748b;
+  --accent: #7c3aed;
+  --pd-accent: #7c3aed;
+  background: var(--bg);
+  color: var(--text-primary);
+  font-family: system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+.eqv4-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.eqv4-input {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: 'Roboto Mono', monospace;
+  font-size: 13px;
+  padding: 4px 8px;
+  outline: none;
+}
+.eqv4-input:focus { border-color: var(--pd-accent); }
+.eqv4-go-btn {
+  background: var(--pd-accent);
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+.eqv4-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  flex: 1;
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 24px;
+  text-align: center;
+}
+.eqv4-empty-icon { font-size: 28px; }
+.eqv4-body {
+  flex: 1;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+}
+.eqv4-grid-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.eqv4-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.eqv4-card-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.eqv4-card-remove:hover { color: #ef4444; }
+.eqv4-card-component {
+  flex: 1;
+  min-height: 0;
+}
+.eqv4-edit-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  background: var(--bg);
+}
+.eqv4-grid-config {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+.eqv4-config-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.eqv4-config-input {
+  width: 48px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  padding: 2px 4px;
+  text-align: center;
+}
+</style>

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -324,12 +324,12 @@ describe('addCard', () => {
   })
 
   test('with addCard called and no gap fits expect card appended to bottom', async () => {
-    // Arrange — gridCols:3, one card at x=0,y=0,w=3,h=2 fills entire grid for 2 rows.
-    // Adding 'session' (defaultW:3): no gap in rows 0-1 (full width occupied),
-    // so fallback appends at x=0, y=maxOccupiedY (=2).
+    // Arrange — gridCols:2, hero at x=0,y=0,w=2,h=2 fills the entire 2-column grid.
+    // Adding 'session' (defaultW:3): cols-defaultW = 2-3 = -1, so the inner
+    // loop condition (x <= -1) never executes — placed stays null, fallback fires.
     const emitted = []
     const wrapper = mountWidget(
-      { settings: { gridCols: 3, cards: [{ id: 'hero', x: 0, y: 0, w: 3, h: 2 }] } },
+      { settings: { gridCols: 2, cards: [{ id: 'hero', x: 0, y: 0, w: 2, h: 2 }] } },
       (s) => emitted.push(s)
     )
 

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -1,0 +1,513 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+// ── Global stubs ─────────────────────────────────────────────────────────────
+
+vi.mock('vue3-grid-layout-next', () => ({
+  GridLayout: {
+    name: 'GridLayout',
+    props: ['layout', 'colNum', 'rowHeight', 'margin', 'isDraggable', 'isResizable', 'verticalCompact', 'useCssTransforms'],
+    emits: ['update:layout', 'layout-updated'],
+    template: '<div class="mock-grid-layout"><slot /></div>',
+  },
+  GridItem: {
+    name: 'GridItem',
+    props: ['x', 'y', 'w', 'h', 'i'],
+    template: '<div class="mock-grid-item" :data-i="i"><slot /></div>',
+  },
+}))
+
+vi.mock('@/composables/useConfig.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useConfig: () => ({
+      config: ref({
+        massiveApiKey: 'test-massive-key',
+        apiKey: 'secret',
+        wsEndpoint: 'ws://localhost:4202/ws',
+      }),
+      loading: ref(false),
+      error: ref(null),
+      fetchConfig: vi.fn(),
+      isAuthenticated: () => true,
+    }),
+  }
+})
+
+class MockWebSocket {
+  constructor() {
+    this.readyState = WebSocket.CONNECTING
+    setTimeout(() => { this.readyState = WebSocket.OPEN; this.onopen?.() }, 0)
+  }
+  send() {}
+  close() { this.onclose?.({ code: 1000 }) }
+}
+global.WebSocket = MockWebSocket
+global.WebSocket.CONNECTING = 0
+global.WebSocket.OPEN = 1
+global.WebSocket.CLOSING = 2
+global.WebSocket.CLOSED = 3
+
+const MASSIVE_TICKER_RESPONSE = {
+  results: {
+    name: 'Tesla Inc.',
+    sic_description: 'Motor Vehicles',
+    description: 'Tesla designs electric vehicles.',
+    homepage_url: 'https://tesla.com',
+    primary_exchange: 'XNAS',
+    market_cap: 800000000000,
+    total_employees: 127855,
+    list_date: '2010-06-29',
+    branding: { logo_url: 'https://api.massive.com/logo.svg', icon_url: 'https://api.massive.com/icon.png' },
+  },
+}
+const MASSIVE_SI_RESPONSE = { results: [{ short_interest: 12000000, days_to_cover: 2.4 }] }
+const MASSIVE_SV_RESPONSE = { results: [{ short_volume_ratio: 38.5 }] }
+
+function mockMassiveFetch() {
+  global.fetch = vi.fn().mockImplementation((url) => {
+    if (url.includes('/v3/reference/tickers/')) return Promise.resolve({ ok: true, json: async () => MASSIVE_TICKER_RESPONSE })
+    if (url.includes('/short-interest'))         return Promise.resolve({ ok: true, json: async () => MASSIVE_SI_RESPONSE })
+    if (url.includes('/short-volume'))           return Promise.resolve({ ok: true, json: async () => MASSIVE_SV_RESPONSE })
+    return Promise.resolve({ ok: true, json: async () => ({}) })
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) })
+})
+
+import EnhancedQuoteV4 from '../EnhancedQuoteV4.vue'
+
+const SAMPLE_QUOTE = {
+  symbol: 'TSLA',
+  close: 250.0,
+  change: 5.0,
+  pct_change: 2.04,
+  pct_change_since_open: 1.5,
+  change_since_open: 3.75,
+  end_timestamp: Date.now(),
+  official_open_price: 248.0,
+  aggregate_vwap: 250.5,
+  accumulated_volume: 25000000,
+  relative_volume: 2.5,
+  avg_volume: 20000000,
+  free_float: 800000000,
+  prev_day_close: 245.0,
+  prev_day_open: 244.0,
+  prev_day_high: 253.0,
+  prev_day_low: 243.0,
+  prev_day_volume: 22000000,
+  prev_day_vwap: 248.0,
+  pre_market_high: 252.0,
+  pre_market_low: 248.0,
+  regular_session_high: 255.0,
+  regular_session_low: 247.0,
+  after_hours_high: 251.0,
+  after_hours_low: 249.0,
+}
+
+// VTU 2.4.x + <script setup>: capture emitted events via attrs onXxx callback.
+function mountWidget(props = {}, onUpdateSettings = null) {
+  const attrs = onUpdateSettings ? { onUpdateSettings } : {}
+  return mount(EnhancedQuoteV4, {
+    props: { isLocked: true, linkColor: null, isMobile: false, settings: {}, ...props },
+    attrs,
+  })
+}
+
+// ── Empty / waiting states ────────────────────────────────────────────────────
+
+describe('Empty and waiting states', () => {
+  test('with no ticker expect empty state rendered', () => {
+    // Arrange / Act
+    const wrapper = mountWidget()
+
+    // Assert
+    expect(wrapper.find('.eqv4-empty').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-body').exists()).toBe(false)
+  })
+
+  test('with ticker but no quote data expect waiting state shown', async () => {
+    // Arrange
+    const wrapper = mountWidget()
+
+    // Act
+    await wrapper.find('.eqv4-input').setValue('TSLA')
+    await wrapper.find('.eqv4-go-btn').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.eqv4-empty').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-empty-text').text()).toContain('TSLA')
+  })
+})
+
+// ── Default layout emission ───────────────────────────────────────────────────
+
+describe('Default layout emission', () => {
+  test('with no settings.cards expect update-settings emitted with default cards', async () => {
+    // Arrange
+    const emitted = []
+
+    // Act
+    mountWidget({ settings: {} }, (s) => emitted.push(s))
+    await nextTick()
+
+    // Assert
+    expect(emitted.length).toBeGreaterThan(0)
+    const payload = emitted[0]
+    expect(Array.isArray(payload.cards)).toBe(true)
+    expect(payload.cards.length).toBe(7)
+    expect(payload.cards.map(c => c.id)).toContain('hero')
+  })
+
+  test('with settings.cards already set expect no default emission', async () => {
+    // Arrange
+    const emitted = []
+    const existingCards = [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }]
+
+    // Act
+    mountWidget({ settings: { cards: existingCards } }, (s) => emitted.push(s))
+    await nextTick()
+
+    // Assert
+    expect(emitted.length).toBe(0)
+  })
+})
+
+// ── Grid layout computed ──────────────────────────────────────────────────────
+
+describe('Grid layout computed', () => {
+  test('with settings.cards expect gridLayout derived with i equal to id', () => {
+    // Arrange
+    const cards = [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }, { id: 'today', x: 0, y: 3, w: 2, h: 2 }]
+    const wrapper = mountWidget({ settings: { cards } })
+
+    // Act / Assert — VTU unwraps computed refs; access directly
+    expect(wrapper.vm.gridLayout[0].i).toBe('hero')
+    expect(wrapper.vm.gridLayout[1].i).toBe('today')
+  })
+
+  test('with no settings.cards expect gridLayout uses default 7 cards', () => {
+    // Arrange / Act
+    const wrapper = mountWidget({ settings: {} })
+
+    // Assert
+    expect(wrapper.vm.gridLayout.length).toBe(7)
+  })
+})
+
+// ── Ticker input ──────────────────────────────────────────────────────────────
+
+describe('Ticker input', () => {
+  test('with go button click expect manualTicker set to uppercased input', async () => {
+    // Arrange
+    const wrapper = mountWidget()
+
+    // Act
+    await wrapper.find('.eqv4-input').setValue('tsla')
+    await wrapper.find('.eqv4-go-btn').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.vm.manualTicker).toBe('TSLA')
+  })
+
+  test('with enter key on input expect manualTicker applied', async () => {
+    // Arrange
+    const wrapper = mountWidget()
+
+    // Act
+    await wrapper.find('.eqv4-input').setValue('aapl')
+    await wrapper.find('.eqv4-input').trigger('keyup.enter')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.vm.manualTicker).toBe('AAPL')
+  })
+})
+
+// ── WDS data ──────────────────────────────────────────────────────────────────
+
+describe('WDS data handling', () => {
+  test('with quote data set expect grid body rendered', async () => {
+    // Arrange
+    const wrapper = mountWidget({ settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } })
+    await wrapper.find('.eqv4-input').setValue('TSLA')
+    await wrapper.find('.eqv4-go-btn').trigger('click')
+    await nextTick()
+
+    // Act — set quoteData via exposed ref (ticker already set above)
+    wrapper.vm.quoteData = SAMPLE_QUOTE
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.eqv4-body').exists()).toBe(true)
+    expect(wrapper.find('.mock-grid-layout').exists()).toBe(true)
+  })
+})
+
+// ── Company and short data fetch ──────────────────────────────────────────────
+
+describe('Company and short data fetch', () => {
+  test('with ticker applied expect company fetch called', async () => {
+    // Arrange
+    mockMassiveFetch()
+    const wrapper = mountWidget()
+
+    // Act
+    await wrapper.find('.eqv4-input').setValue('TSLA')
+    await wrapper.find('.eqv4-go-btn').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/v3/reference/tickers/TSLA')
+    )
+  })
+
+  test('with ticker applied expect short interest fetch called', async () => {
+    // Arrange
+    mockMassiveFetch()
+    const wrapper = mountWidget()
+
+    // Act
+    await wrapper.find('.eqv4-input').setValue('TSLA')
+    await wrapper.find('.eqv4-go-btn').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/short-interest'))
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/short-volume'))
+  })
+
+  test('with company fetch success expect companyData populated', async () => {
+    // Arrange
+    mockMassiveFetch()
+    const wrapper = mountWidget()
+
+    // Act
+    await wrapper.find('.eqv4-input').setValue('TSLA')
+    await wrapper.find('.eqv4-go-btn').trigger('click')
+    await nextTick()
+    await nextTick() // settle async fetch
+
+    // Assert
+    expect(wrapper.vm.companyData.name).toBe('Tesla Inc.')
+    expect(wrapper.vm.companyData.primary_exchange).toBe('XNAS')
+  })
+})
+
+// ── addCard ───────────────────────────────────────────────────────────────────
+
+describe('addCard', () => {
+  test('with addCard called expect update-settings emitted with card appended', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget(
+      { settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
+      (s) => emitted.push(s)
+    )
+
+    // Act
+    wrapper.vm.addCard('today')
+    await nextTick()
+
+    // Assert
+    expect(emitted.length).toBeGreaterThan(0)
+    const lastPayload = emitted[emitted.length - 1]
+    expect(lastPayload.cards.some(c => c.id === 'today')).toBe(true)
+  })
+
+  test('with addCard called and no gap fits expect card appended to bottom', async () => {
+    // Arrange — hero fills all 6 columns at y=0 to y=2
+    const emitted = []
+    const wrapper = mountWidget(
+      { settings: { gridCols: 6, cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
+      (s) => emitted.push(s)
+    )
+
+    // Act — add 'today' (defaultW: 2); hero occupies full width for 3 rows
+    wrapper.vm.addCard('today')
+    await nextTick()
+
+    // Assert — today placed at y >= 3 (below hero)
+    const lastPayload = emitted[emitted.length - 1]
+    const added = lastPayload.cards.find(c => c.id === 'today')
+    expect(added).toBeDefined()
+    expect(added.y).toBeGreaterThanOrEqual(3)
+  })
+
+  test('with addCard called for unknown id expect no emission', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget(
+      { settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
+      (s) => emitted.push(s)
+    )
+    const beforeCount = emitted.length
+
+    // Act
+    wrapper.vm.addCard('nonexistent')
+    await nextTick()
+
+    // Assert
+    expect(emitted.length).toBe(beforeCount)
+  })
+})
+
+// ── removeCard ────────────────────────────────────────────────────────────────
+
+describe('removeCard', () => {
+  test('with removeCard called expect update-settings emitted without removed card', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget(
+      {
+        settings: {
+          cards: [
+            { id: 'hero',  x: 0, y: 0, w: 6, h: 3 },
+            { id: 'today', x: 0, y: 3, w: 2, h: 2 },
+          ],
+        },
+      },
+      (s) => emitted.push(s)
+    )
+
+    // Act
+    wrapper.vm.removeCard('today')
+    await nextTick()
+
+    // Assert
+    expect(emitted.length).toBeGreaterThan(0)
+    const lastPayload = emitted[emitted.length - 1]
+    expect(lastPayload.cards.find(c => c.id === 'today')).toBeUndefined()
+    expect(lastPayload.cards.find(c => c.id === 'hero')).toBeDefined()
+  })
+})
+
+// ── Grid config ───────────────────────────────────────────────────────────────
+
+describe('Grid config', () => {
+  test('with gridCols change expect update-settings emitted with new gridCols', async () => {
+    // Arrange — need isLocked:false, activeTicker, and quoteData to render body + edit bar
+    const emitted = []
+    const wrapper = mountWidget(
+      { isLocked: false, settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
+      (s) => emitted.push(s)
+    )
+    // Set ticker so activeTicker is truthy, then set quoteData
+    wrapper.vm.manualTicker = 'TSLA'
+    await nextTick()
+    wrapper.vm.quoteData = SAMPLE_QUOTE
+    await nextTick()
+
+    // Act
+    const inputs = wrapper.findAll('.eqv4-config-input')
+    await inputs[0].setValue('8')
+    await inputs[0].trigger('change')
+    await nextTick()
+
+    // Assert
+    const lastPayload = emitted[emitted.length - 1]
+    expect(lastPayload.gridCols).toBe(8)
+  })
+
+  test('with gridRowHeight change expect update-settings emitted with new gridRowHeight', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget(
+      { isLocked: false, settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
+      (s) => emitted.push(s)
+    )
+    wrapper.vm.manualTicker = 'TSLA'
+    await nextTick()
+    wrapper.vm.quoteData = SAMPLE_QUOTE
+    await nextTick()
+
+    // Act
+    const inputs = wrapper.findAll('.eqv4-config-input')
+    await inputs[1].setValue('50')
+    await inputs[1].trigger('change')
+    await nextTick()
+
+    // Assert
+    const lastPayload = emitted[emitted.length - 1]
+    expect(lastPayload.gridRowHeight).toBe(50)
+  })
+})
+
+// ── chipCardIds ───────────────────────────────────────────────────────────────
+
+describe('chipCardIds', () => {
+  test('with settings.chipCards set expect chipCardIds computed correctly', () => {
+    // Arrange / Act
+    const wrapper = mountWidget({
+      settings: { chipCards: ['today', 'volume'] },
+    })
+
+    // Assert — VTU unwraps computed refs via defineExpose
+    expect(wrapper.vm.chipCardIds.has('today')).toBe(true)
+    expect(wrapper.vm.chipCardIds.has('volume')).toBe(true)
+    expect(wrapper.vm.chipCardIds.has('hero')).toBe(false)
+  })
+
+  test('with no settings.chipCards expect empty chipCardIds set', () => {
+    // Arrange / Act
+    const wrapper = mountWidget({ settings: {} })
+
+    // Assert
+    expect(wrapper.vm.chipCardIds.size).toBe(0)
+  })
+})
+
+// ── activeCardIds ─────────────────────────────────────────────────────────────
+
+describe('activeCardIds', () => {
+  test('with settings.cards expect activeCardIds contains configured card ids', () => {
+    // Arrange
+    const cards = [
+      { id: 'hero',  x: 0, y: 0, w: 6, h: 3 },
+      { id: 'today', x: 0, y: 3, w: 2, h: 2 },
+    ]
+
+    // Act
+    const wrapper = mountWidget({ settings: { cards } })
+
+    // Assert
+    expect(wrapper.vm.activeCardIds.has('hero')).toBe(true)
+    expect(wrapper.vm.activeCardIds.has('today')).toBe(true)
+    expect(wrapper.vm.activeCardIds.has('session')).toBe(false)
+  })
+})
+
+// ── Exposed interface ─────────────────────────────────────────────────────────
+
+describe('Exposed interface', () => {
+  test('with widget mounted expect all required properties exposed', () => {
+    // Arrange / Act
+    const wrapper = mountWidget()
+    const vm = wrapper.vm
+
+    // Assert
+    expect(vm.lastDataAt).toBeDefined()
+    expect(vm.isConnected).toBeDefined()
+    expect(vm.reconnecting).toBeDefined()
+    expect(vm.quoteData).toBeDefined()
+    expect(vm.manualTicker).toBeDefined()
+    expect(vm.companyData).toBeDefined()
+    expect(vm.companyLoading).toBeDefined()
+    expect(vm.shortInterestData).toBeDefined()
+    expect(vm.shortInterestLoading).toBeDefined()
+    expect(vm.gridLayout).toBeDefined()
+    expect(vm.gridCols).toBeDefined()
+    expect(vm.gridRowHeight).toBeDefined()
+    expect(vm.chipCardIds).toBeDefined()
+    expect(typeof vm.addCard).toBe('function')
+    expect(typeof vm.removeCard).toBe('function')
+    expect(vm.activeCardIds).toBeDefined()
+  })
+})

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import EQV4CardPicker from '../EQV4CardPicker.vue'
 
 // ── Global stubs ─────────────────────────────────────────────────────────────
 
@@ -323,22 +324,25 @@ describe('addCard', () => {
   })
 
   test('with addCard called and no gap fits expect card appended to bottom', async () => {
-    // Arrange — hero fills all 6 columns at y=0 to y=2
+    // Arrange — gridCols:3, one card at x=0,y=0,w=3,h=2 fills entire grid for 2 rows.
+    // Adding 'session' (defaultW:3): no gap in rows 0-1 (full width occupied),
+    // so fallback appends at x=0, y=maxOccupiedY (=2).
     const emitted = []
     const wrapper = mountWidget(
-      { settings: { gridCols: 6, cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
+      { settings: { gridCols: 3, cards: [{ id: 'hero', x: 0, y: 0, w: 3, h: 2 }] } },
       (s) => emitted.push(s)
     )
 
-    // Act — add 'today' (defaultW: 2); hero occupies full width for 3 rows
-    wrapper.vm.addCard('today')
+    // Act
+    wrapper.vm.addCard('session')
     await nextTick()
 
-    // Assert — today placed at y >= 3 (below hero)
+    // Assert — fallback places session at x=0, y=2 (maxOccupiedY)
     const lastPayload = emitted[emitted.length - 1]
-    const added = lastPayload.cards.find(c => c.id === 'today')
+    const added = lastPayload.cards.find(c => c.id === 'session')
     expect(added).toBeDefined()
-    expect(added.y).toBeGreaterThanOrEqual(3)
+    expect(added.x).toBe(0)
+    expect(added.y).toBe(2)
   })
 
   test('with addCard called for unknown id expect no emission', async () => {
@@ -481,6 +485,113 @@ describe('activeCardIds', () => {
     expect(wrapper.vm.activeCardIds.has('hero')).toBe(true)
     expect(wrapper.vm.activeCardIds.has('today')).toBe(true)
     expect(wrapper.vm.activeCardIds.has('session')).toBe(false)
+  })
+})
+
+// ── onLayoutUpdated ─────────────────────────────────────────────────────────
+
+describe('onLayoutUpdated', () => {
+  test('with layout-updated event expect update-settings emitted with new card positions', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget(
+      { settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
+      (s) => emitted.push(s)
+    )
+    wrapper.vm.manualTicker = 'TSLA'
+    await nextTick()
+    wrapper.vm.quoteData = SAMPLE_QUOTE
+    await nextTick()
+
+    // Act — emit layout-updated from the mock GridLayout with new positions
+    const grid = wrapper.findComponent({ name: 'GridLayout' })
+    await grid.vm.$emit('layout-updated', [{ i: 'hero', x: 1, y: 0, w: 5, h: 3 }])
+    await nextTick()
+
+    // Assert
+    const payload = emitted[emitted.length - 1]
+    expect(payload.cards[0].id).toBe('hero')
+    expect(payload.cards[0].x).toBe(1)
+    expect(payload.cards[0].w).toBe(5)
+  })
+
+  test('with layout-updated event expect persisted cards do not contain i field', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget(
+      { settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }, { id: 'today', x: 0, y: 3, w: 2, h: 2 }] } },
+      (s) => emitted.push(s)
+    )
+    wrapper.vm.manualTicker = 'TSLA'
+    await nextTick()
+    wrapper.vm.quoteData = SAMPLE_QUOTE
+    await nextTick()
+
+    // Act
+    const grid = wrapper.findComponent({ name: 'GridLayout' })
+    await grid.vm.$emit('layout-updated', [
+      { i: 'hero',  x: 0, y: 0, w: 6, h: 3 },
+      { i: 'today', x: 0, y: 3, w: 2, h: 2 },
+    ])
+    await nextTick()
+
+    // Assert — no i field on any persisted card
+    const payload = emitted[emitted.length - 1]
+    for (const card of payload.cards) {
+      expect(card.i).toBeUndefined()
+      expect(card.id).toBeDefined()
+    }
+  })
+})
+
+// ── EQV4CardPicker ────────────────────────────────────────────────────────────
+
+describe('EQV4CardPicker', () => {
+  const absentCards = [{ id: 'today', label: 'Today' }, { id: 'volume', label: 'Volume' }]
+
+  test('with add-card button click expect dropdown opens', async () => {
+    // Arrange
+    const wrapper = mount(EQV4CardPicker, { props: { absentCards } })
+
+    // Act / Assert — dropdown hidden initially
+    expect(wrapper.find('.eqv4-picker-dropdown').exists()).toBe(false)
+
+    // Act
+    await wrapper.find('.eqv4-picker-btn').trigger('click')
+
+    // Assert
+    expect(wrapper.find('.eqv4-picker-dropdown').exists()).toBe(true)
+  })
+
+  test('with card item click expect add-card emitted and dropdown closes', async () => {
+    // Arrange
+    const calls = []
+    const wrapper = mount(EQV4CardPicker, {
+      props: { absentCards },
+      attrs: { 'onAdd-card': (id) => calls.push(id) },
+    })
+
+    // Act
+    await wrapper.find('.eqv4-picker-btn').trigger('click')
+    await wrapper.find('.eqv4-picker-item').trigger('click')
+
+    // Assert
+    expect(calls).toEqual(['today'])
+    expect(wrapper.find('.eqv4-picker-dropdown').exists()).toBe(false)
+  })
+
+  test('with absent cards list expect all absent card labels rendered in dropdown', async () => {
+    // Arrange
+    const wrapper = mount(EQV4CardPicker, { props: { absentCards } })
+
+    // Act
+    await wrapper.find('.eqv4-picker-btn').trigger('click')
+
+    // Assert
+    const items = wrapper.findAll('.eqv4-picker-item')
+    expect(items.length).toBe(2)
+    expect(items[0].text()).toBe('Today')
+    expect(items[1].text()).toBe('Volume')
   })
 })
 


### PR DESCRIPTION
## Summary

Implements the `EnhancedQuoteV4.vue` root widget and `EQV4CardPicker.vue`.

refs #190

## Files Created
- `EnhancedQuoteV4.vue` — root widget: inner `GridLayout`, settings handling, data layer, edit mode wiring, defineExpose
- `EQV4CardPicker.vue` — add-card dropdown listing absent cards
- `__tests__/EnhancedQuoteV4.spec.js` — 22 test cases, all passing

## Key Logic

**Settings / layout:**
- `gridLayout` computed: maps `settings.cards` → layout array with `i: card.id`; default 7-card layout if absent
- First render without `settings.cards`: emits `update-settings` with default layout immediately (immediate watcher)
- `@layout-updated` (dragend/resizeend only): strips `i`, persists new card positions via `update-settings`
- Internal `internalLayout` ref synced from `gridLayout` computed on settings change

**Edit mode:**
- X button on card header calls `removeCard(cardId)`
- EQV4CardPicker lists absent cards; selection calls `addCard(cardId)`
- First-fit scan (row-major, append-to-bottom fallback) places new cards
- Cols/row-height numeric inputs emit `update-settings` on change (clamped: cols 1–24, rowHeight 20–120)

**Data layer:**
- WDS via `useWebSocketClient` (`autoConnect: false`, arm on config ready)
- Company + short interest via Massive REST API (same as EQv3)
- Bus connection via `useWidgetBus` — Hero card is sole `setActiveTicker` caller
- `brandingMode` + `activeBrandingUrl` + `toggleBranding` match EQv3 shape

**defineExpose:**
`lastDataAt, isConnected, reconnecting, quoteData, manualTicker, companyData, companyLoading, shortInterestData, shortInterestLoading, gridLayout, gridCols, gridRowHeight, chipCardIds, addCard, removeCard, activeCardIds`

## Test Results
168/168 passing (146 existing + 22 new)