### PR TITLE
fix(DashboardGrid): set dashboardColNum before layout in loadLayout

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -432,9 +432,11 @@ const loadLayout = () => {
   if (!name || !savedLayouts.value[name]) return
 
   const saved = savedLayouts.value[name]
+  // Set dashboardColNum BEFORE layout so the grid never renders widgets
+  // against the wrong column count during the reactive update cycle.
+  dashboardColNum.value = saved.dashboardColNum ?? 12
   layout.value = JSON.parse(JSON.stringify(saved.layout))
   widgetCounter = saved.widgetCounter || 0
-  dashboardColNum.value = saved.dashboardColNum ?? 12
 }
 
 const deleteCurrentLayout = () => {
@@ -464,9 +466,10 @@ const loadDefaultLayout = () => {
   // Fall back to autosave
   if (savedLayouts.value[AUTOSAVE_KEY]) {
     const saved = savedLayouts.value[AUTOSAVE_KEY]
+    // Set dashboardColNum BEFORE layout — same ordering rule as loadLayout()
+    dashboardColNum.value = saved.dashboardColNum ?? 12
     layout.value = JSON.parse(JSON.stringify(saved.layout))
     widgetCounter = saved.widgetCounter || 0
-    dashboardColNum.value = saved.dashboardColNum ?? 12
   }
 }
 
@@ -851,7 +854,7 @@ onBeforeUnmount(() => {
   if (hoverTimeout) clearTimeout(hoverTimeout)
 })
 
-defineExpose({ dashboardColNum, layout, addWidget, saveLayout, saveLayoutName })
+defineExpose({ dashboardColNum, layout, addWidget, saveLayout, saveLayoutName, loadLayout, selectedLayoutName })
 </script>
 
 <style scoped>

--- a/client/src/components/__tests__/DashboardGridColNum.spec.js
+++ b/client/src/components/__tests__/DashboardGridColNum.spec.js
@@ -327,3 +327,43 @@ describe('dashboardColNum autosave', () => {
     wrapper.unmount()
   })
 })
+
+// ── Layout switch col-count ordering (BUG-2 regression) ────────────────────────────────
+
+describe('dashboardColNum on layout switch', () => {
+  test('with switch from 12-col layout to 24-col layout expect grid renders col-num 24', async () => {
+    // Arrange — two layouts: source=12 cols, target=24 cols
+    // Target has widget positions valid at 24 cols (x=12 is out-of-bounds at 12 cols)
+    seedLayouts({
+      'source-layout': {
+        layout: [{ x: 0, y: 0, w: 6, h: 19, i: 'widget-0', type: 'quote' }],
+        widgetCounter: 1, dashboardColNum: 12,
+        created: Date.now(), modified: Date.now(), description: '',
+      },
+      'target-layout': {
+        layout: [{ x: 12, y: 0, w: 12, h: 19, i: 'widget-0', type: 'quote' }],
+        widgetCounter: 1, dashboardColNum: 24,
+        created: Date.now(), modified: Date.now(), description: '',
+      },
+    }, 'source-layout')
+
+    const wrapper = mountGrid()
+    await nextTick()
+    await nextTick()
+
+    // Confirm loaded on source layout at 12 cols
+    expect(wrapper.vm.dashboardColNum).toBe(12)
+
+    // Act — switch to 24-col layout (mirrors selectLayout() flow)
+    wrapper.vm.selectedLayoutName = 'target-layout'
+    wrapper.vm.loadLayout()
+    await nextTick()
+    await nextTick()
+
+    // Assert — col-num must be 24 (not mangled by intermediate 12-col render)
+    expect(wrapper.vm.dashboardColNum).toBe(24)
+    expect(wrapper.find('.mock-grid-layout').attributes('data-col-num')).toBe('24')
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Root Cause

In `loadLayout()` and `loadDefaultLayout()`, `layout.value` was assigned before `dashboardColNum.value`. Vue's reactive update cycle causes `<GridLayout>` to render the new layout immediately against the **old** (departing layout's) column count. `vue3-grid-layout-next` with `vertical-compact: true` then compacts widget positions to fit the wrong column count — mangling any widget whose `x` or `w` is valid in the destination column count but out-of-bounds in the source.

This is why switching from "EQv4" (12-col) to "EQv4 2" (24-col) works when the source is also 12-col: `dashboardColNum` doesn't change, so there's no intermediate wrong-column render. Switching from any other column count triggers the mangle.

## Fix

Swap the assignment order in both `loadLayout()` and the autosave fallback path in `loadDefaultLayout()`:

```js
// Before (buggy)
layout.value = JSON.parse(JSON.stringify(saved.layout))
dashboardColNum.value = saved.dashboardColNum ?? 12

// After (fixed)
dashboardColNum.value = saved.dashboardColNum ?? 12  // grid column count first
layout.value = JSON.parse(JSON.stringify(saved.layout))
```

Also exposes `loadLayout` and `selectedLayoutName` via `defineExpose` to enable direct testing of the load path.

## Tests

One new regression test in `DashboardGridColNum.spec.js`:
- Seeds two layouts: source (12-col, widget at x=0), target (24-col, widget at x=12 — valid only at 24 cols)
- Loads source layout, then switches to target via `selectedLayoutName` + `loadLayout()`
- Asserts `dashboardColNum` and `data-col-num` are both 24 after the switch

240/240 passing.

refs #209