### PR TITLE
feat(WidgetMenu): rename widgets for clarity

### DIFF
--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -33,9 +33,9 @@ const availableWidgets = [
   { type: 'top-volume', label: 'Top Volume', icon: '📊' },
   { type: 'news-feed', label: 'News Feed', icon: '📰' },
   { type: 'company-news', label: 'Company News', icon: '🗞️' },
-  { type: 'quote', label: 'Quote', icon: '⚡' },
-  { type: 'enhanced-quote', label: 'Enhanced Quote', icon: '✨' },
-  { type: 'enhanced-quote-v4', label: 'Enhanced Quote V4', icon: '💎' },
+  { type: 'quote', label: 'Mini Quote', icon: '⚡' },
+  { type: 'enhanced-quote', label: 'Quote', icon: '✨' },
+  { type: 'enhanced-quote-v4', label: 'Enhanced Quote', icon: '💎' },
 ]
 
 const selectWidget = (widgetType) => {

--- a/client/src/components/__tests__/WidgetMenuAndWrapper.spec.js
+++ b/client/src/components/__tests__/WidgetMenuAndWrapper.spec.js
@@ -5,7 +5,7 @@ import { mount } from '@vue/test-utils'
 import WidgetMenu from '../WidgetMenu.vue'
 
 describe('WidgetMenu', () => {
-  test('with menu open expect enhanced-quote-v4 option present', async () => {
+  test('with menu open expect enhanced-quote option present', async () => {
     // Arrange
     const wrapper = mount(WidgetMenu)
 
@@ -13,10 +13,10 @@ describe('WidgetMenu', () => {
     await wrapper.find('.menu-toggle').trigger('click')
 
     // Assert
-    expect(wrapper.text()).toContain('Enhanced Quote V4')
+    expect(wrapper.text()).toContain('Enhanced Quote')
   })
 
-  test('with Enhanced Quote V4 clicked expect add-widget emitted with enhanced-quote-v4', async () => {
+  test('with Enhanced Quote clicked expect add-widget emitted with enhanced-quote-v4', async () => {
     // Arrange
     const calls = []
     const wrapper = mount(WidgetMenu, {
@@ -26,7 +26,7 @@ describe('WidgetMenu', () => {
     // Act
     await wrapper.find('.menu-toggle').trigger('click')
     const buttons = wrapper.findAll('.widget-button')
-    const v4btn = buttons.find(b => b.text().includes('Enhanced Quote V4'))
+    const v4btn = buttons.find(b => b.text().trim().endsWith('Enhanced Quote'))
     await v4btn.trigger('click')
 
     // Assert


### PR DESCRIPTION
## Summary

Cosmetic rename to make the three quote widgets meaningfully distinct in the menu.

| Before | After | Type |
|---|---|---|
| Quote | Mini Quote | Real-time feed, scanner data, no HOD/LOD, feature locked |
| Enhanced Quote | Quote | EQv3 — enhanced_quote feed with HOD/LOD via DRA, column-based layouts, feature locked |
| Enhanced Quote V4 | Enhanced Quote | EQv4 — same feed as Quote, grid-based layout, CompanyNews card, active roadmap |

## Changes
- `WidgetMenu.vue` — label strings only; `type` values and icons unchanged
- `WidgetMenuAndWrapper.spec.js` — updated test descriptions and label assertions to match new names

## Tests
237/237 passing.