### PR TITLE
fix(EQv4): rewrite HeroCard — port EQv3 hero CSS directly

### DIFF
--- a/client/src/components/widgets/EQV4HeroCard.vue
+++ b/client/src/components/widgets/EQV4HeroCard.vue
@@ -1,90 +1,50 @@
 <template>
-  <div :class="['eqv4-hero-card', heroMode === 'wide' ? 'eqv4-hero--wide' : 'eqv4-hero--narrow']">
-
-    <!-- Wide mode: two columns — left: logo/symbol/flame/name/sic; right: price/change/since-open/as-of -->
-    <template v-if="heroMode === 'wide'">
-      <div class="eqv4-hero-left">
-        <img
-          v-if="activeBrandingUrl"
-          :src="activeBrandingUrl"
-          class="eqv4-hero-logo"
-          :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
-        />
-        <div class="eqv4-hero-symbol-row">
-          <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
-          <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
-        </div>
-        <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
-        <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
-        <button
-          v-if="!isLocked"
-          class="eqv4-branding-toggle filter-btn"
-          :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
-          @click="emit('toggle-branding')"
-        >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
+  <div class="eqv4-hero-card">
+    <!-- Symbol block: logo + symbol + flame — left side -->
+    <div class="eqv4-hero-symbol-block">
+      <img
+        v-if="activeBrandingUrl"
+        :src="activeBrandingUrl"
+        class="eqv4-hero-logo"
+        :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
+      />
+      <div class="eqv4-hero-symbol-row">
+        <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
+        <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
       </div>
-      <div class="eqv4-hero-right">
-        <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
-        <span :class="['eqv4-change-badge', changeClass]">
-          {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
-          ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
-        </span>
-        <div class="eqv4-since-open">
-          since open
-          <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
-            <span v-if="quoteData?.change_since_open != null">
-              {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
-            </span>
-            ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
+      <!-- Branding toggle — edit mode only -->
+      <button
+        v-if="!isLocked"
+        class="eqv4-branding-toggle filter-btn"
+        :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
+        @click="emit('toggle-branding')"
+      >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
+    </div>
+
+    <!-- Price block: price + change + since-open + as-of — right side -->
+    <div class="eqv4-hero-price-block">
+      <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
+      <span :class="['eqv4-change-badge', changeClass]">
+        {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
+        ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
+      </span>
+      <div class="eqv4-since-open">
+        since open
+        <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
+          <span v-if="quoteData?.change_since_open != null">
+            {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
           </span>
-        </div>
-        <div class="eqv4-as-of">as of {{ dataAge }}</div>
-      </div>
-    </template>
-
-    <!-- Narrow mode: vertical stack — symbol → price → identity -->
-    <template v-else>
-      <div class="eqv4-hero-symbol-block">
-        <img
-          v-if="activeBrandingUrl"
-          :src="activeBrandingUrl"
-          class="eqv4-hero-logo"
-          :alt="brandingMode === 'icon' ? 'Company icon' : 'Company logo'"
-        />
-        <div class="eqv4-hero-symbol-row">
-          <span class="eqv4-symbol">{{ quoteData?.symbol }}</span>
-          <img v-if="flameIcon" :src="flameIcon.src" :title="flameIcon.tooltip" class="eqv4-flame-icon" />
-        </div>
-        <button
-          v-if="!isLocked"
-          class="eqv4-branding-toggle filter-btn"
-          :title="brandingMode === 'logo' ? 'Switch to icon' : 'Switch to logo'"
-          @click="emit('toggle-branding')"
-        >{{ brandingMode === 'logo' ? 'icon' : 'logo' }}</button>
-      </div>
-      <div class="eqv4-hero-price-block">
-        <span class="eqv4-price">${{ fmt(quoteData?.close, 2) }}</span>
-        <span :class="['eqv4-change-badge', changeClass]">
-          {{ (quoteData?.change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.change, 2) }}
-          ({{ (quoteData?.pct_change ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change, 2) }}%)
+          ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
         </span>
-        <div class="eqv4-since-open">
-          since open
-          <span :class="(quoteData?.pct_change_since_open ?? 0) >= 0 ? 'eqv4-pos' : 'eqv4-neg'">
-            <span v-if="quoteData?.change_since_open != null">
-              {{ (quoteData?.change_since_open ?? 0) >= 0 ? '+' : '-' }}${{ fmt(Math.abs(quoteData?.change_since_open ?? 0), 2) }}
-            </span>
-            ({{ (quoteData?.pct_change_since_open ?? 0) >= 0 ? '+' : '' }}{{ fmt(quoteData?.pct_change_since_open, 2) }}%)
-          </span>
-        </div>
-        <div class="eqv4-as-of">as of {{ dataAge }}</div>
       </div>
-      <div class="eqv4-hero-identity-block">
-        <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
-        <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
-      </div>
-    </template>
+      <div class="eqv4-as-of">as of {{ dataAge }}</div>
+    </div>
 
+    <!-- Identity block: company name + SIC — spans full width below; hidden in narrow mode -->
+    <div v-if="heroMode === 'wide'" class="eqv4-hero-identity-block">
+      <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
+      <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
+    </div>
   </div>
 </template>
 
@@ -119,121 +79,133 @@ const dataAge = computed(() => {
 </script>
 
 <style scoped>
-/* ── Base ── */
+/* Hero card — ported directly from EQv3 hero CSS */
 .eqv4-hero-card {
+  padding: 8px 10px;
   height: 100%;
-  overflow: auto;
-  padding: 6px;
   box-sizing: border-box;
+  overflow: auto;
   display: flex;
-  gap: 6px;
-}
-
-/* ── Wide mode: two columns ── */
-.eqv4-hero--wide {
   flex-direction: row;
-  align-items: flex-start;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 12px;
 }
 
-/* ── Narrow mode: vertical stack ── */
-.eqv4-hero--narrow {
-  flex-direction: column;
-}
-.eqv4-hero--narrow .eqv4-hero-symbol-block {
+/* Symbol block: logo + symbol row — flex row, left side */
+.eqv4-hero-symbol-block {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-.eqv4-hero--narrow .eqv4-hero-price-block {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.eqv4-hero--narrow .eqv4-hero-identity-block {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  margin-top: 4px;
-}
-.eqv4-hero-left {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
+  align-items: center;
+  gap: 8px;
   flex-shrink: 0;
-  min-width: 0;
-  flex: 1;
 }
-.eqv4-hero-right {
+
+/* Price block: stacked column, right side */
+.eqv4-hero-price-block {
   display: flex;
   flex-direction: column;
-  gap: 2px;
   align-items: flex-end;
+  gap: 2px;
   flex-shrink: 0;
 }
 
-/* ── Shared elements ── */
+/* Identity block: spans full width below symbol + price */
+.eqv4-hero-identity-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  width: 100%;
+}
+
 .eqv4-hero-symbol-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
 }
+
 .eqv4-hero-logo {
-  height: 32px;
-  max-width: 120px;
+  width: 40px;
+  height: 40px;
   object-fit: contain;
+  border-radius: 4px;
+  flex-shrink: 0;
 }
-.eqv4-symbol {
-  font-family: 'Roboto Mono', monospace;
-  font-size: 20px;
-  font-weight: 700;
-  color: var(--text-primary, #e2e8f0);
-}
-.eqv4-flame-icon {
-  width: 16px;
-  height: 16px;
-}
-.eqv4-price {
-  font-family: 'Roboto Mono', monospace;
-  font-size: 22px;
-  font-weight: 700;
-  color: var(--text-primary, #e2e8f0);
-}
-.eqv4-change-badge {
-  font-family: 'Roboto Mono', monospace;
+
+.eqv4-hero-company-name {
   font-size: 13px;
   font-weight: 600;
-  padding: 2px 6px;
-  border-radius: 4px;
-  align-self: flex-start;
+  color: var(--text-primary, #e2e8f0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.eqv4-change-badge.positive { background: rgba(34,197,94,0.15); color: #22c55e; }
-.eqv4-change-badge.negative { background: rgba(239,68,68,0.15);  color: #ef4444; }
-.eqv4-since-open {
-  font-size: 11px;
+
+.eqv4-hero-sic {
+  font-size: 10px;
   color: var(--text-muted, #64748b);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.eqv4-pos { color: #22c55e; }
-.eqv4-neg { color: #ef4444; }
+
+.eqv4-symbol {
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+}
+
+.eqv4-price {
+  font-size: 22px;
+  font-weight: 600;
+  font-family: 'Roboto Mono', monospace;
+  color: #fff;
+}
+
+.eqv4-change-badge {
+  font-size: 15px;
+  font-weight: 600;
+  font-family: 'Roboto Mono', monospace;
+  padding: 2px 8px;
+  border-radius: 12px;
+  white-space: nowrap;
+}
+.eqv4-change-badge.positive {
+  background: rgba(34, 197, 94, 0.2);
+  color: #22c55e;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+.eqv4-change-badge.negative {
+  background: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
+.eqv4-since-open {
+  font-size: 13px;
+  color: var(--text-muted, #64748b);
+  text-align: right;
+}
+.eqv4-pos { color: #22c55e; font-weight: 600; }
+.eqv4-neg { color: #ef4444; font-weight: 600; }
+
 .eqv4-as-of {
   font-size: 10px;
   color: var(--text-muted, #64748b);
   font-style: italic;
 }
-.eqv4-hero-company-name {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-primary, #e2e8f0);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+
+.eqv4-flame-icon {
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+  margin-left: 2px;
+  position: relative;
+  top: -2px;
 }
-.eqv4-hero-sic {
-  font-size: 11px;
-  color: var(--text-muted, #64748b);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+
 .eqv4-branding-toggle {
   align-self: flex-start;
   margin-top: 2px;

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -729,54 +729,34 @@ const HERO_QUOTE = {
 const HERO_COMPANY = { name: 'Apple Inc.', sic_description: 'Electronic Computers' }
 
 describe('EQV4HeroCard', () => {
-  test('with heroMode wide expect two-column class applied', () => {
-    // Arrange / Act
-    const wrapper = mount(EQV4HeroCard, {
-      props: { quoteData: HERO_QUOTE, heroMode: 'wide', isLocked: true },
-    })
-
-    // Assert
-    expect(wrapper.find('.eqv4-hero--wide').exists()).toBe(true)
-    expect(wrapper.find('.eqv4-hero--narrow').exists()).toBe(false)
-  })
-
-  test('with heroMode narrow expect vertical-stack class applied', () => {
-    // Arrange / Act
-    const wrapper = mount(EQV4HeroCard, {
-      props: { quoteData: HERO_QUOTE, heroMode: 'narrow', isLocked: true },
-    })
-
-    // Assert
-    expect(wrapper.find('.eqv4-hero--narrow').exists()).toBe(true)
-    expect(wrapper.find('.eqv4-hero--wide').exists()).toBe(false)
-  })
-
-  test('with heroMode wide expect left and right columns rendered', () => {
+  test('with heroMode wide expect symbol, price, and identity blocks rendered', () => {
     // Arrange / Act
     const wrapper = mount(EQV4HeroCard, {
       props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'wide', isLocked: true },
     })
 
-    // Assert
-    expect(wrapper.find('.eqv4-hero-left').exists()).toBe(true)
-    expect(wrapper.find('.eqv4-hero-right').exists()).toBe(true)
+    // Assert — all three blocks present in wide mode
+    expect(wrapper.find('.eqv4-hero-symbol-block').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-hero-price-block').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-hero-identity-block').exists()).toBe(true)
     expect(wrapper.text()).toContain('AAPL')
     expect(wrapper.text()).toContain('Apple Inc.')
     expect(wrapper.text()).toContain('189.50')
   })
 
-  test('with heroMode narrow expect vertical stack rendered', () => {
+  test('with heroMode narrow expect identity block hidden', () => {
     // Arrange / Act
     const wrapper = mount(EQV4HeroCard, {
       props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'narrow', isLocked: true },
     })
 
-    // Assert
+    // Assert — symbol + price present; identity block absent
     expect(wrapper.find('.eqv4-hero-symbol-block').exists()).toBe(true)
     expect(wrapper.find('.eqv4-hero-price-block').exists()).toBe(true)
-    expect(wrapper.find('.eqv4-hero-identity-block').exists()).toBe(true)
-    expect(wrapper.text()).toContain('Apple Inc.')
+    expect(wrapper.find('.eqv4-hero-identity-block').exists()).toBe(false)
+    expect(wrapper.text()).toContain('AAPL')
     expect(wrapper.text()).toContain('189.50')
+    expect(wrapper.text()).not.toContain('Apple Inc.')
   })
 
   test('with null quoteData expect no crash', () => {


### PR DESCRIPTION
## Summary

Replaces the broken two-template hero layout with a direct port of EQv3's hero CSS.

refs #188

## Root Cause

The two-template approach (separate HTML structures for wide/narrow) required recreating EQv3's flex layout from scratch. Got it wrong multiple times. EQv3's hero works because it is one `flex-direction: row; flex-wrap: wrap` container — symbol-block floats left, price-block floats right, identity-block drops below at full width naturally. That behavior is not reproducible by maintaining two separate templates.

## Fix

- Single template, EQv3's exact CSS ported and renamed (`eqv3-` → `eqv4-`)
- `heroMode` controls one thing only: whether the identity block (`v-if="heroMode === 'wide'"`) is visible
- **wide**: symbol + price + company name/SIC (full hero)
- **narrow**: symbol + price only (identity hidden)

## Test Results
187/187 passing