### PR TITLE
fix(EQv4): resolve flame icon srcs via Vite asset import

### DIFF
--- a/client/src/components/widgets/EnhancedQuoteV4.vue
+++ b/client/src/components/widgets/EnhancedQuoteV4.vue
@@ -494,11 +494,20 @@ watch(isConnected, (connected) => {
 })
 
 // ── Flame icon ────────────────────────────────────────────────────────────────
+const FLAME_SRCS = {
+  red:    new URL('@/assets/icons/flame-red.svg',    import.meta.url).href,
+  orange: new URL('@/assets/icons/flame-orange.svg', import.meta.url).href,
+  yellow: new URL('@/assets/icons/flame-yellow.svg', import.meta.url).href,
+  white:  new URL('@/assets/icons/flame-white.svg',  import.meta.url).href,
+  blue:   new URL('@/assets/icons/flame-blue.svg',   import.meta.url).href,
+  dark:   new URL('@/assets/icons/flame-dark.svg',   import.meta.url).href,
+}
+
 const flameIcon = computed(() => {
   if (!activeTicker.value) return null
   const variant = getFlameVariant(activeTicker.value)
   if (!variant) return null
-  return { src: variant, tooltip: getFlameTooltip(activeTicker.value) }
+  return { src: FLAME_SRCS[variant], tooltip: getFlameTooltip(activeTicker.value) }
 })
 
 // ── Branding ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes 404 on flame icons in EQv4.

refs #188

## Root Cause

`flameIcon` computed was returning `{ src: variant, ... }` where `variant` is a plain string (`'orange'`, `'red'`, etc.). Vite doesn't know to bundle these — the browser requested `GET /static/orange` and got a 404.

EQv3 correctly resolves each variant at module init via `new URL('@/assets/icons/flame-{variant}.svg', import.meta.url).href`.

## Fix

Added `FLAME_SRCS` map (identical to EQv3) and updated `flameIcon` to use `FLAME_SRCS[variant]` as the src.

## Test Results
189/189 passing