### PR TITLE
fix(EQv4): remove ticker tags from news card row (Finlight REST doesn't populate companies)

### DIFF
--- a/client/src/components/widgets/EQV4CompanyNewsCard.vue
+++ b/client/src/components/widgets/EQV4CompanyNewsCard.vue
@@ -91,11 +91,7 @@
           <span class="eqv4-news-title">
             {{ item.title }}<span v-if="item.source" class="eqv4-headline-source"> — {{ shortSource(item.source) }}</span>
           </span>
-          <span
-            v-for="co in usCompanies(item)"
-            :key="co.ticker"
-            class="eqv4-ticker-tag"
-          >{{ co.ticker }}</span>
+          <!-- Finlight REST API does not populate companies/tickers on ticker queries -->
         </div>
       </div>
     </RecycleScroller>
@@ -113,7 +109,6 @@ import { useConfig } from '@/composables/useConfig.js'
 import NewsArticleModal from './NewsArticleModal.vue'
 
 const ARTICLE_COUNT_OPTIONS = [5, 10, 20, 50, 100]
-const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
 
 const props = defineProps({
   ticker:       { type: String,  default: null },
@@ -206,8 +201,6 @@ const filteredArticles = computed(() => {
 })
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-const isUsTicker  = (co) => US_EXCHANGES.has(co.primaryListing?.exchangeCode)
-const usCompanies = (item) => (item.companies ?? []).filter(isUsTicker)
 const shortSource = (src) => src ? src.replace(/^www\./, '').replace(/\.[^.]+$/, '') : ''
 const sentimentClass = (s) => s === 'positive' ? 'positive' : s === 'negative' ? 'negative' : 'neutral'
 
@@ -429,16 +422,5 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
 .eqv4-sentiment-dot.negative { background: #ef4444; }
 .eqv4-sentiment-dot.neutral  { background: #64748b; }
 
-/* ── Ticker tags (inline in headline cell) ── */
-.eqv4-ticker-tag {
-  font-size: 9px;
-  font-family: 'Roboto Mono', monospace;
-  background: var(--surface, #141420);
-  border: 1px solid var(--border, #2d2d3d);
-  border-radius: 3px;
-  padding: 0 3px;
-  color: var(--text-muted, #64748b);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
+/* Ticker tags removed — Finlight REST API does not populate companies on ticker queries */
 </style>


### PR DESCRIPTION
## Summary

Finlight REST API (`POST /v2/articles` with `ticker:` query) does not populate the `companies` array in practice. Rendering empty ticker tags in the row is dead weight.

refs #204

## Changes

- Removed `US_EXCHANGES`, `isUsTicker`, `usCompanies` from `EQV4CompanyNewsCard.vue`
- Removed ticker tag `v-for` from the headline row template
- Removed `.eqv4-ticker-tag` CSS (only existed for the now-removed tags)
- Left a comment in both locations explaining why

`NewsArticleModal` still renders the companies section — it degrades gracefully when `companies` is empty/absent, and will correctly display tickers when used with WDS-based news widgets in the future.

## Test Results
227/227 passing