### PR TITLE
fix(EQv4): move edit bar outside data guard; fix layout-update feedback loop

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV4.vue
+++ b/client/src/components/widgets/EnhancedQuoteV4.vue
@@ -28,6 +28,9 @@
 
     <!-- Quote data available -->
     <div v-else class="eqv4-body">
+
+      <!-- Edit bar — always visible when unlocked, regardless of data state -->
+
       <GridLayout
         v-model:layout="internalLayout"
         :col-num="gridCols"
@@ -74,35 +77,36 @@
         </GridItem>
       </GridLayout>
 
-      <!-- Edit mode: add card + grid config -->
-      <div v-if="!isLocked" class="eqv4-edit-bar">
-        <EQV4CardPicker
-          v-if="absentCards.length > 0"
-          :absent-cards="absentCards"
-          @add-card="addCard"
-        />
-        <div class="eqv4-grid-config">
-          <label class="eqv4-config-label">
-            Cols
-            <input
-              type="number"
-              :value="gridCols"
-              min="1" max="24"
-              class="eqv4-config-input"
-              @change="onGridColsChange"
-            />
-          </label>
-          <label class="eqv4-config-label">
-            Row H
-            <input
-              type="number"
-              :value="gridRowHeight"
-              min="20" max="120"
-              class="eqv4-config-input"
-              @change="onGridRowHeightChange"
-            />
-          </label>
-        </div>
+    </div>
+
+    <!-- Edit bar — visible whenever unlocked, outside the data guard -->
+    <div v-if="!isLocked" class="eqv4-edit-bar">
+      <EQV4CardPicker
+        v-if="absentCards.length > 0"
+        :absent-cards="absentCards"
+        @add-card="addCard"
+      />
+      <div class="eqv4-grid-config">
+        <label class="eqv4-config-label">
+          Cols
+          <input
+            type="number"
+            :value="gridCols"
+            min="1" max="24"
+            class="eqv4-config-input"
+            @change="onGridColsChange"
+          />
+        </label>
+        <label class="eqv4-config-label">
+          Row H
+          <input
+            type="number"
+            :value="gridRowHeight"
+            min="20" max="120"
+            class="eqv4-config-input"
+            @change="onGridRowHeightChange"
+          />
+        </label>
       </div>
     </div>
   </div>
@@ -181,9 +185,16 @@ const gridLayout = computed(() =>
 
 // Internal mutable layout ref — v-model:layout for GridLayout reactivity.
 // Kept in sync with gridLayout computed on settings change.
+// Guard flag: prevents re-syncing internalLayout when the settings change
+// was triggered by our own onLayoutUpdated emit (avoids feedback loop).
 const internalLayout = ref(gridLayout.value.map(c => ({ ...c })))
+let _ownLayoutUpdate = false
 
 watch(gridLayout, (newLayout) => {
+  if (_ownLayoutUpdate) {
+    _ownLayoutUpdate = false
+    return
+  }
   internalLayout.value = newLayout.map(c => ({ ...c }))
 }, { deep: true })
 
@@ -206,7 +217,9 @@ watch(settingsCards, (cards) => {
 
 // @layout-updated fires on dragend/resizeend only (not on every drag tick).
 // Persist new positions via update-settings.
+// Set guard before emitting so the gridLayout watcher skips the echo-back.
 const onLayoutUpdated = (newLayout) => {
+  _ownLayoutUpdate = true
   emit('update-settings', {
     ...props.settings,
     cards: newLayout.map(({ i, ...rest }) => ({ ...rest, id: i })),

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -397,16 +397,12 @@ describe('removeCard', () => {
 
 describe('Grid config', () => {
   test('with gridCols change expect update-settings emitted with new gridCols', async () => {
-    // Arrange — need isLocked:false, activeTicker, and quoteData to render body + edit bar
+    // Arrange — edit bar is always visible when !isLocked; no ticker or data needed
     const emitted = []
     const wrapper = mountWidget(
       { isLocked: false, settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
       (s) => emitted.push(s)
     )
-    // Set ticker so activeTicker is truthy, then set quoteData
-    wrapper.vm.manualTicker = 'TSLA'
-    await nextTick()
-    wrapper.vm.quoteData = SAMPLE_QUOTE
     await nextTick()
 
     // Act
@@ -421,15 +417,12 @@ describe('Grid config', () => {
   })
 
   test('with gridRowHeight change expect update-settings emitted with new gridRowHeight', async () => {
-    // Arrange
+    // Arrange — edit bar is always visible when !isLocked; no ticker or data needed
     const emitted = []
     const wrapper = mountWidget(
       { isLocked: false, settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
       (s) => emitted.push(s)
     )
-    wrapper.vm.manualTicker = 'TSLA'
-    await nextTick()
-    wrapper.vm.quoteData = SAMPLE_QUOTE
     await nextTick()
 
     // Act

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -535,6 +535,29 @@ describe('onLayoutUpdated', () => {
       expect(card.id).toBeDefined()
     }
   })
+
+  test('with layout-updated event expect update-settings emitted exactly once (no feedback loop)', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget(
+      { settings: { cards: [{ id: 'hero', x: 0, y: 0, w: 6, h: 3 }] } },
+      (s) => emitted.push(s)
+    )
+    wrapper.vm.manualTicker = 'TSLA'
+    await nextTick()
+    wrapper.vm.quoteData = SAMPLE_QUOTE
+    await nextTick()
+    const beforeCount = emitted.length
+
+    // Act — simulate one drag-end event
+    const grid = wrapper.findComponent({ name: 'GridLayout' })
+    await grid.vm.$emit('layout-updated', [{ i: 'hero', x: 1, y: 0, w: 5, h: 3 }])
+    await nextTick()
+    await nextTick() // allow any potential echo-back to propagate
+
+    // Assert — exactly one emission per drag event
+    expect(emitted.length - beforeCount).toBe(1)
+  })
 })
 
 // ── EQV4CardPicker ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two production bugs found during first use of EQv4 after all sub-issues merged.

refs #188

## Bug 1 — Edit tools not accessible before a ticker is set

**Symptom:** No controls to add cards or configure the grid on a freshly added EQv4 widget until a ticker is entered *and* quote data arrives.

**Root cause:** `eqv4-edit-bar` was nested inside `v-else class="eqv4-body"`, gated on `activeTicker && quoteData`. In the empty and waiting states, the entire edit section was hidden.

**Fix:** Moved the edit bar outside the data guard — it now renders whenever `!isLocked`, regardless of ticker or data state.

## Bug 2 — UI lockup when linked to a live ticker on the color bus

**Symptom:** Linking EQv4 to a live ticker via the color bus locked up the entire UI.

**Root cause:** `watch(gridLayout, { deep: true })` reset `internalLayout` on every settings change. `onLayoutUpdated` emits `update-settings` → parent stores new settings → `props.settings` changes → `gridLayout` computed reacts → watcher fires → `internalLayout` reset → GridLayout fires `@layout-updated` again → infinite loop.

**Fix:** Added `_ownLayoutUpdate` guard flag. Set to `true` before emitting in `onLayoutUpdated`. The watcher checks and clears it — skips the reset when the change originated from us. External settings changes (parent prop updates) still sync through normally.

## Files Changed
- `EnhancedQuoteV4.vue` — edit bar moved, guard flag added
- `EnhancedQuoteV4.spec.js` — grid config tests updated to reflect edit bar is always visible when unlocked (no ticker/data setup required)

## Test Results
178/178 passing
