### PR TITLE
feat(EQv4): chips fill card width and are centered in chip mode

### DIFF
--- a/client/src/components/widgets/EQV4PrevCard.vue
+++ b/client/src/components/widgets/EQV4PrevCard.vue
@@ -39,8 +39,8 @@ defineProps({
 .eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
 .eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
-.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
-.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
+.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; align-content: center; height: 100%; }
+.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 6px 8px; flex: 1; min-width: 0; }
 .eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
 .eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); }
 </style>

--- a/client/src/components/widgets/EQV4SessionCard.vue
+++ b/client/src/components/widgets/EQV4SessionCard.vue
@@ -57,8 +57,8 @@ defineProps({
 .eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
 .eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
-.eqv4-session-chips { display: flex; flex-wrap: wrap; gap: 6px; }
-.eqv4-session-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 4px 8px; min-width: 56px; gap: 2px; }
+.eqv4-session-chips { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; align-content: center; height: 100%; }
+.eqv4-session-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 6px 10px; flex: 1; min-width: 0; gap: 2px; }
 .eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
 .eqv4-session-chip-vals { display: flex; flex-direction: column; align-items: center; font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); gap: 1px; }
 .eqv4-muted-val { color: var(--text-muted, #64748b); }

--- a/client/src/components/widgets/EQV4ShortCard.vue
+++ b/client/src/components/widgets/EQV4ShortCard.vue
@@ -45,8 +45,8 @@ const allNull = computed(() => {
 .eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
 .eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
-.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
-.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
+.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; align-content: center; height: 100%; }
+.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 6px 8px; flex: 1; min-width: 0; }
 .eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
 .eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); }
 .eqv4-muted-msg { font-size: 11px; color: var(--text-muted, #64748b); font-style: italic; }

--- a/client/src/components/widgets/EQV4TodayCard.vue
+++ b/client/src/components/widgets/EQV4TodayCard.vue
@@ -31,8 +31,8 @@ defineProps({
 .eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
 .eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
-.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
-.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
+.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; align-content: center; height: 100%; }
+.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 6px 8px; flex: 1; min-width: 0; }
 .eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
 .eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); }
 </style>

--- a/client/src/components/widgets/EQV4VolumeCard.vue
+++ b/client/src/components/widgets/EQV4VolumeCard.vue
@@ -67,8 +67,8 @@ const rvBarColor = computed(() => {
 .eqv4-kv { display: flex; justify-content: space-between; align-items: center; padding: 2px 0; border-bottom: 1px solid var(--border, #2d2d3d); gap: 8px; }
 .eqv4-k { color: var(--text-muted, #64748b); font-size: 13px; font-family: system-ui, sans-serif; flex-shrink: 0; }
 .eqv4-v { font-family: 'Roboto Mono', monospace; font-size: 13px; color: var(--text-primary, #e2e8f0); text-align: right; }
-.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
-.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 3px 6px; min-width: 44px; }
+.eqv4-chip-row { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; align-content: center; height: 100%; }
+.eqv4-chip { display: flex; flex-direction: column; align-items: center; background: var(--surface, #141420); border: 1px solid var(--border, #2d2d3d); border-radius: 4px; padding: 6px 8px; flex: 1; min-width: 0; }
 .eqv4-chip-label { font-size: 11px; color: var(--text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.05em; }
 .eqv4-chip-val { font-family: 'Roboto Mono', monospace; font-size: 14px; color: var(--text-primary, #e2e8f0); }
 .eqv4-chip-val.extreme { color: #dc2626; }


### PR DESCRIPTION
## Summary

In chip mode, chips now expand to fill the card width and are centered.

refs #188

## Changes

- `.eqv4-chip-row` / `.eqv4-session-chips`: added `justify-content: center`, `align-content: center`, `height: 100%`
- `.eqv4-chip` / `.eqv4-session-chip`: `flex: 1` (expand to fill), `min-width: 0` (allow shrinking), increased padding (`3px 6px` → `6px 8px`)

5 files: `EQV4TodayCard`, `EQV4PrevCard`, `EQV4VolumeCard`, `EQV4SessionCard`, `EQV4ShortCard`

## Test Results
187/187 passing