### PR TITLE
fix(EQv4): correct heroMode layout inversion

### DIFF
--- a/client/src/components/widgets/EQV4HeroCard.vue
+++ b/client/src/components/widgets/EQV4HeroCard.vue
@@ -1,8 +1,49 @@
 <template>
   <div :class="['eqv4-hero-card', heroMode === 'wide' ? 'eqv4-hero--wide' : 'eqv4-hero--narrow']">
 
-    <!-- Wide mode: vertical stack (symbol → price → identity) -->
+    <!-- Wide mode: two columns — left: logo/symbol/flame/name/sic; right: price/change/since-open/as-of -->
     <template v-if="heroMode === 'wide'">
+      <div class="eqv4-hero-left">
+        <img
+          v-if="activeBrandingUrl"
+          :src="activeBrandingUrl"
+          class="eqv4-hero-logo"
+          :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
+        />
+        <div class="eqv4-hero-symbol-row">
+          <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
+          <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
+        </div>
+        <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
+        <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
+        <button
+          v-if="!isLocked"
+          class="eqv4-branding-toggle filter-btn"
+          :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
+          @click="emit('toggle-branding')"
+        >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
+      </div>
+      <div class="eqv4-hero-right">
+        <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
+        <span :class="['eqv4-change-badge', changeClass]">
+          {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
+          ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
+        </span>
+        <div class="eqv4-since-open">
+          since open
+          <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
+            <span v-if="quoteData?.change_since_open != null">
+              {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
+            </span>
+            ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
+          </span>
+        </div>
+        <div class="eqv4-as-of">as of {{ dataAge }}</div>
+      </div>
+    </template>
+
+    <!-- Narrow mode: vertical stack — symbol → price → identity -->
+    <template v-else>
       <div class="eqv4-hero-symbol-block">
         <img
           v-if="activeBrandingUrl"
@@ -41,47 +82,6 @@
       <div class="eqv4-hero-identity-block">
         <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
         <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
-      </div>
-    </template>
-
-    <!-- Narrow mode: two columns — left: logo/symbol/flame/name/sic; right: price/change/since-open/as-of -->
-    <template v-else>
-      <div class="eqv4-hero-left">
-        <img
-          v-if="activeBrandingUrl"
-          :src="activeBrandingUrl"
-          class="eqv4-hero-logo"
-          :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
-        />
-        <div class="eqv4-hero-symbol-row">
-          <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
-          <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
-        </div>
-        <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
-        <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
-        <button
-          v-if="!isLocked"
-          class="eqv4-branding-toggle filter-btn"
-          :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
-          @click="emit('toggle-branding')"
-        >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
-      </div>
-      <div class="eqv4-hero-right">
-        <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
-        <span :class="['eqv4-change-badge', changeClass]">
-          {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
-          ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
-        </span>
-        <div class="eqv4-since-open">
-          since open
-          <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
-            <span v-if="quoteData?.change_since_open != null">
-              {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
-            </span>
-            ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
-          </span>
-        </div>
-        <div class="eqv4-as-of">as of {{ dataAge }}</div>
       </div>
     </template>
 

--- a/client/src/components/widgets/EQV4HeroCard.vue
+++ b/client/src/components/widgets/EQV4HeroCard.vue
@@ -129,31 +129,31 @@ const dataAge = computed(() => {
   gap: 6px;
 }
 
-/* ── Wide mode: vertical stack ── */
+/* ── Wide mode: two columns ── */
 .eqv4-hero--wide {
+  flex-direction: row;
+  align-items: flex-start;
+}
+
+/* ── Narrow mode: vertical stack ── */
+.eqv4-hero--narrow {
   flex-direction: column;
 }
-.eqv4-hero--wide .eqv4-hero-symbol-block {
+.eqv4-hero--narrow .eqv4-hero-symbol-block {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
-.eqv4-hero--wide .eqv4-hero-price-block {
+.eqv4-hero--narrow .eqv4-hero-price-block {
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
-.eqv4-hero--wide .eqv4-hero-identity-block {
+.eqv4-hero--narrow .eqv4-hero-identity-block {
   display: flex;
   flex-direction: column;
   gap: 2px;
   margin-top: 4px;
-}
-
-/* ── Narrow mode: two columns ── */
-.eqv4-hero--narrow {
-  flex-direction: row;
-  align-items: flex-start;
 }
 .eqv4-hero-left {
   display: flex;

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -729,7 +729,7 @@ const HERO_QUOTE = {
 const HERO_COMPANY = { name: 'Apple Inc.', sic_description: 'Electronic Computers' }
 
 describe('EQV4HeroCard', () => {
-  test('with heroMode wide expect vertical-stack class applied', () => {
+  test('with heroMode wide expect two-column class applied', () => {
     // Arrange / Act
     const wrapper = mount(EQV4HeroCard, {
       props: { quoteData: HERO_QUOTE, heroMode: 'wide', isLocked: true },
@@ -740,7 +740,7 @@ describe('EQV4HeroCard', () => {
     expect(wrapper.find('.eqv4-hero--narrow').exists()).toBe(false)
   })
 
-  test('with heroMode narrow expect two-column class applied', () => {
+  test('with heroMode narrow expect vertical-stack class applied', () => {
     // Arrange / Act
     const wrapper = mount(EQV4HeroCard, {
       props: { quoteData: HERO_QUOTE, heroMode: 'narrow', isLocked: true },
@@ -751,10 +751,10 @@ describe('EQV4HeroCard', () => {
     expect(wrapper.find('.eqv4-hero--wide').exists()).toBe(false)
   })
 
-  test('with heroMode narrow expect left and right columns rendered', () => {
+  test('with heroMode wide expect left and right columns rendered', () => {
     // Arrange / Act
     const wrapper = mount(EQV4HeroCard, {
-      props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'narrow', isLocked: true },
+      props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'wide', isLocked: true },
     })
 
     // Assert
@@ -765,10 +765,10 @@ describe('EQV4HeroCard', () => {
     expect(wrapper.text()).toContain('189.50')
   })
 
-  test('with heroMode wide expect all data present in vertical layout', () => {
+  test('with heroMode narrow expect vertical stack rendered', () => {
     // Arrange / Act
     const wrapper = mount(EQV4HeroCard, {
-      props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'wide', isLocked: true },
+      props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'narrow', isLocked: true },
     })
 
     // Assert


### PR DESCRIPTION
## Summary

`wide` and `narrow` hero layouts were rendering each other's content.

refs #188

## Root Cause

The `v-if="heroMode === 'wide'"` branch rendered the vertical-stack layout (three blocks stacked). The `v-else` branch rendered the two-column layout. The names are inverted — wide should use the full card width with two columns, narrow should stack vertically.

## Fix

Swapped the template content between branches:
- **wide** now renders: two columns — left (logo/symbol/flame/company name/SIC), right (price/change/since-open/as-of)
- **narrow** now renders: vertical stack — symbol block → price block → identity block

Spec tests updated to assert the correct layout structure for each mode.

## Test Results
189/189 passing