### PR TITLE
fix(EQv4): use X-API-KEY header for Finlight auth

### DIFF
--- a/client/src/components/widgets/EQV4CompanyNewsCard.vue
+++ b/client/src/components/widgets/EQV4CompanyNewsCard.vue
@@ -186,7 +186,7 @@ const fetchNews = async () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${config.value.finlightApiKey}`,
+        'X-API-KEY': config.value.finlightApiKey,
       },
       body: JSON.stringify({
         query: `ticker:${props.ticker}`,

--- a/client/src/components/widgets/__tests__/EQV4CompanyNewsCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV4CompanyNewsCard.spec.js
@@ -115,7 +115,7 @@ describe('Empty state', () => {
 // ── Fetch on ticker change ────────────────────────────────────────────────────
 
 describe('Fetch triggers', () => {
-  test('with ticker set expect fetch called with correct query', async () => {
+  test('with ticker set expect fetch called with correct query and X-API-KEY header', async () => {
     // Arrange
     mockFinlightSuccess()
 
@@ -129,6 +129,7 @@ describe('Fetch triggers', () => {
       'https://api.finlight.me/v2/articles',
       expect.objectContaining({
         method: 'POST',
+        headers: expect.objectContaining({ 'X-API-KEY': 'test-finlight-key' }),
         body: expect.stringContaining('"query":"ticker:AAPL"'),
       })
     )


### PR DESCRIPTION
## Summary

Fixes HTTP 401 from Finlight API.

refs #204

## Root Cause

`Authorization: Bearer ${key}` is not the correct auth mechanism for Finlight. The API requires `X-API-KEY: ${key}`.

## Fix

```diff
- 'Authorization': `Bearer ${config.value.finlightApiKey}`,
+ 'X-API-KEY': config.value.finlightApiKey,
```

Test updated to assert the correct header is sent.

## Test Results
211/211 passing