### PR TITLE
fix(EQv4): hero narrow mode — column stack mirroring EQv3 full-mode hero

### DIFF
--- a/client/src/components/widgets/EQV4HeroCard.vue
+++ b/client/src/components/widgets/EQV4HeroCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="eqv4-hero-card">
+  <div :class="['eqv4-hero-card', { 'eqv4-hero--narrow': heroMode === 'narrow' }]">
     <!-- Symbol block: logo + symbol + flame — left side -->
     <div class="eqv4-hero-symbol-block">
       <img
@@ -93,6 +93,13 @@ const dataAge = computed(() => {
   gap: 4px 12px;
 }
 
+/* Narrow mode: column stack instead of side-by-side row */
+.eqv4-hero--narrow {
+  flex-direction: column;
+  align-items: flex-start;
+  flex-wrap: nowrap;
+}
+
 /* Symbol block: logo + symbol row — flex row, left side */
 .eqv4-hero-symbol-block {
   display: flex;
@@ -101,13 +108,19 @@ const dataAge = computed(() => {
   flex-shrink: 0;
 }
 
-/* Price block: stacked column, right side */
+/* Price block: stacked column, right side in wide / left-aligned in narrow */
 .eqv4-hero-price-block {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 2px;
   flex-shrink: 0;
+}
+.eqv4-hero--narrow .eqv4-hero-price-block {
+  align-items: flex-start;
+}
+.eqv4-hero--narrow .eqv4-since-open {
+  text-align: left;
 }
 
 /* Identity block: spans full width below symbol + price */

--- a/client/src/components/widgets/EQV4HeroCard.vue
+++ b/client/src/components/widgets/EQV4HeroCard.vue
@@ -40,8 +40,8 @@
       <div class="eqv4-as-of">as of {{ dataAge }}</div>
     </div>
 
-    <!-- Identity block: company name + SIC — spans full width below; hidden in narrow mode -->
-    <div v-if="heroMode === 'wide'" class="eqv4-hero-identity-block">
+    <!-- Identity block: company name + SIC — always rendered, spans full width below in wide; stacks in narrow -->
+    <div class="eqv4-hero-identity-block">
       <span v-if="companyData?.name" class="eqv4-hero-company-name">{{ companyData.name }}</span>
       <span v-if="companyData?.sic_description" class="eqv4-hero-sic">{{ companyData.sic_description }}</span>
     </div>
@@ -93,11 +93,12 @@ const dataAge = computed(() => {
   gap: 4px 12px;
 }
 
-/* Narrow mode: column stack instead of side-by-side row */
+/* Narrow mode: column stack — mirrors EQv3 full-mode hero (symbol → price → identity, all stacked) */
 .eqv4-hero--narrow {
   flex-direction: column;
-  align-items: flex-start;
   flex-wrap: nowrap;
+  align-items: flex-start;
+  justify-content: flex-start;
 }
 
 /* Symbol block: logo + symbol row — flex row, left side */
@@ -118,9 +119,20 @@ const dataAge = computed(() => {
 }
 .eqv4-hero--narrow .eqv4-hero-price-block {
   align-items: flex-start;
+  width: 100%;
 }
 .eqv4-hero--narrow .eqv4-since-open {
   text-align: left;
+}
+.eqv4-hero--narrow .eqv4-hero-company-name {
+  white-space: normal;
+}
+.eqv4-hero--narrow .eqv4-hero-sic {
+  white-space: normal;
+}
+.eqv4-hero--narrow .eqv4-hero-identity-block {
+  margin-top: 8px;
+  width: 100%;
 }
 
 /* Identity block: spans full width below symbol + price */

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -744,13 +744,14 @@ describe('EQV4HeroCard', () => {
     expect(wrapper.text()).toContain('189.50')
   })
 
-  test('with heroMode narrow expect identity block hidden', () => {
+  test('with heroMode narrow expect narrow class applied, identity hidden, price and symbol present', () => {
     // Arrange / Act
     const wrapper = mount(EQV4HeroCard, {
       props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'narrow', isLocked: true },
     })
 
-    // Assert — symbol + price present; identity block absent
+    // Assert — narrow class on root; symbol + price present; identity block absent
+    expect(wrapper.find('.eqv4-hero--narrow').exists()).toBe(true)
     expect(wrapper.find('.eqv4-hero-symbol-block').exists()).toBe(true)
     expect(wrapper.find('.eqv4-hero-price-block').exists()).toBe(true)
     expect(wrapper.find('.eqv4-hero-identity-block').exists()).toBe(false)

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -744,20 +744,20 @@ describe('EQV4HeroCard', () => {
     expect(wrapper.text()).toContain('189.50')
   })
 
-  test('with heroMode narrow expect narrow class applied, identity hidden, price and symbol present', () => {
+  test('with heroMode narrow expect narrow class applied and all three blocks present', () => {
     // Arrange / Act
     const wrapper = mount(EQV4HeroCard, {
       props: { quoteData: HERO_QUOTE, companyData: HERO_COMPANY, heroMode: 'narrow', isLocked: true },
     })
 
-    // Assert — narrow class on root; symbol + price present; identity block absent
+    // Assert — narrow class on root; all three blocks present (same data, column layout)
     expect(wrapper.find('.eqv4-hero--narrow').exists()).toBe(true)
     expect(wrapper.find('.eqv4-hero-symbol-block').exists()).toBe(true)
     expect(wrapper.find('.eqv4-hero-price-block').exists()).toBe(true)
-    expect(wrapper.find('.eqv4-hero-identity-block').exists()).toBe(false)
+    expect(wrapper.find('.eqv4-hero-identity-block').exists()).toBe(true)
     expect(wrapper.text()).toContain('AAPL')
     expect(wrapper.text()).toContain('189.50')
-    expect(wrapper.text()).not.toContain('Apple Inc.')
+    expect(wrapper.text()).toContain('Apple Inc.')
   })
 
   test('with null quoteData expect no crash', () => {


### PR DESCRIPTION
## Summary

Corrects `heroMode` behavior so both wide and narrow show the same data, just arranged differently — matching EQv3's two hero layouts exactly.

refs #188

## Root Cause

Previous implementation hid the identity block (company name/SIC) in narrow mode, leaving empty space. This was wrong. EQv3's narrow/wide and full-mode heroes show the same data — only the layout changes.

## Correct Behavior

**wide** (default): `flex-direction: row; flex-wrap: wrap`
- Symbol block left, price block right, identity block spans full width below
- Mirrors EQv3 narrow/wide hero layout

**narrow**: `flex-direction: column; flex-wrap: nowrap`
- Symbol → price → identity, all vertically stacked
- Mirrors EQv3 full-mode hero (the 200px left column), minus the fixed width (card size is user-controlled in EQv4)
- Price block and since-open left-aligned; company name/SIC allowed to wrap

Both modes render all three blocks. Same data, different arrangement.

## Files Changed
- `EQV4HeroCard.vue` — identity block always rendered; `.eqv4-hero--narrow` CSS overrides to column stack with left-alignment
- `EnhancedQuoteV4.spec.js` — narrow test updated to assert all three blocks present

## Test Results
187/187 passing