### PR TITLE
feat(EQv4): add EQV4CompanyNewsCard — REST-based company news card

### DIFF
--- a/client/src/components/widgets/EQV4CompanyNewsCard.vue
+++ b/client/src/components/widgets/EQV4CompanyNewsCard.vue
@@ -1,0 +1,546 @@
+<template>
+  <div class="eqv4-news-card">
+
+    <!-- Card header: label + selector + refresh + X (edit mode) -->
+    <div class="eqv4-news-header">
+      <span class="eqv4-news-label">Company News</span>
+      <div class="eqv4-news-controls">
+        <span class="eqv4-news-count-wrap">
+          <select
+            :value="articleCount"
+            class="eqv4-news-count-select"
+            title="Number of articles"
+            @change="onArticleCountChange"
+          >
+            <option v-for="n in ARTICLE_COUNT_OPTIONS" :key="n" :value="n">{{ n }}</option>
+          </select>
+        </span>
+        <button
+          class="eqv4-news-refresh"
+          :class="{ 'eqv4-news-refresh--spinning': loading }"
+          title="Refresh news"
+          :disabled="loading"
+          @click="fetchNews"
+        >↻</button>
+        <button
+          v-if="!isLocked"
+          class="eqv4-news-remove"
+          title="Remove card"
+          @click="emit('remove')"
+        >✕</button>
+      </div>
+    </div>
+
+    <!-- Search bar -->
+    <div class="eqv4-news-search-wrap">
+      <input
+        v-model.trim="searchQuery"
+        type="search"
+        placeholder="Search headlines…"
+        class="eqv4-news-search"
+        @keydown.escape="searchQuery = ''"
+      />
+      <span class="eqv4-news-article-count">
+        <template v-if="filteredArticles.length !== articles.length">
+          {{ filteredArticles.length }} / {{ articles.length }}
+        </template>
+        <template v-else>
+          {{ articles.length }}
+        </template>
+      </span>
+    </div>
+
+    <!-- Column header -->
+    <div class="eqv4-news-thead">
+      <div
+        class="eqv4-nth eqv4-nth-time"
+        :class="{ 'eqv4-nth-sorted': sortKey === 'time' }"
+        @click="cycleSort('time')"
+      >Time<span v-if="sortKey === 'time'" class="eqv4-sort-indicator">{{ sortDir === 'asc' ? ' ▲' : ' ▼' }}</span></div>
+      <div
+        class="eqv4-nth eqv4-nth-headline"
+        :class="{ 'eqv4-nth-sorted': sortKey === 'title' }"
+        @click="cycleSort('title')"
+      >Headline<span v-if="sortKey === 'title'" class="eqv4-sort-indicator">{{ sortDir === 'asc' ? ' ▲' : ' ▼' }}</span></div>
+      <div class="eqv4-nth eqv4-nth-source">Source</div>
+      <div class="eqv4-nth eqv4-nth-tickers">Tickers</div>
+    </div>
+
+    <!-- States -->
+    <div v-if="!ticker" class="eqv4-news-empty">Enter a ticker to load news</div>
+    <div v-else-if="error" class="eqv4-news-error">{{ error }} <button class="eqv4-retry-btn" @click="fetchNews">↻ Retry</button></div>
+    <div v-else-if="loading && articles.length === 0" class="eqv4-news-empty">
+      <span class="eqv4-news-spinner">↻</span> Loading…
+    </div>
+    <div v-else-if="!loading && articles.length === 0" class="eqv4-news-empty">No news found for {{ ticker }}</div>
+
+    <!-- Virtual scroller -->
+    <RecycleScroller
+      v-else
+      class="eqv4-news-scroller"
+      :items="filteredArticles"
+      :item-size="22"
+      key-field="link"
+      v-slot="{ item }"
+    >
+      <div class="eqv4-news-row" @click="selected = item">
+        <div class="eqv4-ntd eqv4-ntd-time">{{ formatTime(item.publishDate) }}</div>
+        <div class="eqv4-ntd eqv4-ntd-headline">
+          <span :class="['eqv4-sentiment-dot', sentimentClass(item.sentiment)]" :title="item.sentiment"></span>
+          <span class="eqv4-news-title">{{ item.title }}</span>
+        </div>
+        <div class="eqv4-ntd eqv4-ntd-source">{{ shortSource(item.source) }}</div>
+        <div class="eqv4-ntd eqv4-ntd-tickers">
+          <span
+            v-for="co in usCompanies(item).slice(0, 3)"
+            :key="co.ticker"
+            class="eqv4-ticker-tag"
+          >{{ co.ticker }}</span>
+        </div>
+      </div>
+    </RecycleScroller>
+
+    <!-- Detail modal -->
+    <Teleport to="body">
+      <div v-if="selected" class="eqv4-modal-backdrop" @click.self="selected = null">
+        <div class="eqv4-modal-card">
+          <button class="eqv4-modal-close" @click="selected = null">✕</button>
+          <div class="eqv4-modal-body">
+            <div class="eqv4-modal-meta">
+              <span class="eqv4-modal-time">{{ formatDateTime(selected.publishDate) }}</span>
+              <a
+                v-if="selected.source"
+                :href="'https://' + selected.source"
+                target="_blank"
+                rel="noopener"
+                class="eqv4-modal-source"
+              >{{ selected.source }}</a>
+              <span :class="['eqv4-modal-sentiment', sentimentClass(selected.sentiment)]">
+                {{ selected.sentiment }}
+              </span>
+            </div>
+            <a :href="selected.link" target="_blank" rel="noopener" class="eqv4-modal-title">
+              {{ selected.title }}
+            </a>
+            <p v-if="selected.summary" class="eqv4-modal-summary">{{ selected.summary }}</p>
+            <div v-if="selected.companies && selected.companies.length" class="eqv4-modal-companies">
+              <div
+                v-for="co in selected.companies"
+                :key="co.companyId || co.ticker"
+                class="eqv4-modal-company"
+              >
+                <span
+                  :class="['eqv4-ticker-tag', isUsTicker(co) ? '' : 'eqv4-ticker-foreign']"
+                >{{ co.ticker }}</span>
+                <span class="eqv4-modal-company-name">{{ co.name }}</span>
+                <span class="eqv4-modal-exchange">{{ co.primaryListing?.exchangeCode }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { RecycleScroller } from 'vue-virtual-scroller'
+import { useConfig } from '@/composables/useConfig.js'
+
+const ARTICLE_COUNT_OPTIONS = [5, 10, 20, 50, 100]
+const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
+
+const props = defineProps({
+  ticker:       { type: String,  default: null },
+  articleCount: { type: Number,  default: 20 },
+  isLocked:     { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['update-article-count', 'remove'])
+
+const { config } = useConfig()
+
+// ── State ─────────────────────────────────────────────────────────────────────
+const articles    = ref([])
+const loading     = ref(false)
+const error       = ref(null)
+const selected    = ref(null)
+const searchQuery = ref('')
+const sortKey     = ref('time')
+const sortDir     = ref('desc')
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+const fetchNews = async () => {
+  if (!props.ticker) return
+  if (!config.value?.finlightApiKey) {
+    error.value = 'Finlight API key not configured'
+    return
+  }
+  loading.value = true
+  error.value = null
+  articles.value = []
+  try {
+    const resp = await fetch('https://api.finlight.me/v2/articles', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${config.value.finlightApiKey}`,
+      },
+      body: JSON.stringify({
+        query: `ticker:${props.ticker}`,
+        pageSize: props.articleCount,
+        page: 1,
+        language: 'en',
+      }),
+    })
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const json = await resp.json()
+    articles.value = json.articles ?? []
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => props.ticker, (t) => { if (t) fetchNews() }, { immediate: true })
+watch(() => props.articleCount, () => { if (props.ticker) fetchNews() })
+
+// ── Controls ──────────────────────────────────────────────────────────────────
+const onArticleCountChange = (e) => {
+  emit('update-article-count', parseInt(e.target.value, 10))
+}
+
+const cycleSort = (key) => {
+  if (sortKey.value === key) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortDir.value = key === 'time' ? 'desc' : 'asc'
+  }
+}
+
+// ── Filtered + sorted articles ────────────────────────────────────────────────
+const filteredArticles = computed(() => {
+  let items = articles.value
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    items = items.filter(a => a.title?.toLowerCase().includes(q))
+  }
+  return [...items].sort((a, b) => {
+    if (sortKey.value === 'time') {
+      const diff = new Date(a.publishDate) - new Date(b.publishDate)
+      return sortDir.value === 'asc' ? diff : -diff
+    }
+    if (sortKey.value === 'title') {
+      const cmp = (a.title ?? '').localeCompare(b.title ?? '')
+      return sortDir.value === 'asc' ? cmp : -cmp
+    }
+    return 0
+  })
+})
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const isUsTicker  = (co) => US_EXCHANGES.has(co.primaryListing?.exchangeCode)
+const usCompanies = (item) => (item.companies ?? []).filter(isUsTicker)
+const shortSource = (src) => src ? src.replace(/^www\./, '').replace(/\.[^.]+$/, '') : ''
+const sentimentClass = (s) => s === 'positive' ? 'positive' : s === 'negative' ? 'negative' : 'neutral'
+
+const formatTime = (ts) => {
+  if (!ts) return ''
+  const d = new Date(ts)
+  if (isNaN(d.getTime())) return ''
+  return `${d.getMonth() + 1}/${d.getDate()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+}
+
+const formatDateTime = (ts) => {
+  if (!ts) return ''
+  const d = new Date(ts)
+  return isNaN(d.getTime()) ? '' : d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+// Escape closes modal
+const onKeyUp = (e) => { if (e.key === 'Escape') selected.value = null }
+onMounted(()   => document.addEventListener('keyup', onKeyUp))
+onUnmounted(() => document.removeEventListener('keyup', onKeyUp))
+
+// ── Expose ────────────────────────────────────────────────────────────────────
+defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews })
+</script>
+
+<style scoped>
+.eqv4-news-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg, #0d0d12);
+  color: var(--text-primary, #e2e8f0);
+  font-family: system-ui, sans-serif;
+}
+
+/* ── Header ── */
+.eqv4-news-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  background: var(--bg, #0d0d12);
+  flex-shrink: 0;
+}
+.eqv4-news-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.eqv4-news-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.eqv4-news-count-select {
+  background: var(--surface, #141420);
+  border: 1px solid var(--border, #2d2d3d);
+  border-radius: 3px;
+  color: var(--text-muted, #64748b);
+  font-size: 11px;
+  padding: 1px 3px;
+  cursor: pointer;
+}
+.eqv4-news-refresh {
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+.eqv4-news-refresh:hover { color: var(--pd-accent, #7c3aed); }
+.eqv4-news-refresh--spinning { animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.eqv4-news-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.eqv4-news-remove:hover { color: #ef4444; }
+
+/* ── Search ── */
+.eqv4-news-search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  flex-shrink: 0;
+}
+.eqv4-news-search {
+  flex: 1;
+  background: var(--surface, #141420);
+  border: 1px solid var(--border, #2d2d3d);
+  border-radius: 3px;
+  color: var(--text-primary, #e2e8f0);
+  font-size: 11px;
+  padding: 2px 6px;
+  outline: none;
+}
+.eqv4-news-search:focus { border-color: var(--pd-accent, #7c3aed); }
+.eqv4-news-article-count {
+  font-size: 10px;
+  color: var(--text-muted, #64748b);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Column header ── */
+.eqv4-news-thead {
+  display: flex;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  flex-shrink: 0;
+  background: var(--bg, #0d0d12);
+}
+.eqv4-nth {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 4px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.eqv4-nth-time    { width: 90px; flex-shrink: 0; }
+.eqv4-nth-headline { flex: 1; min-width: 0; cursor: pointer; }
+.eqv4-nth-source  { width: 80px; flex-shrink: 0; }
+.eqv4-nth-tickers { width: 70px; flex-shrink: 0; }
+.eqv4-nth-sorted  { color: var(--pd-accent, #7c3aed); }
+.eqv4-sort-indicator { font-size: 8px; }
+
+/* ── Empty / error states ── */
+.eqv4-news-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+  padding: 8px;
+  text-align: center;
+}
+.eqv4-news-error {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #ef4444;
+  padding: 8px;
+}
+.eqv4-retry-btn {
+  background: none;
+  border: 1px solid #ef4444;
+  border-radius: 3px;
+  color: #ef4444;
+  font-size: 10px;
+  padding: 1px 5px;
+  cursor: pointer;
+}
+.eqv4-news-spinner {
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+
+/* ── Virtual scroller ── */
+.eqv4-news-scroller {
+  flex: 1;
+  min-height: 0;
+}
+.eqv4-news-row {
+  display: flex;
+  align-items: center;
+  height: 22px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+}
+.eqv4-news-row:hover { background: var(--surface, #141420); }
+.eqv4-ntd {
+  font-size: 11px;
+  padding: 0 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary, #e2e8f0);
+}
+.eqv4-ntd-time    { width: 90px; flex-shrink: 0; color: var(--text-muted, #64748b); }
+.eqv4-ntd-headline { flex: 1; min-width: 0; display: flex; align-items: center; gap: 4px; }
+.eqv4-ntd-source  { width: 80px; flex-shrink: 0; color: var(--text-muted, #64748b); font-size: 10px; }
+.eqv4-ntd-tickers { width: 70px; flex-shrink: 0; display: flex; gap: 2px; overflow: hidden; }
+.eqv4-news-title  { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+
+/* ── Sentiment dot ── */
+.eqv4-sentiment-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+.eqv4-sentiment-dot.positive { background: #22c55e; }
+.eqv4-sentiment-dot.negative { background: #ef4444; }
+.eqv4-sentiment-dot.neutral  { background: #64748b; }
+
+/* ── Ticker tags ── */
+.eqv4-ticker-tag {
+  font-size: 9px;
+  font-family: 'Roboto Mono', monospace;
+  background: var(--surface, #141420);
+  border: 1px solid var(--border, #2d2d3d);
+  border-radius: 3px;
+  padding: 0 3px;
+  color: var(--text-muted, #64748b);
+  white-space: nowrap;
+}
+.eqv4-ticker-foreign { opacity: 0.5; }
+
+/* ── Detail modal ── */
+.eqv4-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+.eqv4-modal-card {
+  background: var(--surface, #141420);
+  border: 1px solid var(--border, #2d2d3d);
+  border-radius: 8px;
+  max-width: 600px;
+  width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+  position: relative;
+  padding: 16px;
+}
+.eqv4-modal-close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  font-size: 16px;
+  cursor: pointer;
+  line-height: 1;
+}
+.eqv4-modal-close:hover { color: var(--text-primary, #e2e8f0); }
+.eqv4-modal-body { display: flex; flex-direction: column; gap: 8px; }
+.eqv4-modal-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 11px;
+  flex-wrap: wrap;
+}
+.eqv4-modal-time   { color: var(--text-muted, #64748b); }
+.eqv4-modal-source { color: var(--pd-accent, #7c3aed); text-decoration: none; font-size: 11px; }
+.eqv4-modal-source:hover { text-decoration: underline; }
+.eqv4-modal-sentiment { font-size: 11px; font-weight: 600; }
+.eqv4-modal-sentiment.positive { color: #22c55e; }
+.eqv4-modal-sentiment.negative { color: #ef4444; }
+.eqv4-modal-sentiment.neutral  { color: #64748b; }
+.eqv4-modal-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary, #e2e8f0);
+  text-decoration: none;
+  line-height: 1.4;
+}
+.eqv4-modal-title:hover { text-decoration: underline; color: var(--pd-accent, #7c3aed); }
+.eqv4-modal-summary {
+  font-size: 12px;
+  color: var(--text-muted, #64748b);
+  line-height: 1.5;
+  margin: 0;
+}
+.eqv4-modal-companies { display: flex; flex-direction: column; gap: 4px; margin-top: 4px; }
+.eqv4-modal-company  { display: flex; align-items: center; gap: 6px; font-size: 11px; }
+.eqv4-modal-company-name { color: var(--text-primary, #e2e8f0); }
+.eqv4-modal-exchange { color: var(--text-muted, #64748b); font-size: 10px; }
+</style>

--- a/client/src/components/widgets/EnhancedQuoteV4.vue
+++ b/client/src/components/widgets/EnhancedQuoteV4.vue
@@ -43,8 +43,9 @@
           :x="item.x" :y="item.y" :w="item.w" :h="item.h" :i="item.i"
           class="eqv4-grid-item"
         >
-          <!-- Card header: label + edit-mode controls -->
-          <div class="eqv4-card-header">
+          <!-- Card header: label + edit-mode controls
+               Suppressed for company-news — that card owns its full header -->
+          <div v-if="item.i !== 'company-news'" class="eqv4-card-header">
             <span class="eqv4-card-label">{{ cardLabel(item.i) }}</span>
             <span v-if="!isLocked" class="eqv4-card-controls">
               <!-- Hero layout toggle -->
@@ -80,10 +81,14 @@
             :is-locked="isLocked"
             :chips-mode="chipCardIds.has(item.i)"
             :hero-mode="item.i === 'hero' ? heroMode : undefined"
+            :ticker="item.i === 'company-news' ? activeTicker : undefined"
+            :article-count="item.i === 'company-news' ? newsArticleCount : undefined"
             :branding-mode="brandingMode"
             :active-branding-url="activeBrandingUrl"
             :flame-icon="flameIcon"
             @toggle-branding="toggleBranding"
+            @update-article-count="item.i === 'company-news' ? onNewsArticleCountChange($event) : undefined"
+            @remove="item.i === 'company-news' ? removeCard('company-news') : undefined"
             class="eqv4-card-component"
           />
         </GridItem>
@@ -135,7 +140,8 @@ import EQV4PrevCard    from './EQV4PrevCard.vue'
 import EQV4VolumeCard  from './EQV4VolumeCard.vue'
 import EQV4SessionCard from './EQV4SessionCard.vue'
 import EQV4ShortCard   from './EQV4ShortCard.vue'
-import EQV4CompanyCard from './EQV4CompanyCard.vue'
+import EQV4CompanyCard     from './EQV4CompanyCard.vue'
+import EQV4CompanyNewsCard from './EQV4CompanyNewsCard.vue'
 import EQV4CardPicker  from './EQV4CardPicker.vue'
 
 // ── Card registry ────────────────────────────────────────────────────────────
@@ -146,7 +152,8 @@ const CARD_REGISTRY = [
   { id: 'volume',  label: 'Volume',         component: EQV4VolumeCard,  defaultW: 2, defaultH: 2 },
   { id: 'session', label: 'Session H/L',    component: EQV4SessionCard, defaultW: 3, defaultH: 3 },
   { id: 'short',   label: 'Short Interest', component: EQV4ShortCard,   defaultW: 3, defaultH: 2 },
-  { id: 'company', label: 'Company',        component: EQV4CompanyCard, defaultW: 3, defaultH: 3 },
+  { id: 'company',      label: 'Company',        component: EQV4CompanyCard,     defaultW: 3, defaultH: 3 },
+  { id: 'company-news', label: 'Company News',   component: EQV4CompanyNewsCard, defaultW: 6, defaultH: 4 },
 ]
 
 const CARD_MAP = Object.fromEntries(CARD_REGISTRY.map(c => [c.id, c]))
@@ -183,6 +190,7 @@ const gridRowHeight = computed(() => props.settings?.gridRowHeight ?? 40)
 const chipCardIds = computed(() => new Set(props.settings?.chipCards ?? []))
 const brandingMode = computed(() => props.settings?.brandingMode ?? 'logo')
 const heroMode = computed(() => props.settings?.heroMode ?? 'wide')
+const newsArticleCount = computed(() => props.settings?.newsArticleCount ?? 20)
 
 // Cards that support chip render mode (company card does not)
 const CHIPS_CAPABLE = new Set(['today', 'prev', 'volume', 'session', 'short'])
@@ -198,6 +206,10 @@ const toggleCardChips = (cardId) => {
 const toggleHeroMode = () => {
   const next = heroMode.value === 'wide' ? 'narrow' : 'wide'
   emit('update-settings', { ...props.settings, heroMode: next })
+}
+
+const onNewsArticleCountChange = (count) => {
+  emit('update-settings', { ...props.settings, newsArticleCount: count })
 }
 
 const settingsCards = computed(() => {
@@ -541,6 +553,7 @@ defineExpose({
   gridRowHeight,
   chipCardIds,
   heroMode,
+  newsArticleCount,
   addCard,
   removeCard,
   toggleCardChips,

--- a/client/src/components/widgets/__tests__/EQV4CompanyNewsCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV4CompanyNewsCard.spec.js
@@ -1,0 +1,502 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+// ── Stubs ─────────────────────────────────────────────────────────────────────
+
+vi.mock('vue-virtual-scroller', () => ({
+  RecycleScroller: {
+    name: 'RecycleScroller',
+    props: ['items', 'itemSize', 'keyField'],
+    template: '<div class="mock-scroller"><div v-for="item in items" :key="item[keyField]"><slot :item="item" /></div></div>',
+  },
+}))
+
+vi.mock('@/composables/useConfig.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useConfig: () => ({
+      config: ref({ finlightApiKey: 'test-finlight-key', massiveApiKey: 'k', apiKey: 's' }),
+      loading: ref(false),
+      error: ref(null),
+      fetchConfig: vi.fn(),
+      isAuthenticated: () => true,
+    }),
+  }
+})
+
+// Finlight API mock helpers
+const SAMPLE_ARTICLES = [
+  {
+    link: 'https://example.com/1',
+    source: 'www.reuters.com',
+    title: 'Apple beats earnings estimates',
+    summary: 'Apple reported strong Q2 results.',
+    publishDate: '2026-04-16T12:00:00Z',
+    sentiment: 'positive',
+    confidence: 0.95,
+    companies: [
+      { ticker: 'AAPL', name: 'Apple Inc.', companyId: 1, primaryListing: { exchangeCode: 'XNAS', exchangeCountry: 'US' } },
+    ],
+  },
+  {
+    link: 'https://example.com/2',
+    source: 'www.seekingalpha.com',
+    title: 'AAPL price target cut by analyst',
+    summary: 'Morgan Stanley cuts AAPL target.',
+    publishDate: '2026-04-16T10:00:00Z',
+    sentiment: 'negative',
+    confidence: 0.88,
+    companies: [
+      { ticker: 'AAPL', name: 'Apple Inc.', companyId: 1, primaryListing: { exchangeCode: 'XNAS', exchangeCountry: 'US' } },
+    ],
+  },
+  {
+    link: 'https://example.com/3',
+    source: 'www.bloomberg.com',
+    title: 'Tech sector outlook positive',
+    summary: 'Broad tech rally expected.',
+    publishDate: '2026-04-16T08:00:00Z',
+    sentiment: 'positive',
+    confidence: 0.75,
+    companies: [],
+  },
+]
+
+function mockFinlightSuccess(articles = SAMPLE_ARTICLES) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status: 'ok', page: 1, pageSize: articles.length, articles }),
+  })
+}
+
+function mockFinlightError(status = 500) {
+  global.fetch = vi.fn().mockResolvedValue({ ok: false, status, json: async () => ({}) })
+}
+
+function mockFinlightNetworkError() {
+  global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ articles: [] }) })
+})
+
+import EQV4CompanyNewsCard from '../EQV4CompanyNewsCard.vue'
+
+function mountCard(props = {}) {
+  return mount(EQV4CompanyNewsCard, {
+    props: {
+      ticker: null,
+      articleCount: 20,
+      isLocked: true,
+      ...props,
+    },
+  })
+}
+
+// ── Empty / no-ticker state ───────────────────────────────────────────────────
+
+describe('Empty state', () => {
+  test('with no ticker expect no-ticker message shown', () => {
+    // Arrange / Act
+    const wrapper = mountCard({ ticker: null })
+
+    // Assert
+    expect(wrapper.text()).toContain('Enter a ticker to load news')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ── Fetch on ticker change ────────────────────────────────────────────────────
+
+describe('Fetch triggers', () => {
+  test('with ticker set expect fetch called with correct query', async () => {
+    // Arrange
+    mockFinlightSuccess()
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.finlight.me/v2/articles',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"query":"ticker:AAPL"'),
+      })
+    )
+  })
+
+  test('with ticker set expect pageSize sent in request body', async () => {
+    // Arrange
+    mockFinlightSuccess()
+
+    // Act
+    const wrapper = mountCard({ ticker: 'TSLA', articleCount: 50 })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    const callBody = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(callBody.pageSize).toBe(50)
+  })
+
+  test('with articleCount changed expect fetch called again', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL', articleCount: 20 })
+    await nextTick()
+    await nextTick()
+    const firstCallCount = global.fetch.mock.calls.length
+
+    // Act
+    await wrapper.setProps({ articleCount: 50 })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.length).toBeGreaterThan(firstCallCount)
+  })
+
+  test('with null finlightApiKey expect error state shown without fetch', async () => {
+    // Arrange — override config mock to have no key
+    vi.doMock('@/composables/useConfig.js', async () => {
+      const { ref } = await import('vue')
+      return { useConfig: () => ({ config: ref({ finlightApiKey: null }), loading: ref(false), error: ref(null), fetchConfig: vi.fn(), isAuthenticated: () => false }) }
+    })
+
+    // Use the exposed fetchNews directly on a mounted card
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    // Manually clear key from config via exposed ref — simulate missing key
+    // We test the guard via the exposed fetchNews function
+    wrapper.vm.articles  // just access to ensure mounted
+    // Simulate the guard by calling fetchNews with config null
+    // The actual mock has a key; test the guard branch via a direct call after clearing
+    // This is covered by the integration — the guard fires if finlightApiKey is falsy
+    expect(global.fetch).toBeDefined() // fetch is available; guard tested via articles count
+  })
+})
+
+// ── Articles rendered ─────────────────────────────────────────────────────────
+
+describe('Articles rendered', () => {
+  test('with successful fetch expect articles in scroller', async () => {
+    // Arrange
+    mockFinlightSuccess()
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.mock-scroller').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Apple beats earnings estimates')
+    expect(wrapper.text()).toContain('AAPL price target cut by analyst')
+  })
+
+  test('with successful fetch expect exposed articles populated', async () => {
+    // Arrange
+    mockFinlightSuccess()
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.vm.articles.length).toBe(3)
+  })
+
+  test('with empty results expect no-news message shown', async () => {
+    // Arrange
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ articles: [] }) })
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.text()).toContain('No news found for AAPL')
+  })
+})
+
+// ── Error states ──────────────────────────────────────────────────────────────
+
+describe('Error states', () => {
+  test('with HTTP error expect error message shown', async () => {
+    // Arrange
+    mockFinlightError(500)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.text()).toContain('HTTP 500')
+    expect(wrapper.find('.eqv4-news-error').exists()).toBe(true)
+  })
+
+  test('with network error expect error message shown', async () => {
+    // Arrange
+    mockFinlightNetworkError()
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.eqv4-news-error').exists()).toBe(true)
+    expect(wrapper.vm.error).toBeTruthy()
+  })
+
+  test('with error shown expect retry button calls fetchNews', async () => {
+    // Arrange
+    mockFinlightError(500)
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Act — switch to success then click retry
+    mockFinlightSuccess()
+    await wrapper.find('.eqv4-retry-btn').trigger('click')
+    await nextTick()
+    await nextTick()
+
+    // Assert — articles now populated
+    expect(wrapper.vm.articles.length).toBe(3)
+  })
+})
+
+// ── Search filter ─────────────────────────────────────────────────────────────
+
+describe('Search filter', () => {
+  test('with search query expect only matching articles shown', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    await wrapper.find('.eqv4-news-search').setValue('earnings')
+    await nextTick()
+
+    // Assert — only "Apple beats earnings estimates" matches
+    expect(wrapper.vm.filteredArticles.length).toBe(1)
+    expect(wrapper.text()).toContain('Apple beats earnings estimates')
+    expect(wrapper.text()).not.toContain('price target cut')
+  })
+
+  test('with search cleared expect all articles shown', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+    await wrapper.find('.eqv4-news-search').setValue('earnings')
+    await nextTick()
+
+    // Act
+    await wrapper.find('.eqv4-news-search').setValue('')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.vm.filteredArticles.length).toBe(3)
+  })
+})
+
+// ── Sort ──────────────────────────────────────────────────────────────────────
+
+describe('Sort', () => {
+  test('with default sort expect articles ordered newest first', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert — default time desc; first article should be 12:00 (newest)
+    const first = wrapper.vm.filteredArticles[0]
+    expect(first.title).toBe('Apple beats earnings estimates')
+  })
+
+  test('with time sort clicked twice expect oldest first', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Act — click time header twice (desc → asc)
+    const timeHeader = wrapper.find('.eqv4-nth-time')
+    await timeHeader.trigger('click') // first click: already desc → asc
+    await nextTick()
+
+    // Assert — oldest first (08:00 article)
+    const first = wrapper.vm.filteredArticles[0]
+    expect(first.title).toBe('Tech sector outlook positive')
+  })
+
+  test('with headline sort expect articles ordered alphabetically', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Act — click headline header (default asc for non-time columns)
+    await wrapper.find('.eqv4-nth-headline').trigger('click')
+    await nextTick()
+
+    // Assert — 'AAPL price target cut...' comes before 'Apple beats...' alphabetically
+    const first = wrapper.vm.filteredArticles[0]
+    expect(first.title).toContain('AAPL price target cut')
+  })
+
+  test('with headline sort clicked twice expect descending order', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const headlineHeader = wrapper.find('.eqv4-nth-headline')
+    await headlineHeader.trigger('click')
+    await headlineHeader.trigger('click')
+    await nextTick()
+
+    // Assert — 'Tech sector...' > 'Apple beats...' desc
+    const first = wrapper.vm.filteredArticles[0]
+    expect(first.title).toContain('Tech sector outlook positive')
+  })
+})
+
+// ── Article count ─────────────────────────────────────────────────────────────
+
+describe('Article count selector', () => {
+  test('with article count changed expect update-article-count emitted', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const calls = []
+    const wrapper = mountCard(
+      { ticker: 'AAPL', articleCount: 20 },
+    )
+    // VTU 2.4.x: capture emitted via attrs
+    // Re-mount with event capture
+    const wrapper2 = mount(EQV4CompanyNewsCard, {
+      props: { ticker: 'AAPL', articleCount: 20, isLocked: true },
+      attrs: { onUpdateArticleCount: (n) => calls.push(n) },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const select = wrapper2.find('.eqv4-news-count-select')
+    await select.setValue('50')
+    await select.trigger('change')
+    await nextTick()
+
+    // Assert
+    expect(calls).toContain(50)
+  })
+})
+
+// ── Remove button ─────────────────────────────────────────────────────────────
+
+describe('Remove button', () => {
+  test('with isLocked false expect remove button visible', () => {
+    // Arrange / Act
+    const wrapper = mountCard({ isLocked: false })
+
+    // Assert
+    expect(wrapper.find('.eqv4-news-remove').exists()).toBe(true)
+  })
+
+  test('with isLocked true expect remove button hidden', () => {
+    // Arrange / Act
+    const wrapper = mountCard({ isLocked: true })
+
+    // Assert
+    expect(wrapper.find('.eqv4-news-remove').exists()).toBe(false)
+  })
+
+  test('with remove button click expect remove event emitted', async () => {
+    // Arrange
+    const calls = []
+    const wrapper = mount(EQV4CompanyNewsCard, {
+      props: { ticker: null, articleCount: 20, isLocked: false },
+      attrs: { onRemove: () => calls.push(true) },
+    })
+
+    // Act
+    await wrapper.find('.eqv4-news-remove').trigger('click')
+
+    // Assert
+    expect(calls).toHaveLength(1)
+  })
+})
+
+// ── Refresh button ────────────────────────────────────────────────────────────
+
+describe('Refresh button', () => {
+  test('with refresh button click expect fetchNews called again', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+    const callsBefore = global.fetch.mock.calls.length
+
+    // Act
+    await wrapper.find('.eqv4-news-refresh').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.length).toBeGreaterThan(callsBefore)
+  })
+})
+
+// ── Detail modal ──────────────────────────────────────────────────────────────
+
+describe('Detail modal', () => {
+  test('with row click expect detail modal shown with article content', async () => {
+    // Arrange
+    mockFinlightSuccess()
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    await wrapper.find('.eqv4-news-row').trigger('click')
+    await nextTick()
+
+    // Assert — modal content (Teleport renders to body in jsdom)
+    expect(wrapper.vm.selected).not.toBeNull()
+    expect(wrapper.vm.selected.title).toBe('Apple beats earnings estimates')
+  })
+})
+
+// ── Exposed interface ─────────────────────────────────────────────────────────
+
+describe('Exposed interface', () => {
+  test('with card mounted expect required properties exposed', () => {
+    // Arrange / Act
+    const wrapper = mountCard()
+    const vm = wrapper.vm
+
+    // Assert
+    expect(vm.articles).toBeDefined()
+    expect(vm.loading).toBeDefined()
+    expect(vm.error).toBeDefined()
+    expect(typeof vm.fetchNews).toBe('function')
+  })
+})

--- a/client/src/components/widgets/__tests__/EQV4CompanyNewsCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV4CompanyNewsCard.spec.js
@@ -12,16 +12,19 @@ vi.mock('vue-virtual-scroller', () => ({
   },
 }))
 
+// Export _configRef so individual tests can mutate it (e.g. to simulate missing key)
 vi.mock('@/composables/useConfig.js', async () => {
   const { ref } = await import('vue')
+  const _configRef = ref({ finlightApiKey: 'test-finlight-key', massiveApiKey: 'k', apiKey: 's' })
   return {
-    useConfig: () => ({
-      config: ref({ finlightApiKey: 'test-finlight-key', massiveApiKey: 'k', apiKey: 's' }),
+    useConfig: vi.fn(() => ({
+      config: _configRef,
       loading: ref(false),
       error: ref(null),
       fetchConfig: vi.fn(),
       isAuthenticated: () => true,
-    }),
+    })),
+    _configRef,
   }
 })
 
@@ -162,22 +165,22 @@ describe('Fetch triggers', () => {
     expect(global.fetch.mock.calls.length).toBeGreaterThan(firstCallCount)
   })
 
-  test('with null finlightApiKey expect error state shown without fetch', async () => {
-    // Arrange — override config mock to have no key
-    vi.doMock('@/composables/useConfig.js', async () => {
-      const { ref } = await import('vue')
-      return { useConfig: () => ({ config: ref({ finlightApiKey: null }), loading: ref(false), error: ref(null), fetchConfig: vi.fn(), isAuthenticated: () => false }) }
-    })
+  test('with null finlightApiKey expect error shown and fetch not called', async () => {
+    // Arrange — mutate the shared config ref to remove the key
+    const { _configRef } = await import('@/composables/useConfig.js')
+    _configRef.value.finlightApiKey = null
 
-    // Use the exposed fetchNews directly on a mounted card
+    // Act
     const wrapper = mountCard({ ticker: 'AAPL' })
-    // Manually clear key from config via exposed ref — simulate missing key
-    // We test the guard via the exposed fetchNews function
-    wrapper.vm.articles  // just access to ensure mounted
-    // Simulate the guard by calling fetchNews with config null
-    // The actual mock has a key; test the guard branch via a direct call after clearing
-    // This is covered by the integration — the guard fires if finlightApiKey is falsy
-    expect(global.fetch).toBeDefined() // fetch is available; guard tested via articles count
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(wrapper.vm.error).toBe('Finlight API key not configured')
+
+    // Restore
+    _configRef.value.finlightApiKey = 'test-finlight-key'
   })
 })
 


### PR DESCRIPTION
## Summary

Adds `EQV4CompanyNewsCard` — a new card type in the EQv4 widget that fetches company news from the Finlight REST API.

refs #204

## Files Created
- `EQV4CompanyNewsCard.vue` — active card (intentional deviation from passive-card pattern; documented in design doc)
- `__tests__/EQV4CompanyNewsCard.spec.js` — 24 test cases

## Files Modified
- `EnhancedQuoteV4.vue` — registry entry, generic header suppressed for `company-news`, prop pass-through (`ticker`, `articleCount`), `newsArticleCount` settings handler, `@remove`/`@update-article-count` event handling

## Features
- Finlight REST API (`POST /v2/articles`, `ticker:{symbol}` query)
- Virtual scroller table: time, headline (sentiment dot), source, tickers columns
- Sortable by time (default: newest first) and headline
- Client-side search filter
- Article count selector [5, 10, 20, 50, 100] — card header, always visible
- Refresh button — card header, always visible
- Loading / empty / error states with retry
- Detail modal on row click
- Finlight API key null guard
- Card owns its full header (label + selector + refresh + X in edit mode)

## Test Results
211/211 passing (187 existing + 24 new)