### PR TITLE
fix(DashboardGrid): autosave on dashboardColNum change

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -499,6 +499,11 @@ watch(layout, () => {
   if (!isLocked.value) autoSaveLayout()
 }, { deep: true })
 
+// Watch dashboardColNum — autosave so col count is persisted without a manual save
+watch(dashboardColNum, () => {
+  if (!isLocked.value) autoSaveLayout()
+})
+
 // Import/Export
 const exportLayouts = () => {
   const exportData = {

--- a/client/src/components/__tests__/DashboardGridColNum.spec.js
+++ b/client/src/components/__tests__/DashboardGridColNum.spec.js
@@ -243,3 +243,87 @@ describe('addWidget with dashboardColNum', () => {
     wrapper.unmount()
   })
 })
+
+// ── Autosave on dashboardColNum change ──────────────────────────────────────────────────────
+
+describe('dashboardColNum autosave', () => {
+  test('with autosave enabled and colNum changed expect dashboardColNum written to storage', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    seedLayouts({
+      'my-layout': {
+        layout: [], widgetCounter: 0, dashboardColNum: 12,
+        created: Date.now(), modified: Date.now(), description: '',
+      }
+    }, 'my-layout')
+    const wrapper = mountGrid()
+    await nextTick()
+    await nextTick()
+
+    // Ensure edit mode and autosave on
+    await wrapper.find('button[title="Unlock layout (edit mode)"]').trigger('click')
+    await nextTick()
+    const autosaveBtn = wrapper.find('button[title="Autosave ON \u2014 click to disable"]')
+    if (!autosaveBtn.exists()) {
+      // autosave already off — enable it
+      await wrapper.find('button[title="Autosave OFF \u2014 click to enable"]').trigger('click')
+      await nextTick()
+    }
+
+    // Act — change column count
+    wrapper.vm.dashboardColNum = 24
+    await nextTick()
+    vi.runAllTimers()
+    await nextTick()
+
+    // Assert — storage contains updated dashboardColNum for the selected layout
+    const call = localStorageMock.setItem.mock.calls
+      .reverse()
+      .find(([k]) => k === 'dashboard-layouts')
+    expect(call).toBeDefined()
+    const saved = JSON.parse(call[1])
+    expect(saved['my-layout']?.dashboardColNum).toBe(24)
+
+    vi.useRealTimers()
+    wrapper.unmount()
+  })
+
+  test('with autosave disabled and colNum changed expect storage not updated', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    seedLayouts({
+      'my-layout': {
+        layout: [], widgetCounter: 0, dashboardColNum: 12,
+        created: Date.now(), modified: Date.now(), description: '',
+      }
+    }, 'my-layout')
+    const wrapper = mountGrid()
+    await nextTick()
+    await nextTick()
+
+    // Unlock, then disable autosave
+    await wrapper.find('button[title="Unlock layout (edit mode)"]').trigger('click')
+    await nextTick()
+    // Toggle autosave off (it's on by default)
+    const autosaveOnBtn = wrapper.find('button[title="Autosave ON \u2014 click to disable"]')
+    if (autosaveOnBtn.exists()) {
+      await autosaveOnBtn.trigger('click')
+      await nextTick()
+    }
+
+    localStorageMock.setItem.mockClear()
+
+    // Act
+    wrapper.vm.dashboardColNum = 24
+    await nextTick()
+    vi.runAllTimers()
+    await nextTick()
+
+    // Assert — no layout write triggered
+    const layoutWrite = localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-layouts')
+    expect(layoutWrite).toBeUndefined()
+
+    vi.useRealTimers()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Root Cause

`autoSaveLayout()` was only triggered by the `watch(layout, ...)` watcher. When `dashboardColNum` changed with no widgets on the grid (empty layout array), the layout array didn't change, so autosave never fired and the new column count was never persisted.

This also explains the layout mangling side effect: switching away from a layout and back caused `loadLayout()` to restore the stale `dashboardColNum` from storage, and vue-grid-layout re-evaluated widget positions against the wrong column count.

## Fix

Added a `watch(dashboardColNum, ...)` that mirrors the layout watcher — calls `autoSaveLayout()` when not locked. One line change to `DashboardGrid.vue`.

## Tests

Two new cases in `DashboardGridColNum.spec.js` using `vi.useFakeTimers()` to control the debounce:
- autosave enabled + colNum changed → storage written with new `dashboardColNum`
- autosave disabled + colNum changed → no storage write

239/239 passing.