### PR TITLE
feat(EQv4): register enhanced-quote-v4 in WidgetMenu and WidgetWrapper

### DIFF
--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -35,7 +35,7 @@ const availableWidgets = [
   { type: 'company-news', label: 'Company News', icon: '🗞️' },
   { type: 'quote', label: 'Quote', icon: '⚡' },
   { type: 'enhanced-quote', label: 'Enhanced Quote', icon: '✨' },
-  { type: 'enhanced-quote-v4', label: 'Enhanced Quote V4', icon: '⚡' },
+  { type: 'enhanced-quote-v4', label: 'Enhanced Quote V4', icon: '💎' },
 ]
 
 const selectWidget = (widgetType) => {

--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -35,6 +35,7 @@ const availableWidgets = [
   { type: 'company-news', label: 'Company News', icon: '🗞️' },
   { type: 'quote', label: 'Quote', icon: '⚡' },
   { type: 'enhanced-quote', label: 'Enhanced Quote', icon: '✨' },
+  { type: 'enhanced-quote-v4', label: 'Enhanced Quote V4', icon: '⚡' },
 ]
 
 const selectWidget = (widgetType) => {

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -71,6 +71,7 @@ import CompanyNews from './widgets/CompanyNews.vue'
 import NewsFeed from './widgets/NewsFeed.vue'
 import Quote from './widgets/Quote.vue'
 import EnhancedQuoteV3 from './widgets/EnhancedQuoteV3.vue'
+import EnhancedQuoteV4 from './widgets/EnhancedQuoteV4.vue'
 import { LINK_COLORS, LINK_COLOR_MAP } from '@/composables/useWidgetBus.js'
 
 const props = defineProps({
@@ -93,6 +94,7 @@ const widgetComponents = {
   'quote':           Quote,
   'enhanced-quote':    EnhancedQuoteV3,
   'enhanced-quote-v3': EnhancedQuoteV3,  // backward-compat alias
+  'enhanced-quote-v4': EnhancedQuoteV4,
 }
 
 const widgetComponent = computed(() => widgetComponents[props.widgetType])

--- a/client/src/components/__tests__/WidgetMenuAndWrapper.spec.js
+++ b/client/src/components/__tests__/WidgetMenuAndWrapper.spec.js
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+// ── WidgetMenu ────────────────────────────────────────────────────────────────
+import WidgetMenu from '../WidgetMenu.vue'
+
+describe('WidgetMenu', () => {
+  test('with menu open expect enhanced-quote-v4 option present', async () => {
+    // Arrange
+    const wrapper = mount(WidgetMenu)
+
+    // Act — open the menu
+    await wrapper.find('.menu-toggle').trigger('click')
+
+    // Assert
+    const buttons = wrapper.findAll('.widget-button')
+    const types = buttons.map(b => b.attributes('data-type') ?? b.text())
+    // Find the EQv4 entry by checking emitted value or button text
+    expect(wrapper.text()).toContain('Enhanced Quote V4')
+  })
+
+  test('with Enhanced Quote V4 clicked expect add-widget emitted with enhanced-quote-v4', async () => {
+    // Arrange
+    const calls = []
+    const wrapper = mount(WidgetMenu, {
+      attrs: { onAddWidget: (t) => calls.push(t) },
+    })
+
+    // Act
+    await wrapper.find('.menu-toggle').trigger('click')
+    const buttons = wrapper.findAll('.widget-button')
+    const v4btn = buttons.find(b => b.text().includes('Enhanced Quote V4'))
+    await v4btn.trigger('click')
+
+    // Assert
+    expect(calls).toContain('enhanced-quote-v4')
+  })
+})
+
+// ── WidgetWrapper ─────────────────────────────────────────────────────────────
+
+// Stub all widget components — WidgetWrapper just resolves and renders them.
+vi.mock('../widgets/TopVolume.vue',       () => ({ default: { template: '<div class="stub-top-volume" />' } }))
+vi.mock('../widgets/TopGappers.vue',      () => ({ default: { template: '<div class="stub-top-gappers" />' } }))
+vi.mock('../widgets/TopGainers.vue',      () => ({ default: { template: '<div class="stub-top-gainers" />' } }))
+vi.mock('../widgets/CompanyNews.vue',     () => ({ default: { template: '<div class="stub-company-news" />' } }))
+vi.mock('../widgets/NewsFeed.vue',        () => ({ default: { template: '<div class="stub-news-feed" />' } }))
+vi.mock('../widgets/Quote.vue',           () => ({ default: { template: '<div class="stub-quote" />' } }))
+vi.mock('../widgets/EnhancedQuoteV3.vue', () => ({ default: { template: '<div class="stub-eqv3" />' } }))
+vi.mock('../widgets/EnhancedQuoteV4.vue', () => ({ default: { template: '<div class="stub-eqv4" />' } }))
+
+import WidgetWrapper from '../WidgetWrapper.vue'
+
+function mountWrapper(widgetType) {
+  return mount(WidgetWrapper, {
+    props: {
+      widgetId: 'test-widget-1',
+      widgetType,
+      isLocked: true,
+      settings: {},
+    },
+  })
+}
+
+describe('WidgetWrapper', () => {
+  test('with widgetType enhanced-quote-v4 expect EQV4 component rendered', () => {
+    // Arrange / Act
+    const wrapper = mountWrapper('enhanced-quote-v4')
+
+    // Assert
+    expect(wrapper.find('.stub-eqv4').exists()).toBe(true)
+  })
+
+  test('with widgetType enhanced-quote-v3 expect EQV3 component rendered', () => {
+    // Arrange / Act
+    const wrapper = mountWrapper('enhanced-quote-v3')
+
+    // Assert
+    expect(wrapper.find('.stub-eqv3').exists()).toBe(true)
+  })
+
+  test('with widgetType enhanced-quote expect EQV3 backward-compat alias resolved', () => {
+    // Arrange / Act
+    const wrapper = mountWrapper('enhanced-quote')
+
+    // Assert
+    expect(wrapper.find('.stub-eqv3').exists()).toBe(true)
+  })
+})

--- a/client/src/components/__tests__/WidgetMenuAndWrapper.spec.js
+++ b/client/src/components/__tests__/WidgetMenuAndWrapper.spec.js
@@ -13,9 +13,6 @@ describe('WidgetMenu', () => {
     await wrapper.find('.menu-toggle').trigger('click')
 
     // Assert
-    const buttons = wrapper.findAll('.widget-button')
-    const types = buttons.map(b => b.attributes('data-type') ?? b.text())
-    // Find the EQv4 entry by checking emitted value or button text
     expect(wrapper.text()).toContain('Enhanced Quote V4')
   })
 


### PR DESCRIPTION
## Summary

Wires EQv4 into the dashboard UI.

refs #192
refs #188

## Files Modified
- `WidgetMenu.vue` — adds `enhanced-quote-v4` entry (label: "Enhanced Quote V4", icon: 💎)
- `WidgetWrapper.vue` — imports `EnhancedQuoteV4` and adds `'enhanced-quote-v4'` to the component resolver map

## Files Created
- `__tests__/WidgetMenuAndWrapper.spec.js` — 5 test cases covering WidgetMenu EQv4 listing + emit, and WidgetWrapper resolution for EQv4, EQv3, and the backward-compat `enhanced-quote` alias

## Test Results
178/178 passing (173 existing + 5 new)