### PR TITLE
feat(EQv4): always render grid; hero wide/narrow toggle; chips toggle in card header

### DIFF
--- a/client/src/components/widgets/EQV4HeroCard.vue
+++ b/client/src/components/widgets/EQV4HeroCard.vue
@@ -1,50 +1,90 @@
 <template>
-  <div class="eqv4-hero-card">
-    <!-- Symbol + branding image -->
-    <div class="eqv4-hero-symbol-block">
-      <img
-        v-if="activeBrandingUrl"
-        :src="activeBrandingUrl"
-        class="eqv4-hero-logo"
-        :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
-      />
-      <div class="eqv4-hero-symbol-row">
-        <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
-        <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
-      </div>
-      <!-- Branding toggle — edit mode only -->
-      <button
-        v-if="!isLocked"
-        class="eqv4-branding-toggle filter-btn"
-        :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
-        @click="emit('toggle-branding')"
-      >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
-    </div>
+  <div :class="['eqv4-hero-card', heroMode === 'wide' ? 'eqv4-hero--wide' : 'eqv4-hero--narrow']">
 
-    <!-- Price block -->
-    <div class="eqv4-hero-price-block">
-      <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
-      <span :class="['eqv4-change-badge', changeClass]">
-        {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
-        ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
-      </span>
-      <div class="eqv4-since-open">
-        since open
-        <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
-          <span v-if="quoteData?.change_since_open != null">
-            {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
-          </span>
-          ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
+    <!-- Wide mode: vertical stack (symbol → price → identity) -->
+    <template v-if="heroMode === 'wide'">
+      <div class="eqv4-hero-symbol-block">
+        <img
+          v-if="activeBrandingUrl"
+          :src="activeBrandingUrl"
+          class="eqv4-hero-logo"
+          :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
+        />
+        <div class="eqv4-hero-symbol-row">
+          <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
+          <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
+        </div>
+        <button
+          v-if="!isLocked"
+          class="eqv4-branding-toggle filter-btn"
+          :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
+          @click="emit('toggle-branding')"
+        >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
+      </div>
+      <div class="eqv4-hero-price-block">
+        <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
+        <span :class="['eqv4-change-badge', changeClass]">
+          {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
+          ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
         </span>
+        <div class="eqv4-since-open">
+          since open
+          <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
+            <span v-if="quoteData?.change_since_open != null">
+              {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
+            </span>
+            ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
+          </span>
+        </div>
+        <div class="eqv4-as-of">as of {{ dataAge }}</div>
       </div>
-      <div class="eqv4-as-of">as of {{ dataAge }}</div>
-    </div>
+      <div class="eqv4-hero-identity-block">
+        <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
+        <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
+      </div>
+    </template>
 
-    <!-- Identity block: name + SIC -->
-    <div class="eqv4-hero-identity-block">
-      <span v-if="companyName" class="eqv4-hero-company-name">{{ companyName }}</span>
-      <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
-    </div>
+    <!-- Narrow mode: two columns — left: logo/symbol/flame/name/sic; right: price/change/since-open/as-of -->
+    <template v-else>
+      <div class="eqv4-hero-left">
+        <img
+          v-if="activeBrandingUrl"
+          :src="activeBrandingUrl"
+          class="eqv4-hero-logo"
+          :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
+        />
+        <div class="eqv4-hero-symbol-row">
+          <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
+          <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
+        </div>
+        <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
+        <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
+        <button
+          v-if="!isLocked"
+          class="eqv4-branding-toggle filter-btn"
+          :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
+          @click="emit('toggle-branding')"
+        >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
+      </div>
+      <div class="eqv4-hero-right">
+        <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
+        <span :class="['eqv4-change-badge', changeClass]">
+          {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
+          ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
+        </span>
+        <div class="eqv4-since-open">
+          since open
+          <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
+            <span v-if="quoteData?.change_since_open != null">
+              {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
+            </span>
+            ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
+          </span>
+        </div>
+        <div class="eqv4-as-of">as of {{ dataAge }}</div>
+      </div>
+    </template>
+
   </div>
 </template>
 
@@ -53,12 +93,13 @@ import { computed } from 'vue'
 import { fmt } from './eqv3Utils.js'
 
 const props = defineProps({
-  quoteData:      { type: Object,  required: true },
-  companyData:    { type: Object,  default: () => ({}) },
-  isLocked:       { type: Boolean, default: true },
-  brandingMode:   { type: String,  default: 'logo' },
-  activeBrandingUrl: { type: String, default: null },
-  flameIcon:      { type: Object,  default: null },
+  quoteData:         { type: Object,  default: null },
+  companyData:       { type: Object,  default: () => ({}) },
+  isLocked:          { type: Boolean, default: true },
+  brandingMode:      { type: String,  default: 'logo' },
+  activeBrandingUrl: { type: String,  default: null },
+  flameIcon:         { type: Object,  default: null },
+  heroMode:          { type: String,  default: 'wide' },  // 'wide' | 'narrow'
 })
 
 const emit = defineEmits(['toggle-branding'])
@@ -75,34 +116,71 @@ const dataAge = computed(() => {
     hour: '2-digit', minute: '2-digit', second: '2-digit',
   })
 })
-
-const companyName = computed(() => props.companyData?.name ?? null)
 </script>
 
 <style scoped>
+/* ── Base ── */
 .eqv4-hero-card {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
   height: 100%;
   overflow: auto;
   padding: 6px;
   box-sizing: border-box;
+  display: flex;
+  gap: 6px;
 }
-.eqv4-hero-symbol-block {
+
+/* ── Wide mode: vertical stack ── */
+.eqv4-hero--wide {
+  flex-direction: column;
+}
+.eqv4-hero--wide .eqv4-hero-symbol-block {
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+.eqv4-hero--wide .eqv4-hero-price-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.eqv4-hero--wide .eqv4-hero-identity-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 4px;
+}
+
+/* ── Narrow mode: two columns ── */
+.eqv4-hero--narrow {
+  flex-direction: row;
+  align-items: flex-start;
+}
+.eqv4-hero-left {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex-shrink: 0;
+  min-width: 0;
+  flex: 1;
+}
+.eqv4-hero-right {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-end;
+  flex-shrink: 0;
+}
+
+/* ── Shared elements ── */
+.eqv4-hero-symbol-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 .eqv4-hero-logo {
   height: 32px;
   max-width: 120px;
   object-fit: contain;
-}
-.eqv4-hero-symbol-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
 }
 .eqv4-symbol {
   font-family: 'Roboto Mono', monospace;
@@ -113,15 +191,6 @@ const companyName = computed(() => props.companyData?.name ?? null)
 .eqv4-flame-icon {
   width: 16px;
   height: 16px;
-}
-.eqv4-branding-toggle {
-  align-self: flex-start;
-  margin-top: 2px;
-}
-.eqv4-hero-price-block {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
 }
 .eqv4-price {
   font-family: 'Roboto Mono', monospace;
@@ -150,21 +219,25 @@ const companyName = computed(() => props.companyData?.name ?? null)
   color: var(--text-muted, #64748b);
   font-style: italic;
 }
-.eqv4-hero-identity-block {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
 .eqv4-hero-company-name {
   font-size: 12px;
   font-weight: 600;
   color: var(--text-primary, #e2e8f0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .eqv4-hero-sic {
   font-size: 11px;
   color: var(--text-muted, #64748b);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-/* Shared filter-btn style (matches EQv3 pill style) */
+.eqv4-branding-toggle {
+  align-self: flex-start;
+  margin-top: 2px;
+}
 .filter-btn {
   background: none;
   border: 1px solid var(--border, #2d2d3d);

--- a/client/src/components/widgets/EQV4PrevCard.vue
+++ b/client/src/components/widgets/EQV4PrevCard.vue
@@ -2,22 +2,22 @@
   <div class="eqv4-card-body">
     <template v-if="chipsMode">
       <div class="eqv4-chip-row">
-        <div class="eqv4-chip"><span class="eqv4-chip-label">O</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
-        <div class="eqv4-chip"><span class="eqv4-chip-label">H</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
-        <div class="eqv4-chip"><span class="eqv4-chip-label">L</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
-        <div class="eqv4-chip"><span class="eqv4-chip-label">C</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
-        <div class="eqv4-chip"><span class="eqv4-chip-label">Vol</span><span class="eqv4-chip-val">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
-        <div class="eqv4-chip"><span class="eqv4-chip-label">VWAP</span><span class="eqv4-chip-val">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">O</span><span class="eqv4-chip-val">${{ fmt(quoteData?.prev_day_open, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">H</span><span class="eqv4-chip-val">${{ fmt(quoteData?.prev_day_high, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">L</span><span class="eqv4-chip-val">${{ fmt(quoteData?.prev_day_low, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">C</span><span class="eqv4-chip-val">${{ fmt(quoteData?.prev_day_close, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">Vol</span><span class="eqv4-chip-val">{{ fmtVol(quoteData?.prev_day_volume) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">VWAP</span><span class="eqv4-chip-val">${{ fmt(quoteData?.prev_day_vwap, 2) }}</span></div>
       </div>
     </template>
     <template v-else>
       <div class="eqv4-kv-list">
-        <div class="eqv4-kv"><span class="eqv4-k">Open</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_open, 2) }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">High</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_high, 2) }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Low</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_low, 2) }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Close</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_close, 2) }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Volume</span><span class="eqv4-v">{{ fmtVol(quoteData.prev_day_volume) }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">VWAP</span><span class="eqv4-v">${{ fmt(quoteData.prev_day_vwap, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Open</span><span class="eqv4-v">${{ fmt(quoteData?.prev_day_open, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">High</span><span class="eqv4-v">${{ fmt(quoteData?.prev_day_high, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Low</span><span class="eqv4-v">${{ fmt(quoteData?.prev_day_low, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Close</span><span class="eqv4-v">${{ fmt(quoteData?.prev_day_close, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Volume</span><span class="eqv4-v">{{ fmtVol(quoteData?.prev_day_volume) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">VWAP</span><span class="eqv4-v">${{ fmt(quoteData?.prev_day_vwap, 2) }}</span></div>
       </div>
     </template>
   </div>
@@ -27,7 +27,7 @@
 import { fmt, fmtVol } from './eqv3Utils.js'
 
 defineProps({
-  quoteData:  { type: Object,  required: true },
+  quoteData:  { type: Object,  default: null },
   isLocked:   { type: Boolean, default: true },
   chipsMode:  { type: Boolean, default: false },
 })

--- a/client/src/components/widgets/EQV4SessionCard.vue
+++ b/client/src/components/widgets/EQV4SessionCard.vue
@@ -4,25 +4,25 @@
       <div class="eqv4-session-chips">
         <div class="eqv4-session-chip">
           <span class="eqv4-chip-label">PRE</span>
-          <div v-if="quoteData.pre_market_high != null || quoteData.pre_market_low != null" class="eqv4-session-chip-vals">
-            <span>H: ${{ fmt(quoteData.pre_market_high, 2) }}</span>
-            <span>L: ${{ fmt(quoteData.pre_market_low, 2) }}</span>
+          <div v-if="quoteData?.pre_market_high != null || quoteData?.pre_market_low != null" class="eqv4-session-chip-vals">
+            <span>H: ${{ fmt(quoteData?.pre_market_high, 2) }}</span>
+            <span>L: ${{ fmt(quoteData?.pre_market_low, 2) }}</span>
           </div>
           <div v-else class="eqv4-session-chip-vals eqv4-muted-val">—</div>
         </div>
         <div class="eqv4-session-chip">
           <span class="eqv4-chip-label">REG</span>
-          <div v-if="quoteData.regular_session_high != null || quoteData.regular_session_low != null" class="eqv4-session-chip-vals">
-            <span>H: ${{ fmt(quoteData.regular_session_high, 2) }}</span>
-            <span>L: ${{ fmt(quoteData.regular_session_low, 2) }}</span>
+          <div v-if="quoteData?.regular_session_high != null || quoteData?.regular_session_low != null" class="eqv4-session-chip-vals">
+            <span>H: ${{ fmt(quoteData?.regular_session_high, 2) }}</span>
+            <span>L: ${{ fmt(quoteData?.regular_session_low, 2) }}</span>
           </div>
           <div v-else class="eqv4-session-chip-vals eqv4-muted-val">—</div>
         </div>
         <div class="eqv4-session-chip">
           <span class="eqv4-chip-label">AH</span>
-          <div v-if="quoteData.after_hours_high != null || quoteData.after_hours_low != null" class="eqv4-session-chip-vals">
-            <span>H: ${{ fmt(quoteData.after_hours_high, 2) }}</span>
-            <span>L: ${{ fmt(quoteData.after_hours_low, 2) }}</span>
+          <div v-if="quoteData?.after_hours_high != null || quoteData?.after_hours_low != null" class="eqv4-session-chip-vals">
+            <span>H: ${{ fmt(quoteData?.after_hours_high, 2) }}</span>
+            <span>L: ${{ fmt(quoteData?.after_hours_low, 2) }}</span>
           </div>
           <div v-else class="eqv4-session-chip-vals eqv4-muted-val">—</div>
         </div>
@@ -30,12 +30,12 @@
     </template>
     <template v-else>
       <div class="eqv4-kv-list">
-        <div class="eqv4-kv"><span class="eqv4-k">Pre High</span><span class="eqv4-v">{{ quoteData.pre_market_high != null ? '$' + fmt(quoteData.pre_market_high, 2) : '—' }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Pre Low</span><span class="eqv4-v">{{ quoteData.pre_market_low != null ? '$' + fmt(quoteData.pre_market_low, 2) : '—' }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Reg High</span><span class="eqv4-v">{{ quoteData.regular_session_high != null ? '$' + fmt(quoteData.regular_session_high, 2) : '—' }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Reg Low</span><span class="eqv4-v">{{ quoteData.regular_session_low != null ? '$' + fmt(quoteData.regular_session_low, 2) : '—' }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">AH High</span><span class="eqv4-v">{{ quoteData.after_hours_high != null ? '$' + fmt(quoteData.after_hours_high, 2) : '—' }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">AH Low</span><span class="eqv4-v">{{ quoteData.after_hours_low != null ? '$' + fmt(quoteData.after_hours_low, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Pre High</span><span class="eqv4-v">{{ quoteData?.pre_market_high != null ? '$' + fmt(quoteData?.pre_market_high, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Pre Low</span><span class="eqv4-v">{{ quoteData?.pre_market_low != null ? '$' + fmt(quoteData?.pre_market_low, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Reg High</span><span class="eqv4-v">{{ quoteData?.regular_session_high != null ? '$' + fmt(quoteData?.regular_session_high, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Reg Low</span><span class="eqv4-v">{{ quoteData?.regular_session_low != null ? '$' + fmt(quoteData?.regular_session_low, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">AH High</span><span class="eqv4-v">{{ quoteData?.after_hours_high != null ? '$' + fmt(quoteData?.after_hours_high, 2) : '—' }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">AH Low</span><span class="eqv4-v">{{ quoteData?.after_hours_low != null ? '$' + fmt(quoteData?.after_hours_low, 2) : '—' }}</span></div>
       </div>
     </template>
   </div>
@@ -45,7 +45,7 @@
 import { fmt } from './eqv3Utils.js'
 
 defineProps({
-  quoteData:  { type: Object,  required: true },
+  quoteData:  { type: Object,  default: null },
   isLocked:   { type: Boolean, default: true },
   chipsMode:  { type: Boolean, default: false },
 })

--- a/client/src/components/widgets/EQV4TodayCard.vue
+++ b/client/src/components/widgets/EQV4TodayCard.vue
@@ -2,14 +2,14 @@
   <div class="eqv4-card-body">
     <template v-if="chipsMode">
       <div class="eqv4-chip-row">
-        <div class="eqv4-chip"><span class="eqv4-chip-label">O</span><span class="eqv4-chip-val">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
-        <div class="eqv4-chip"><span class="eqv4-chip-label">VWAP</span><span class="eqv4-chip-val">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">O</span><span class="eqv4-chip-val">${{ fmt(quoteData?.official_open_price, 2) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">VWAP</span><span class="eqv4-chip-val">${{ fmt(quoteData?.aggregate_vwap, 2) }}</span></div>
       </div>
     </template>
     <template v-else>
       <div class="eqv4-kv-list">
-        <div class="eqv4-kv"><span class="eqv4-k">Open</span><span class="eqv4-v">${{ fmt(quoteData.official_open_price, 2) }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">VWAP</span><span class="eqv4-v">${{ fmt(quoteData.aggregate_vwap, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Open</span><span class="eqv4-v">${{ fmt(quoteData?.official_open_price, 2) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">VWAP</span><span class="eqv4-v">${{ fmt(quoteData?.aggregate_vwap, 2) }}</span></div>
       </div>
     </template>
   </div>
@@ -19,7 +19,7 @@
 import { fmt } from './eqv3Utils.js'
 
 defineProps({
-  quoteData:  { type: Object,  required: true },
+  quoteData:  { type: Object,  default: null },
   isLocked:   { type: Boolean, default: true },
   chipsMode:  { type: Boolean, default: false },
 })

--- a/client/src/components/widgets/EQV4VolumeCard.vue
+++ b/client/src/components/widgets/EQV4VolumeCard.vue
@@ -2,22 +2,22 @@
   <div class="eqv4-card-body">
     <template v-if="chipsMode">
       <div class="eqv4-chip-row">
-        <div class="eqv4-chip"><span class="eqv4-chip-label">Vol</span><span class="eqv4-chip-val">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
-        <div class="eqv4-chip"><span class="eqv4-chip-label">Avg</span><span class="eqv4-chip-val">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">Vol</span><span class="eqv4-chip-val">{{ fmtVol(quoteData?.accumulated_volume) }}</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">Avg</span><span class="eqv4-chip-val">{{ fmtVol(quoteData?.avg_volume) }}</span></div>
         <div class="eqv4-chip"><span class="eqv4-chip-label">Float</span><span class="eqv4-chip-val">{{ fmtVol(floatShares) }}</span></div>
-        <div class="eqv4-chip"><span class="eqv4-chip-label">RVol</span><span :class="['eqv4-chip-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span></div>
+        <div class="eqv4-chip"><span class="eqv4-chip-label">RVol</span><span :class="['eqv4-chip-val', relVolClass]">{{ fmt(quoteData?.relative_volume, 2) }}x</span></div>
       </div>
     </template>
     <template v-else>
       <div class="eqv4-kv-list">
-        <div class="eqv4-kv"><span class="eqv4-k">Volume</span><span class="eqv4-v">{{ fmtVol(quoteData.accumulated_volume) }}</span></div>
-        <div class="eqv4-kv"><span class="eqv4-k">Avg Vol</span><span class="eqv4-v">{{ fmtVol(quoteData.avg_volume) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Volume</span><span class="eqv4-v">{{ fmtVol(quoteData?.accumulated_volume) }}</span></div>
+        <div class="eqv4-kv"><span class="eqv4-k">Avg Vol</span><span class="eqv4-v">{{ fmtVol(quoteData?.avg_volume) }}</span></div>
         <div class="eqv4-kv"><span class="eqv4-k">Float</span><span class="eqv4-v">{{ fmtVol(floatShares) }}</span></div>
       </div>
       <div class="eqv4-rv-row">
         <span class="eqv4-k">Rel. Vol</span>
         <div class="eqv4-rv-bar-wrap"><div class="eqv4-rv-bar" :style="{ width: rvBarWidth, background: rvBarColor }"></div></div>
-        <span :class="['eqv4-rv-val', relVolClass]">{{ fmt(quoteData.relative_volume, 2) }}x</span>
+        <span :class="['eqv4-rv-val', relVolClass]">{{ fmt(quoteData?.relative_volume, 2) }}x</span>
       </div>
     </template>
   </div>
@@ -28,7 +28,7 @@ import { computed } from 'vue'
 import { fmt, fmtVol } from './eqv3Utils.js'
 
 const props = defineProps({
-  quoteData:  { type: Object,  required: true },
+  quoteData:  { type: Object,  default: null },
   isLocked:   { type: Boolean, default: true },
   chipsMode:  { type: Boolean, default: false },
 })

--- a/client/src/components/widgets/EnhancedQuoteV4.vue
+++ b/client/src/components/widgets/EnhancedQuoteV4.vue
@@ -79,7 +79,7 @@
             :loading="item.i === 'short' ? shortInterestLoading : (item.i === 'company' ? companyLoading : false)"
             :is-locked="isLocked"
             :chips-mode="chipCardIds.has(item.i)"
-            :hero-mode="heroMode"
+            :hero-mode="item.i === 'hero' ? heroMode : undefined"
             :branding-mode="brandingMode"
             :active-branding-url="activeBrandingUrl"
             :flame-icon="flameIcon"

--- a/client/src/components/widgets/EnhancedQuoteV4.vue
+++ b/client/src/components/widgets/EnhancedQuoteV4.vue
@@ -14,23 +14,18 @@
       <button class="eqv4-go-btn" @click="applyInput" @touchend.prevent="applyInput" title="Load quote">Go</button>
     </div>
 
-    <!-- No ticker yet -->
-    <div v-if="!activeTicker" class="eqv4-empty">
+    <!-- Status overlay — shown over the grid when no ticker or no data yet -->
+    <div v-if="!activeTicker" class="eqv4-overlay">
       <span class="eqv4-empty-icon">⚡</span>
       <span class="eqv4-empty-text">Enter a ticker above, or link to a scanner and click a row</span>
     </div>
-
-    <!-- Ticker set, waiting for data -->
-    <div v-else-if="!quoteData" class="eqv4-empty">
+    <div v-else-if="!quoteData" class="eqv4-overlay">
       <span class="eqv4-empty-icon">⏳</span>
       <span class="eqv4-empty-text">Waiting for data for <strong>{{ activeTicker }}</strong>...</span>
     </div>
 
-    <!-- Quote data available -->
-    <div v-else class="eqv4-body">
-
-      <!-- Edit bar — always visible when unlocked, regardless of data state -->
-
+    <!-- Grid — always rendered so layout is visible and configurable immediately -->
+    <div class="eqv4-body">
       <GridLayout
         v-model:layout="internalLayout"
         :col-num="gridCols"
@@ -48,15 +43,31 @@
           :x="item.x" :y="item.y" :w="item.w" :h="item.h" :i="item.i"
           class="eqv4-grid-item"
         >
-          <!-- Card header: label + X button in edit mode -->
+          <!-- Card header: label + edit-mode controls -->
           <div class="eqv4-card-header">
             <span class="eqv4-card-label">{{ cardLabel(item.i) }}</span>
-            <button
-              v-if="!isLocked"
-              class="eqv4-card-remove"
-              title="Remove card"
-              @click="removeCard(item.i)"
-            >✕</button>
+            <span v-if="!isLocked" class="eqv4-card-controls">
+              <!-- Hero layout toggle -->
+              <button
+                v-if="item.i === 'hero'"
+                class="eqv4-card-toggle"
+                :title="heroMode === 'wide' ? 'Switch to narrow layout' : 'Switch to wide layout'"
+                @click="toggleHeroMode"
+              >{{ heroMode === 'wide' ? 'wide' : 'narrow' }}</button>
+              <!-- Chips toggle for chipsCapable cards -->
+              <button
+                v-if="isChipsCapable(item.i)"
+                :class="['eqv4-card-toggle', { 'eqv4-card-toggle--active': chipCardIds.has(item.i) }]"
+                :title="chipCardIds.has(item.i) ? 'Switch to list mode' : 'Switch to chips mode'"
+                @click="toggleCardChips(item.i)"
+              >{{ chipCardIds.has(item.i) ? 'chips' : 'list' }}</button>
+              <!-- Remove button -->
+              <button
+                class="eqv4-card-remove"
+                title="Remove card"
+                @click="removeCard(item.i)"
+              >✕</button>
+            </span>
           </div>
 
           <!-- Card body: dynamic component by card id -->
@@ -68,6 +79,7 @@
             :loading="item.i === 'short' ? shortInterestLoading : (item.i === 'company' ? companyLoading : false)"
             :is-locked="isLocked"
             :chips-mode="chipCardIds.has(item.i)"
+            :hero-mode="heroMode"
             :branding-mode="brandingMode"
             :active-branding-url="activeBrandingUrl"
             :flame-icon="flameIcon"
@@ -76,7 +88,6 @@
           />
         </GridItem>
       </GridLayout>
-
     </div>
 
     <!-- Edit bar — visible whenever unlocked, outside the data guard -->
@@ -171,6 +182,23 @@ const gridCols = computed(() => props.settings?.gridCols ?? 6)
 const gridRowHeight = computed(() => props.settings?.gridRowHeight ?? 40)
 const chipCardIds = computed(() => new Set(props.settings?.chipCards ?? []))
 const brandingMode = computed(() => props.settings?.brandingMode ?? 'logo')
+const heroMode = computed(() => props.settings?.heroMode ?? 'wide')
+
+// Cards that support chip render mode (company card does not)
+const CHIPS_CAPABLE = new Set(['today', 'prev', 'volume', 'session', 'short'])
+const isChipsCapable = (id) => CHIPS_CAPABLE.has(id)
+
+const toggleCardChips = (cardId) => {
+  const chips = new Set(props.settings?.chipCards ?? [])
+  if (chips.has(cardId)) chips.delete(cardId)
+  else chips.add(cardId)
+  emit('update-settings', { ...props.settings, chipCards: [...chips] })
+}
+
+const toggleHeroMode = () => {
+  const next = heroMode.value === 'wide' ? 'narrow' : 'wide'
+  emit('update-settings', { ...props.settings, heroMode: next })
+}
 
 const settingsCards = computed(() => {
   const c = props.settings?.cards
@@ -503,8 +531,11 @@ defineExpose({
   gridCols,
   gridRowHeight,
   chipCardIds,
+  heroMode,
   addCard,
   removeCard,
+  toggleCardChips,
+  toggleHeroMode,
   activeCardIds,
 })
 </script>
@@ -555,17 +586,21 @@ defineExpose({
   padding: 4px 10px;
   cursor: pointer;
 }
-.eqv4-empty {
+.eqv4-overlay {
+  position: absolute;
+  inset: 40px 0 0 0; /* below controls bar */
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  flex: 1;
   color: var(--text-muted);
   font-size: 13px;
   padding: 24px;
   text-align: center;
+  background: rgba(13, 13, 18, 0.85);
+  z-index: 10;
+  pointer-events: none;
 }
 .eqv4-empty-icon { font-size: 28px; }
 .eqv4-body {
@@ -573,6 +608,7 @@ defineExpose({
   overflow: auto;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 .eqv4-grid-item {
   background: var(--surface);
@@ -595,6 +631,32 @@ defineExpose({
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+.eqv4-card-controls {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+.eqv4-card-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text-muted);
+  font-size: 10px;
+  padding: 1px 5px;
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  text-transform: none;
+  letter-spacing: 0;
+  transition: border-color 0.15s, color 0.15s;
+}
+.eqv4-card-toggle:hover {
+  border-color: var(--pd-accent);
+  color: var(--pd-accent);
+}
+.eqv4-card-toggle--active {
+  border-color: var(--pd-accent);
+  color: var(--pd-accent);
 }
 .eqv4-card-remove {
   background: none;

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -122,16 +122,16 @@ function mountWidget(props = {}, onUpdateSettings = null) {
 // ── Empty / waiting states ────────────────────────────────────────────────────
 
 describe('Empty and waiting states', () => {
-  test('with no ticker expect empty state rendered', () => {
+  test('with no ticker expect overlay shown and grid still rendered', () => {
     // Arrange / Act
     const wrapper = mountWidget()
 
-    // Assert
-    expect(wrapper.find('.eqv4-empty').exists()).toBe(true)
-    expect(wrapper.find('.eqv4-body').exists()).toBe(false)
+    // Assert — overlay visible, body (grid) always rendered
+    expect(wrapper.find('.eqv4-overlay').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-body').exists()).toBe(true)
   })
 
-  test('with ticker but no quote data expect waiting state shown', async () => {
+  test('with ticker but no quote data expect waiting overlay shown', async () => {
     // Arrange
     const wrapper = mountWidget()
 
@@ -141,7 +141,7 @@ describe('Empty and waiting states', () => {
     await nextTick()
 
     // Assert
-    expect(wrapper.find('.eqv4-empty').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-overlay').exists()).toBe(true)
     expect(wrapper.find('.eqv4-empty-text').text()).toContain('TSLA')
   })
 })
@@ -633,8 +633,159 @@ describe('Exposed interface', () => {
     expect(vm.gridCols).toBeDefined()
     expect(vm.gridRowHeight).toBeDefined()
     expect(vm.chipCardIds).toBeDefined()
+    expect(vm.heroMode).toBeDefined()
     expect(typeof vm.addCard).toBe('function')
     expect(typeof vm.removeCard).toBe('function')
+    expect(typeof vm.toggleCardChips).toBe('function')
+    expect(typeof vm.toggleHeroMode).toBe('function')
     expect(vm.activeCardIds).toBeDefined()
+  })
+})
+
+// ── heroMode ──────────────────────────────────────────────────────────────
+
+describe('heroMode', () => {
+  test('with no settings.heroMode expect default wide mode', () => {
+    // Arrange / Act
+    const wrapper = mountWidget({ settings: {} })
+
+    // Assert
+    expect(wrapper.vm.heroMode).toBe('wide')
+  })
+
+  test('with toggleHeroMode called expect update-settings emitted with narrow', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget({ settings: {} }, (s) => emitted.push(s))
+
+    // Act
+    wrapper.vm.toggleHeroMode()
+    await nextTick()
+
+    // Assert
+    const last = emitted[emitted.length - 1]
+    expect(last.heroMode).toBe('narrow')
+  })
+
+  test('with toggleHeroMode called twice expect heroMode returns to wide', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget({ settings: { heroMode: 'narrow' } }, (s) => emitted.push(s))
+
+    // Act
+    wrapper.vm.toggleHeroMode()
+    await nextTick()
+
+    // Assert
+    expect(emitted[emitted.length - 1].heroMode).toBe('wide')
+  })
+})
+
+// ── toggleCardChips ─────────────────────────────────────────────────────────
+
+describe('toggleCardChips', () => {
+  test('with toggleCardChips called on non-chip card expect card added to chipCards', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget({ settings: { chipCards: [] } }, (s) => emitted.push(s))
+
+    // Act
+    wrapper.vm.toggleCardChips('today')
+    await nextTick()
+
+    // Assert
+    const last = emitted[emitted.length - 1]
+    expect(last.chipCards).toContain('today')
+  })
+
+  test('with toggleCardChips called on active chip card expect card removed from chipCards', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget({ settings: { chipCards: ['today'] } }, (s) => emitted.push(s))
+
+    // Act
+    wrapper.vm.toggleCardChips('today')
+    await nextTick()
+
+    // Assert
+    const last = emitted[emitted.length - 1]
+    expect(last.chipCards).not.toContain('today')
+  })
+})
+
+// ── EQV4HeroCard ───────────────────────────────────────────────────────────
+
+import EQV4HeroCard from '../EQV4HeroCard.vue'
+
+const HERO_QUOTE = {
+  symbol: 'AAPL',
+  close: 189.5,
+  change: 2.3,
+  pct_change: 1.23,
+  change_since_open: 1.1,
+  pct_change_since_open: 0.58,
+  end_timestamp: new Date('2026-04-15T16:00:00Z').getTime(),
+}
+const HERO_COMPANY = { name: 'Apple Inc.', sic_description: 'Electronic Computers' }
+
+describe('EQV4HeroCard', () => {
+  test('with heroMode wide expect vertical-stack class applied', () => {
+    // Arrange / Act
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: HERO_QUOTE, heroMode: 'wide', isLocked: true },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-hero--wide').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-hero--narrow').exists()).toBe(false)
+  })
+
+  test('with heroMode narrow expect two-column class applied', () => {
+    // Arrange / Act
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: HERO_QUOTE, heroMode: 'narrow', isLocked: true },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-hero--narrow').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-hero--wide').exists()).toBe(false)
+  })
+
+  test('with heroMode narrow expect left and right columns rendered', () => {
+    // Arrange / Act
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'narrow', isLocked: true },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-hero-left').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-hero-right').exists()).toBe(true)
+    expect(wrapper.text()).toContain('AAPL')
+    expect(wrapper.text()).toContain('Apple Inc.')
+    expect(wrapper.text()).toContain('189.50')
+  })
+
+  test('with heroMode wide expect all data present in vertical layout', () => {
+    // Arrange / Act
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'wide', isLocked: true },
+    })
+
+    // Assert
+    expect(wrapper.find('.eqv4-hero-symbol-block').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-hero-price-block').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-hero-identity-block').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Apple Inc.')
+    expect(wrapper.text()).toContain('189.50')
+  })
+
+  test('with null quoteData expect no crash', () => {
+    // Arrange / Act — grid renders cards with null quoteData before ticker set
+    const wrapper = mount(EQV4HeroCard, {
+      props: { quoteData: null, heroMode: 'wide', isLocked: true },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('—')
   })
 })


### PR DESCRIPTION
## Summary

Three UX improvements to EQv4 based on first-use feedback.

refs #188

## Fix 1 — Grid always rendered (no longer gated on ticker/data)

**Before:** Widget was empty until a ticker was set *and* quote data arrived. The grid and cards only rendered inside `v-else` (quoteData guard).

**After:** Grid renders immediately on mount. Empty/waiting states are now an overlay (`eqv4-overlay`) that appears *above* the grid using `position: absolute` with a semi-transparent background. Cards receive `quoteData=null` until data arrives — all card templates updated with optional chaining (`?.`) and `default: null` prop definitions to handle this safely.

## Fix 2 — Hero card wide/narrow layout toggle

`EQV4HeroCard` now supports a `heroMode` prop (`'wide' | 'narrow'`, default `'wide'`):

- **wide**: vertical stack — symbol block → price block → identity block (same as current)
- **narrow**: two-column — left column has logo/symbol/flame/company name/SIC; right column has price/change/since-open/as-of

Toggle button appears on the Hero card header in edit mode. State stored in `settings.heroMode`. `toggleHeroMode()` exposed on the widget.

## Fix 3 — Chips/kv-list toggle in card headers

Each card header in edit mode now shows a `chips`/`list` toggle button for `chipsCapable` cards (today, prev, volume, session, short). Active state uses `--pd-accent` border + text, matching EQv3 style. `toggleCardChips(cardId)` exposed on the widget.

## Files Changed
- `EnhancedQuoteV4.vue` — overlay pattern, card header controls, heroMode/chips toggle handlers, defineExpose additions
- `EQV4HeroCard.vue` — wide/narrow layout modes with CSS class switching
- `EQV4TodayCard.vue`, `EQV4PrevCard.vue`, `EQV4VolumeCard.vue`, `EQV4SessionCard.vue` — `quoteData` prop changed to `default: null`, optional chaining on all field accesses
- `EnhancedQuoteV4.spec.js` — updated overlay tests, 10 new test cases (heroMode, toggleCardChips, EQV4HeroCard layout modes)

## Test Results
189/189 passing
