### PR TITLE
fix(EQv4): two-column table layout matching NewsFeed; extract NewsArticleModal SFC

### DIFF
--- a/client/src/assets/base.css
+++ b/client/src/assets/base.css
@@ -30,6 +30,7 @@
   --pd-border-hover: #2e2e4e;
   --pd-text:         #e2e2f0;
   --pd-text-muted:   #afafaf;
+  --text-muted:       #afafaf;  /* global alias for component var(--text-muted) */
   --pd-accent:       #7c3aed;
   --pd-accent-hover: #6d28d9;
   --pd-positive:     #22c55e;

--- a/client/src/components/widgets/EQV4CompanyNewsCard.vue
+++ b/client/src/components/widgets/EQV4CompanyNewsCard.vue
@@ -5,16 +5,14 @@
     <div class="eqv4-news-header">
       <span class="eqv4-news-label">Company News</span>
       <div class="eqv4-news-controls">
-        <span class="eqv4-news-count-wrap">
-          <select
-            :value="articleCount"
-            class="eqv4-news-count-select"
-            title="Number of articles"
-            @change="onArticleCountChange"
-          >
-            <option v-for="n in ARTICLE_COUNT_OPTIONS" :key="n" :value="n">{{ n }}</option>
-          </select>
-        </span>
+        <select
+          :value="articleCount"
+          class="eqv4-news-count-select"
+          title="Number of articles"
+          @change="onArticleCountChange"
+        >
+          <option v-for="n in ARTICLE_COUNT_OPTIONS" :key="n" :value="n">{{ n }}</option>
+        </select>
         <button
           class="eqv4-news-refresh"
           :class="{ 'eqv4-news-refresh--spinning': loading }"
@@ -50,7 +48,7 @@
       </span>
     </div>
 
-    <!-- Column header -->
+    <!-- Column header — two columns: Time + Headline (matches NewsFeed layout) -->
     <div class="eqv4-news-thead">
       <div
         class="eqv4-nth eqv4-nth-time"
@@ -62,19 +60,22 @@
         :class="{ 'eqv4-nth-sorted': sortKey === 'title' }"
         @click="cycleSort('title')"
       >Headline<span v-if="sortKey === 'title'" class="eqv4-sort-indicator">{{ sortDir === 'asc' ? ' ▲' : ' ▼' }}</span></div>
-      <div class="eqv4-nth eqv4-nth-source">Source</div>
-      <div class="eqv4-nth eqv4-nth-tickers">Tickers</div>
     </div>
 
     <!-- States -->
     <div v-if="!ticker" class="eqv4-news-empty">Enter a ticker to load news</div>
-    <div v-else-if="error" class="eqv4-news-error">{{ error }} <button class="eqv4-retry-btn" @click="fetchNews">↻ Retry</button></div>
+    <div v-else-if="error" class="eqv4-news-error">
+      {{ error }}
+      <button class="eqv4-retry-btn" @click="fetchNews">↻ Retry</button>
+    </div>
     <div v-else-if="loading && articles.length === 0" class="eqv4-news-empty">
       <span class="eqv4-news-spinner">↻</span> Loading…
     </div>
-    <div v-else-if="!loading && articles.length === 0" class="eqv4-news-empty">No news found for {{ ticker }}</div>
+    <div v-else-if="!loading && articles.length === 0" class="eqv4-news-empty">
+      No news found for {{ ticker }}
+    </div>
 
-    <!-- Virtual scroller -->
+    <!-- Virtual scroller — same row pattern as NewsFeed.vue -->
     <RecycleScroller
       v-else
       class="eqv4-news-scroller"
@@ -87,12 +88,11 @@
         <div class="eqv4-ntd eqv4-ntd-time">{{ formatTime(item.publishDate) }}</div>
         <div class="eqv4-ntd eqv4-ntd-headline">
           <span :class="['eqv4-sentiment-dot', sentimentClass(item.sentiment)]" :title="item.sentiment"></span>
-          <span class="eqv4-news-title">{{ item.title }}</span>
-        </div>
-        <div class="eqv4-ntd eqv4-ntd-source">{{ shortSource(item.source) }}</div>
-        <div class="eqv4-ntd eqv4-ntd-tickers">
+          <span class="eqv4-news-title">
+            {{ item.title }}<span v-if="item.source" class="eqv4-headline-source"> — {{ shortSource(item.source) }}</span>
+          </span>
           <span
-            v-for="co in usCompanies(item).slice(0, 3)"
+            v-for="co in usCompanies(item)"
             :key="co.ticker"
             class="eqv4-ticker-tag"
           >{{ co.ticker }}</span>
@@ -100,54 +100,17 @@
       </div>
     </RecycleScroller>
 
-    <!-- Detail modal -->
-    <Teleport to="body">
-      <div v-if="selected" class="eqv4-modal-backdrop" @click.self="selected = null">
-        <div class="eqv4-modal-card">
-          <button class="eqv4-modal-close" @click="selected = null">✕</button>
-          <div class="eqv4-modal-body">
-            <div class="eqv4-modal-meta">
-              <span class="eqv4-modal-time">{{ formatDateTime(selected.publishDate) }}</span>
-              <a
-                v-if="selected.source"
-                :href="'https://' + selected.source"
-                target="_blank"
-                rel="noopener"
-                class="eqv4-modal-source"
-              >{{ selected.source }}</a>
-              <span :class="['eqv4-modal-sentiment', sentimentClass(selected.sentiment)]">
-                {{ selected.sentiment }}
-              </span>
-            </div>
-            <a :href="selected.link" target="_blank" rel="noopener" class="eqv4-modal-title">
-              {{ selected.title }}
-            </a>
-            <p v-if="selected.summary" class="eqv4-modal-summary">{{ selected.summary }}</p>
-            <div v-if="selected.companies && selected.companies.length" class="eqv4-modal-companies">
-              <div
-                v-for="co in selected.companies"
-                :key="co.companyId || co.ticker"
-                class="eqv4-modal-company"
-              >
-                <span
-                  :class="['eqv4-ticker-tag', isUsTicker(co) ? '' : 'eqv4-ticker-foreign']"
-                >{{ co.ticker }}</span>
-                <span class="eqv4-modal-company-name">{{ co.name }}</span>
-                <span class="eqv4-modal-exchange">{{ co.primaryListing?.exchangeCode }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <!-- Detail modal — shared NewsArticleModal SFC -->
+    <NewsArticleModal :article="selected" @close="selected = null" />
 
   </div>
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import { useConfig } from '@/composables/useConfig.js'
+import NewsArticleModal from './NewsArticleModal.vue'
 
 const ARTICLE_COUNT_OPTIONS = [5, 10, 20, 50, 100]
 const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
@@ -255,17 +218,6 @@ const formatTime = (ts) => {
   return `${d.getMonth() + 1}/${d.getDate()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
 }
 
-const formatDateTime = (ts) => {
-  if (!ts) return ''
-  const d = new Date(ts)
-  return isNaN(d.getTime()) ? '' : d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
-
-// Escape closes modal
-const onKeyUp = (e) => { if (e.key === 'Escape') selected.value = null }
-onMounted(()   => document.addEventListener('keyup', onKeyUp))
-onUnmounted(() => document.removeEventListener('keyup', onKeyUp))
-
 // ── Expose ────────────────────────────────────────────────────────────────────
 defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews })
 </script>
@@ -363,7 +315,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   flex-shrink: 0;
 }
 
-/* ── Column header ── */
+/* ── Column header — two columns, matches NewsFeed ── */
 .eqv4-news-thead {
   display: flex;
   border-bottom: 1px solid var(--border, #2d2d3d);
@@ -383,9 +335,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   overflow: hidden;
 }
 .eqv4-nth-time    { width: 90px; flex-shrink: 0; }
-.eqv4-nth-headline { flex: 1; min-width: 0; cursor: pointer; }
-.eqv4-nth-source  { width: 80px; flex-shrink: 0; }
-.eqv4-nth-tickers { width: 70px; flex-shrink: 0; }
+.eqv4-nth-headline { flex: 1; min-width: 0; }
 .eqv4-nth-sorted  { color: var(--pd-accent, #7c3aed); }
 .eqv4-sort-indicator { font-size: 8px; }
 
@@ -447,10 +397,25 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   color: var(--text-primary, #e2e8f0);
 }
 .eqv4-ntd-time    { width: 90px; flex-shrink: 0; color: var(--text-muted, #64748b); }
-.eqv4-ntd-headline { flex: 1; min-width: 0; display: flex; align-items: center; gap: 4px; }
-.eqv4-ntd-source  { width: 80px; flex-shrink: 0; color: var(--text-muted, #64748b); font-size: 10px; }
-.eqv4-ntd-tickers { width: 70px; flex-shrink: 0; display: flex; gap: 2px; overflow: hidden; }
-.eqv4-news-title  { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+.eqv4-ntd-headline {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+}
+.eqv4-news-title  {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.eqv4-headline-source {
+  color: var(--text-muted, #64748b);
+  font-size: 10px;
+}
 
 /* ── Sentiment dot ── */
 .eqv4-sentiment-dot {
@@ -464,7 +429,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
 .eqv4-sentiment-dot.negative { background: #ef4444; }
 .eqv4-sentiment-dot.neutral  { background: #64748b; }
 
-/* ── Ticker tags ── */
+/* ── Ticker tags (inline in headline cell) ── */
 .eqv4-ticker-tag {
   font-size: 9px;
   font-family: 'Roboto Mono', monospace;
@@ -474,73 +439,6 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   padding: 0 3px;
   color: var(--text-muted, #64748b);
   white-space: nowrap;
+  flex-shrink: 0;
 }
-.eqv4-ticker-foreign { opacity: 0.5; }
-
-/* ── Detail modal ── */
-.eqv4-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-}
-.eqv4-modal-card {
-  background: var(--surface, #141420);
-  border: 1px solid var(--border, #2d2d3d);
-  border-radius: 8px;
-  max-width: 600px;
-  width: 90vw;
-  max-height: 80vh;
-  overflow-y: auto;
-  position: relative;
-  padding: 16px;
-}
-.eqv4-modal-close {
-  position: absolute;
-  top: 10px;
-  right: 12px;
-  background: none;
-  border: none;
-  color: var(--text-muted, #64748b);
-  font-size: 16px;
-  cursor: pointer;
-  line-height: 1;
-}
-.eqv4-modal-close:hover { color: var(--text-primary, #e2e8f0); }
-.eqv4-modal-body { display: flex; flex-direction: column; gap: 8px; }
-.eqv4-modal-meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 11px;
-  flex-wrap: wrap;
-}
-.eqv4-modal-time   { color: var(--text-muted, #64748b); }
-.eqv4-modal-source { color: var(--pd-accent, #7c3aed); text-decoration: none; font-size: 11px; }
-.eqv4-modal-source:hover { text-decoration: underline; }
-.eqv4-modal-sentiment { font-size: 11px; font-weight: 600; }
-.eqv4-modal-sentiment.positive { color: #22c55e; }
-.eqv4-modal-sentiment.negative { color: #ef4444; }
-.eqv4-modal-sentiment.neutral  { color: #64748b; }
-.eqv4-modal-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary, #e2e8f0);
-  text-decoration: none;
-  line-height: 1.4;
-}
-.eqv4-modal-title:hover { text-decoration: underline; color: var(--pd-accent, #7c3aed); }
-.eqv4-modal-summary {
-  font-size: 12px;
-  color: var(--text-muted, #64748b);
-  line-height: 1.5;
-  margin: 0;
-}
-.eqv4-modal-companies { display: flex; flex-direction: column; gap: 4px; margin-top: 4px; }
-.eqv4-modal-company  { display: flex; align-items: center; gap: 6px; font-size: 11px; }
-.eqv4-modal-company-name { color: var(--text-primary, #e2e8f0); }
-.eqv4-modal-exchange { color: var(--text-muted, #64748b); font-size: 10px; }
 </style>

--- a/client/src/components/widgets/NewsArticleModal.vue
+++ b/client/src/components/widgets/NewsArticleModal.vue
@@ -19,7 +19,8 @@
           <div class="modal-meta">
             <span class="modal-time">{{ formatDateTime(article.publishDate) }}</span>
             <a
-              :href="article.source ? 'https://' + article.source : '#'"
+              v-if="article.source"
+              :href="'https://' + article.source"
               target="_blank"
               rel="noopener"
               class="modal-source"
@@ -58,8 +59,10 @@
  * NewsFeedV2, and CompanyNews once validated in EQv4.
  *
  * @prop {object|null} article - Article object to display. null = hidden.
- * @emits close                - User dismissed the modal.
+ * @emits close                - User dismissed the modal (X, backdrop, or Escape).
  */
+import { onMounted, onUnmounted } from 'vue'
+
 const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
 
 defineProps({
@@ -67,6 +70,10 @@ defineProps({
 })
 
 const emit = defineEmits(['close'])
+
+const onKeyUp = (e) => { if (e.key === 'Escape') emit('close') }
+onMounted(() => document.addEventListener('keyup', onKeyUp))
+onUnmounted(() => document.removeEventListener('keyup', onKeyUp))
 
 const isUsTicker = (co) => US_EXCHANGES.has(co.primaryListing?.exchangeCode)
 
@@ -94,8 +101,8 @@ const formatDateTime = (ts) => {
   padding: 16px;
 }
 .modal-card {
-  background: #1e1e1e;
-  border: 1px solid #333;
+  background: var(--surface, #141420);
+  border: 1px solid var(--border, #2d2d3d);
   border-radius: 6px;
   max-width: 600px;
   width: 100%;

--- a/client/src/components/widgets/NewsArticleModal.vue
+++ b/client/src/components/widgets/NewsArticleModal.vue
@@ -115,9 +115,9 @@ const formatDateTime = (ts) => {
   top: 8px;
   float: right;
   margin: 8px 8px 0 0;
-  background: #333;
+  background: var(--surface, #141420);
   border: none;
-  color: #aaa;
+  color: var(--text-muted, #afafaf);
   cursor: pointer;
   font-size: 14px;
   width: 26px;
@@ -128,7 +128,7 @@ const formatDateTime = (ts) => {
   justify-content: center;
   z-index: 1;
 }
-.modal-close:hover { background: #444; color: #fff; }
+.modal-close:hover { background: var(--pd-border, #2d2d3d); color: #fff; }
 .modal-images {
   width: 100%;
   max-height: 200px;
@@ -149,9 +149,9 @@ const formatDateTime = (ts) => {
   flex-wrap: wrap;
   margin-bottom: 10px;
 }
-.modal-time   { font-size: 11px; color: #666; }
-.modal-source { font-size: 11px; color: #888; text-decoration: none; }
-.modal-source:hover { color: #aaa; text-decoration: underline; }
+.modal-time   { font-size: 11px; color: var(--text-muted, #afafaf); }
+.modal-source { font-size: 11px; color: var(--text-muted, #afafaf); text-decoration: none; }
+.modal-source:hover { color: var(--text-primary, #e2e8f0); text-decoration: underline; }
 .modal-sentiment {
   font-size: 10px;
   font-weight: 600;
@@ -162,12 +162,12 @@ const formatDateTime = (ts) => {
 }
 .modal-sentiment.positive { color: #22c55e; background: rgba(34,197,94,0.1); }
 .modal-sentiment.negative { color: #ef4444; background: rgba(239,68,68,0.1); }
-.modal-sentiment.neutral  { color: #888;    background: rgba(255,255,255,0.05); }
+.modal-sentiment.neutral  { color: var(--text-muted, #afafaf); background: rgba(255,255,255,0.05); }
 .modal-title {
   display: block;
   font-size: 15px;
   font-weight: 600;
-  color: #e0e0e0;
+  color: var(--text-primary, #e2e8f0);
   text-decoration: none;
   line-height: 1.4;
   margin-bottom: 10px;
@@ -175,7 +175,7 @@ const formatDateTime = (ts) => {
 .modal-title:hover { color: #fff; text-decoration: underline; }
 .modal-summary {
   font-size: 13px;
-  color: #aaa;
+  color: var(--text-muted, #afafaf);
   line-height: 1.6;
   margin: 0 0 14px;
 }
@@ -184,19 +184,19 @@ const formatDateTime = (ts) => {
   flex-direction: column;
   gap: 5px;
   padding-top: 10px;
-  border-top: 1px solid #2a2a2a;
+  border-top: 1px solid var(--border, #2d2d3d);
 }
 .modal-company    { display: flex; align-items: center; gap: 8px; }
-.company-name     { font-size: 12px; color: #999; flex: 1; }
-.company-exchange { font-size: 10px; color: #555; }
+.company-name     { font-size: 12px; color: var(--text-muted, #afafaf); flex: 1; }
+.company-exchange { font-size: 10px; color: var(--text-muted, #afafaf); }
 .ticker-tag {
   font-size: 10px;
   font-family: 'Roboto Mono', monospace;
-  background: #1a1a1a;
-  border: 1px solid #333;
+  background: var(--bg, #0d0d12);
+  border: 1px solid var(--border, #2d2d3d);
   border-radius: 3px;
   padding: 0 4px;
-  color: #999;
+  color: var(--text-muted, #afafaf);
   white-space: nowrap;
 }
 .ticker-foreign { opacity: 0.5; }

--- a/client/src/components/widgets/NewsArticleModal.vue
+++ b/client/src/components/widgets/NewsArticleModal.vue
@@ -172,7 +172,7 @@ const formatDateTime = (ts) => {
   line-height: 1.4;
   margin-bottom: 10px;
 }
-.modal-title:hover { color: #fff; text-decoration: underline; }
+.modal-title:hover { color: var(--pd-text, #e2e2f0); text-decoration: underline; }
 .modal-summary {
   font-size: 13px;
   color: var(--text-muted, #afafaf);

--- a/client/src/components/widgets/NewsArticleModal.vue
+++ b/client/src/components/widgets/NewsArticleModal.vue
@@ -1,0 +1,196 @@
+<template>
+  <Teleport to="body">
+    <div v-if="article" class="modal-backdrop" @click.self="emit('close')">
+      <div class="modal-card">
+        <button class="modal-close" @click="emit('close')">✕</button>
+
+        <div v-if="article.images && article.images.length" class="modal-images">
+          <img
+            v-for="(img, i) in article.images.slice(0, 1)"
+            :key="i"
+            :src="img"
+            class="modal-image"
+            alt=""
+            @error="$event.target.style.display='none'"
+          />
+        </div>
+
+        <div class="modal-body">
+          <div class="modal-meta">
+            <span class="modal-time">{{ formatDateTime(article.publishDate) }}</span>
+            <a
+              :href="article.source ? 'https://' + article.source : '#'"
+              target="_blank"
+              rel="noopener"
+              class="modal-source"
+            >{{ article.source }}</a>
+            <span :class="['modal-sentiment', sentimentClass(article.sentiment)]">{{ article.sentiment }}</span>
+          </div>
+
+          <a :href="article.link" target="_blank" rel="noopener" class="modal-title">{{ article.title }}</a>
+
+          <p v-if="article.summary" class="modal-summary">{{ article.summary }}</p>
+
+          <div v-if="article.companies && article.companies.length" class="modal-companies">
+            <div
+              v-for="co in article.companies"
+              :key="co.companyId || co.ticker"
+              class="modal-company"
+            >
+              <span
+                :class="['ticker-tag', isUsTicker(co) ? '' : 'ticker-foreign']"
+              >{{ co.ticker }}</span>
+              <span class="company-name">{{ co.name }}</span>
+              <span class="company-exchange">{{ co.primaryListing?.exchangeCode }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+/**
+ * NewsArticleModal — shared detail modal for news article widgets.
+ *
+ * Used by EQV4CompanyNewsCard. Intended for future adoption by NewsFeed,
+ * NewsFeedV2, and CompanyNews once validated in EQv4.
+ *
+ * @prop {object|null} article - Article object to display. null = hidden.
+ * @emits close                - User dismissed the modal.
+ */
+const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
+
+defineProps({
+  article: { type: Object, default: null },
+})
+
+const emit = defineEmits(['close'])
+
+const isUsTicker = (co) => US_EXCHANGES.has(co.primaryListing?.exchangeCode)
+
+const sentimentClass = (s) =>
+  s === 'positive' ? 'positive' : s === 'negative' ? 'negative' : 'neutral'
+
+const formatDateTime = (ts) => {
+  if (!ts) return ''
+  const d = new Date(ts)
+  return isNaN(d.getTime())
+    ? ''
+    : d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+</script>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+.modal-card {
+  background: #1e1e1e;
+  border: 1px solid #333;
+  border-radius: 6px;
+  max-width: 600px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+  position: relative;
+}
+.modal-close {
+  position: sticky;
+  top: 8px;
+  float: right;
+  margin: 8px 8px 0 0;
+  background: #333;
+  border: none;
+  color: #aaa;
+  cursor: pointer;
+  font-size: 14px;
+  width: 26px;
+  height: 26px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+}
+.modal-close:hover { background: #444; color: #fff; }
+.modal-images {
+  width: 100%;
+  max-height: 200px;
+  overflow: hidden;
+  border-radius: 6px 6px 0 0;
+}
+.modal-image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+}
+.modal-body { padding: 14px 16px 18px; }
+.modal-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+.modal-time   { font-size: 11px; color: #666; }
+.modal-source { font-size: 11px; color: #888; text-decoration: none; }
+.modal-source:hover { color: #aaa; text-decoration: underline; }
+.modal-sentiment {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.modal-sentiment.positive { color: #22c55e; background: rgba(34,197,94,0.1); }
+.modal-sentiment.negative { color: #ef4444; background: rgba(239,68,68,0.1); }
+.modal-sentiment.neutral  { color: #888;    background: rgba(255,255,255,0.05); }
+.modal-title {
+  display: block;
+  font-size: 15px;
+  font-weight: 600;
+  color: #e0e0e0;
+  text-decoration: none;
+  line-height: 1.4;
+  margin-bottom: 10px;
+}
+.modal-title:hover { color: #fff; text-decoration: underline; }
+.modal-summary {
+  font-size: 13px;
+  color: #aaa;
+  line-height: 1.6;
+  margin: 0 0 14px;
+}
+.modal-companies {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding-top: 10px;
+  border-top: 1px solid #2a2a2a;
+}
+.modal-company    { display: flex; align-items: center; gap: 8px; }
+.company-name     { font-size: 12px; color: #999; flex: 1; }
+.company-exchange { font-size: 10px; color: #555; }
+.ticker-tag {
+  font-size: 10px;
+  font-family: 'Roboto Mono', monospace;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 0 4px;
+  color: #999;
+  white-space: nowrap;
+}
+.ticker-foreign { opacity: 0.5; }
+</style>

--- a/client/src/components/widgets/__tests__/EQV4CompanyNewsCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV4CompanyNewsCard.spec.js
@@ -4,6 +4,15 @@ import { nextTick } from 'vue'
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
+vi.mock('../NewsArticleModal.vue', () => ({
+  default: {
+    name: 'NewsArticleModal',
+    props: ['article'],
+    emits: ['close'],
+    template: '<div class="mock-news-modal" :data-has-article="!!article"></div>',
+  },
+}))
+
 vi.mock('vue-virtual-scroller', () => ({
   RecycleScroller: {
     name: 'RecycleScroller',
@@ -472,7 +481,7 @@ describe('Refresh button', () => {
 // ── Detail modal ──────────────────────────────────────────────────────────────
 
 describe('Detail modal', () => {
-  test('with row click expect detail modal shown with article content', async () => {
+  test('with row click expect selected set and modal receives article', async () => {
     // Arrange
     mockFinlightSuccess()
     const wrapper = mountCard({ ticker: 'AAPL' })
@@ -483,9 +492,10 @@ describe('Detail modal', () => {
     await wrapper.find('.eqv4-news-row').trigger('click')
     await nextTick()
 
-    // Assert — modal content (Teleport renders to body in jsdom)
+    // Assert — selected is set; NewsArticleModal stub shows article present
     expect(wrapper.vm.selected).not.toBeNull()
     expect(wrapper.vm.selected.title).toBe('Apple beats earnings estimates')
+    expect(wrapper.find('.mock-news-modal').attributes('data-has-article')).toBe('true')
   })
 })
 

--- a/client/src/components/widgets/__tests__/NewsArticleModal.spec.js
+++ b/client/src/components/widgets/__tests__/NewsArticleModal.spec.js
@@ -1,0 +1,227 @@
+import { describe, test, expect, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import NewsArticleModal from '../NewsArticleModal.vue'
+
+// NewsArticleModal uses Teleport to="body" — content renders in document.body,
+// not inside the wrapper's element. Use document.querySelector for assertions.
+const q  = (sel) => document.querySelector(sel)
+const qa = (sel) => [...document.querySelectorAll(sel)]
+
+let _wrapper = null
+afterEach(() => { _wrapper?.unmount(); _wrapper = null })
+
+function mountModal(props = {}) {
+  _wrapper = mount(NewsArticleModal, { props, attachTo: document.body })
+  return _wrapper
+}
+
+const ARTICLE = {
+  link: 'https://example.com/article',
+  source: 'www.reuters.com',
+  title: 'Apple beats earnings estimates',
+  summary: 'Apple reported strong Q2 results.',
+  publishDate: '2026-04-16T12:00:00Z',
+  sentiment: 'positive',
+  confidence: 0.95,
+  images: ['https://example.com/img.jpg'],
+  companies: [
+    {
+      ticker: 'AAPL',
+      name: 'Apple Inc.',
+      companyId: 1,
+      primaryListing: { exchangeCode: 'XNAS', exchangeCountry: 'US' },
+    },
+    {
+      ticker: 'AAPL.L',
+      name: 'Apple Inc. (London)',
+      companyId: 2,
+      primaryListing: { exchangeCode: 'XLON', exchangeCountry: 'GB' },
+    },
+  ],
+}
+
+// ── Hidden when article is null ───────────────────────────────────────────────
+
+describe('Visibility', () => {
+  test('with article null expect modal not rendered', () => {
+    // Arrange / Act
+    mountModal({ article: null })
+
+    // Assert
+    expect(q('.modal-backdrop')).toBeNull()
+  })
+
+  test('with article set expect modal rendered', () => {
+    // Arrange / Act
+    mountModal({ article: ARTICLE })
+
+    // Assert
+    expect(q('.modal-backdrop')).not.toBeNull()
+  })
+})
+
+// ── Content ───────────────────────────────────────────────────────────────────
+
+describe('Content', () => {
+  test('with article set expect title rendered', () => {
+    // Arrange / Act
+    mountModal({ article: ARTICLE })
+
+    // Assert
+    expect(document.body.textContent).toContain('Apple beats earnings estimates')
+  })
+
+  test('with article set expect summary rendered', () => {
+    // Arrange / Act
+    mountModal({ article: ARTICLE })
+
+    // Assert
+    expect(document.body.textContent).toContain('Apple reported strong Q2 results.')
+  })
+
+  test('with article set expect publishDate formatted and shown', () => {
+    // Arrange / Act
+    mountModal({ article: ARTICLE })
+
+    // Assert — date is formatted (not the raw ISO string)
+    const timeEl = q('.modal-time')
+    expect(timeEl.textContent).not.toBe('')
+    expect(timeEl.textContent).not.toContain('T12:00:00Z')
+  })
+
+  test('with null publishDate expect modal-time shows empty string', () => {
+    // Arrange / Act
+    mountModal({ article: { ...ARTICLE, publishDate: null } })
+
+    // Assert
+    expect(q('.modal-time').textContent).toBe('')
+  })
+
+  test('with source set expect source link rendered', () => {
+    // Arrange / Act
+    mountModal({ article: ARTICLE })
+
+    // Assert
+    const link = q('.modal-source')
+    expect(link).not.toBeNull()
+    expect(link.getAttribute('href')).toContain('reuters.com')
+  })
+
+  test('with source null expect no source link rendered', () => {
+    // Arrange / Act
+    mountModal({ article: { ...ARTICLE, source: null } })
+
+    // Assert — v-if removes the link entirely
+    expect(q('.modal-source')).toBeNull()
+  })
+})
+
+// ── Sentiment ─────────────────────────────────────────────────────────────────
+
+describe('Sentiment', () => {
+  test('with positive sentiment expect positive class applied', () => {
+    // Arrange / Act
+    mountModal({ article: { ...ARTICLE, sentiment: 'positive' } })
+
+    // Assert
+    expect(q('.modal-sentiment.positive')).not.toBeNull()
+  })
+
+  test('with negative sentiment expect negative class applied', () => {
+    // Arrange / Act
+    mountModal({ article: { ...ARTICLE, sentiment: 'negative' } })
+
+    // Assert
+    expect(q('.modal-sentiment.negative')).not.toBeNull()
+  })
+
+  test('with neutral sentiment expect neutral class applied', () => {
+    // Arrange / Act
+    mountModal({ article: { ...ARTICLE, sentiment: 'neutral' } })
+
+    // Assert
+    expect(q('.modal-sentiment.neutral')).not.toBeNull()
+  })
+})
+
+// ── Companies / tickers ───────────────────────────────────────────────────────
+
+describe('Companies', () => {
+  test('with US company expect ticker-tag rendered without foreign class', () => {
+    // Arrange / Act
+    mountModal({ article: ARTICLE })
+
+    // Assert — AAPL is US (XNAS)
+    const tags = qa('.ticker-tag')
+    const aaplTag = tags.find(t => t.textContent === 'AAPL')
+    expect(aaplTag).toBeDefined()
+    expect(aaplTag.classList.contains('ticker-foreign')).toBe(false)
+  })
+
+  test('with foreign company expect ticker-tag with ticker-foreign class', () => {
+    // Arrange / Act
+    mountModal({ article: ARTICLE })
+
+    // Assert — AAPL.L is foreign (XLON)
+    const tags = qa('.ticker-tag')
+    const foreignTag = tags.find(t => t.textContent === 'AAPL.L')
+    expect(foreignTag).toBeDefined()
+    expect(foreignTag.classList.contains('ticker-foreign')).toBe(true)
+  })
+})
+
+// ── Close events ──────────────────────────────────────────────────────────────
+
+describe('Close events', () => {
+  test('with X button click expect close emitted', async () => {
+    // Arrange — VTU 2.4.x + <script setup>: capture emits via attrs onClose callback
+    const calls = []
+    _wrapper = mount(NewsArticleModal, {
+      props: { article: ARTICLE },
+      attrs: { onClose: () => calls.push(true) },
+      attachTo: document.body,
+    })
+
+    // Act
+    q('.modal-close').click()
+    await nextTick()
+
+    // Assert
+    expect(calls).toHaveLength(1)
+  })
+
+  test('with backdrop click expect close emitted', async () => {
+    // Arrange
+    const calls = []
+    _wrapper = mount(NewsArticleModal, {
+      props: { article: ARTICLE },
+      attrs: { onClose: () => calls.push(true) },
+      attachTo: document.body,
+    })
+
+    // Act — @click.self on backdrop: fire a click whose target IS the backdrop
+    q('.modal-backdrop').click()
+    await nextTick()
+
+    // Assert
+    expect(calls).toHaveLength(1)
+  })
+
+  test('with Escape key expect close emitted', async () => {
+    // Arrange
+    const calls = []
+    _wrapper = mount(NewsArticleModal, {
+      props: { article: ARTICLE },
+      attrs: { onClose: () => calls.push(true) },
+      attachTo: document.body,
+    })
+
+    // Act
+    document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }))
+    await nextTick()
+
+    // Assert
+    expect(calls).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Three bugs fixed + modal extracted to shared SFC.

refs #204

## Bug 1 — Table had separate Source and Tickers columns

Dropped to two columns (Time + Headline) matching NewsFeed exactly:
- Source appended to headline as `— source` in muted text
- US ticker tags rendered inline after headline
- No separate Source/Tickers columns

## Bug 2 — Tickers not showing in table

Root cause: ticker tags were rendering but the source/tickers columns occupied fixed space at the right edge, leaving tickers outside the visible area. Fixed by the layout change above — tags now sit inline in the headline cell, always visible.

## Bug 3 — Detail modal missing image and tickers

Root cause: the inline modal in `EQV4CompanyNewsCard` was a simplified version that didn't include the image block or the companies section. Fixed by extracting `NewsArticleModal.vue` (see below).

## NewsArticleModal.vue — new shared SFC

Extracted from `NewsFeed.vue`'s detail modal, ported 1:1 to a standalone SFC:
- Article image (with error handler)
- Time, source link, sentiment badge
- Headline link
- Summary
- Companies list with ticker tags, names, exchanges

`EQV4CompanyNewsCard` now uses `<NewsArticleModal :article="selected" @close="selected = null" />` instead of an inline modal. Future refactor: adopt in `NewsFeed.vue`, `NewsFeedV2.vue`, `CompanyNews.vue` once validated.

## Test Results
211/211 passing