### PR TITLE
fix(EQv4): increase chip font sizes for better readability

### DIFF
--- a/client/src/components/widgets/EQV4PrevCard.vue
+++ b/client/src/components/widgets/EQV4PrevCard.vue
@@ -41,6 +41,6 @@ defineProps({
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
 .eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
 .eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
-.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
-.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); }
+.eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
+.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); }
 </style>

--- a/client/src/components/widgets/EQV4SessionCard.vue
+++ b/client/src/components/widgets/EQV4SessionCard.vue
@@ -59,7 +59,7 @@ defineProps({
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
 .eqv4-session-chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .eqv4-session-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 4px 8px; min-width: 56px; gap: 2px; }
-.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
-.eqv4-session-chip-vals { display: flex; flex-direction: column; align-items: center; font-family: 'Roboto Mono', monospace; font-size: 11px; color: var(--text-primary, #e2e8f0); gap: 1px; }
+.eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+.eqv4-session-chip-vals { display: flex; flex-direction: column; align-items: center; font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); gap: 1px; }
 .eqv4-muted-val { color: var(--text-muted, #64748b); }
 </style>

--- a/client/src/components/widgets/EQV4ShortCard.vue
+++ b/client/src/components/widgets/EQV4ShortCard.vue
@@ -47,7 +47,7 @@ const allNull = computed(() => {
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
 .eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
 .eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
-.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
-.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); }
+.eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
+.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); }
 .eqv4-muted-msg { font-size: 11px; color: var(--text-muted, #64748b); font-style: italic; }
 </style>

--- a/client/src/components/widgets/EQV4TodayCard.vue
+++ b/client/src/components/widgets/EQV4TodayCard.vue
@@ -33,6 +33,6 @@ defineProps({
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
 .eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
 .eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
-.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
-.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); }
+.eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
+.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); }
 </style>

--- a/client/src/components/widgets/EQV4VolumeCard.vue
+++ b/client/src/components/widgets/EQV4VolumeCard.vue
@@ -69,8 +69,8 @@ const rvBarColor = computed(() => {
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
 .eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
 .eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
-.eqv4-chip-label { font-size: 9px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
-.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 12px; color: var(--text-primary, #e2e8f0); }
+.eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
+.eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); }
 .eqv4-chip-val.extreme { color: #dc2626; }
 .eqv4-chip-val.high    { color: #f97316; }
 .eqv4-chip-val.medium  { color: #eab308; }


### PR DESCRIPTION
## Summary

Chips were rendering too small (9/12px). Bumped to 11/14px across all 5 chip-capable card SFCs.

refs #188

## Changes

| Element | Before | After |
|---------|--------|-------|
| `.eqv4-chip-label` | 9px | 11px |
| `.eqv4-chip-val` | 12px | 14px |
| `.eqv4-session-chip-vals` | 11px | 14px |

5 files: `EQV4TodayCard`, `EQV4PrevCard`, `EQV4VolumeCard`, `EQV4SessionCard`, `EQV4ShortCard`

## Test Results
187/187 passing