### PR TITLE
fix(WidgetMenu): set friendly userLabel on widget creation

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -652,7 +652,7 @@ const drawLayoutPreview = (layoutData, colOverride) => {
     ctx.font = '12px monospace'
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
-    ctx.fillText(item.type || 'widget', x + w/2, y + h/2)
+    ctx.fillText(item.userLabel || item.type || 'widget', x + w/2, y + h/2)
   })
 }
 
@@ -764,7 +764,7 @@ const drawMiniPreview = (layoutData, colOverride) => {
     ctx.font = '10px monospace'
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
-    ctx.fillText(item.type || 'widget', x + w/2, y + h/2)
+    ctx.fillText(item.userLabel || item.type || 'widget', x + w/2, y + h/2)
   })
 }
 
@@ -777,7 +777,7 @@ const closeSaveDialog = () => {
 }
 
 // Widget Operations
-const addWidget = (widgetType) => {
+const addWidget = ({ type: widgetType, label: widgetLabel }) => {
   const perRow = 2  // always place 2 widgets side by side
   const w = Math.floor(dashboardColNum.value / perRow)
   const index = layout.value.length
@@ -788,7 +788,12 @@ const addWidget = (widgetType) => {
     w,
     h: 19,
     i: `widget-${widgetCounter++}`,
-    type: widgetType
+    type: widgetType,
+    // userLabel is set to the friendly menu label on creation so the widget header
+    // shows a human-readable name immediately. The user can rename from here.
+    // Widgets from saved layouts that predate this change will have no userLabel
+    // and fall back to the raw type string in WidgetWrapper — intentional.
+    userLabel: widgetLabel,
   })
 }
 

--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -11,7 +11,7 @@
       <button
           v-for="widget in availableWidgets"
           :key="widget.type"
-          @click="selectWidget(widget.type)"
+          @click="selectWidget(widget)"
           class="widget-button"
       >
         <span>{{ widget.icon }}</span>
@@ -38,8 +38,8 @@ const availableWidgets = [
   { type: 'enhanced-quote-v4', label: 'Enhanced Quote', icon: '💎' },
 ]
 
-const selectWidget = (widgetType) => {
-  emit('add-widget', widgetType)
+const selectWidget = (widget) => {
+  emit('add-widget', { type: widget.type, label: widget.label })
   isOpen.value = false
 }
 </script>

--- a/client/src/components/__tests__/DashboardGridColNum.spec.js
+++ b/client/src/components/__tests__/DashboardGridColNum.spec.js
@@ -219,7 +219,7 @@ describe('addWidget with dashboardColNum', () => {
     expect(wrapper.vm.dashboardColNum).toBe(12)
 
     // Act
-    wrapper.vm.addWidget('quote')
+    wrapper.vm.addWidget({ type: 'quote', label: 'Mini Quote' })
     await nextTick()
 
     // Assert
@@ -235,11 +235,73 @@ describe('addWidget with dashboardColNum', () => {
     await nextTick()
 
     // Act
-    wrapper.vm.addWidget('quote')
+    wrapper.vm.addWidget({ type: 'quote', label: 'Mini Quote' })
     await nextTick()
 
     // Assert
     expect(wrapper.vm.layout[0].w).toBe(12)
+    wrapper.unmount()
+  })
+})
+
+// ── addWidget sets userLabel ─────────────────────────────────────────────────────────────
+
+describe('addWidget userLabel', () => {
+  test('with quote widget added expect userLabel set to friendly label', async () => {
+    // Arrange
+    const wrapper = mountGrid()
+    await nextTick()
+
+    // Act
+    wrapper.vm.addWidget({ type: 'quote', label: 'Mini Quote' })
+    await nextTick()
+
+    // Assert
+    expect(wrapper.vm.layout[0].userLabel).toBe('Mini Quote')
+    wrapper.unmount()
+  })
+
+  test('with top-gainers widget added expect userLabel set to friendly label', async () => {
+    // Arrange
+    const wrapper = mountGrid()
+    await nextTick()
+
+    // Act
+    wrapper.vm.addWidget({ type: 'top-gainers', label: 'Top Gainers' })
+    await nextTick()
+
+    // Assert
+    expect(wrapper.vm.layout[0].userLabel).toBe('Top Gainers')
+    wrapper.unmount()
+  })
+
+  test('with enhanced-quote-v4 added expect userLabel set to Enhanced Quote', async () => {
+    // Arrange
+    const wrapper = mountGrid()
+    await nextTick()
+
+    // Act
+    wrapper.vm.addWidget({ type: 'enhanced-quote-v4', label: 'Enhanced Quote' })
+    await nextTick()
+
+    // Assert
+    expect(wrapper.vm.layout[0].userLabel).toBe('Enhanced Quote')
+    wrapper.unmount()
+  })
+})
+
+// ── defineExpose includes addWidget ───────────────────────────────────────────────
+
+describe('exposed interface', () => {
+  test('with DashboardGrid mounted expect addWidget exposed on vm', async () => {
+    // Arrange / Act
+    const wrapper = mountGrid()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.vm.addWidget).toBeDefined()
+    expect(wrapper.vm.layout).toBeDefined()
+    expect(wrapper.vm.dashboardColNum).toBeDefined()
     wrapper.unmount()
   })
 })

--- a/client/src/components/__tests__/WidgetMenuAndWrapper.spec.js
+++ b/client/src/components/__tests__/WidgetMenuAndWrapper.spec.js
@@ -20,7 +20,7 @@ describe('WidgetMenu', () => {
     // Arrange
     const calls = []
     const wrapper = mount(WidgetMenu, {
-      attrs: { onAddWidget: (t) => calls.push(t) },
+      attrs: { onAddWidget: (w) => calls.push(w) },
     })
 
     // Act
@@ -29,8 +29,39 @@ describe('WidgetMenu', () => {
     const v4btn = buttons.find(b => b.text().trim().endsWith('Enhanced Quote'))
     await v4btn.trigger('click')
 
+    // Assert — emits { type, label } object, no icon
+    expect(calls[0]).toMatchObject({ type: 'enhanced-quote-v4', label: 'Enhanced Quote' })
+    expect(calls[0]).not.toHaveProperty('icon')
+  })
+
+  test.each([
+    { type: 'top-gainers',       label: 'Top Gainers' },
+    { type: 'top-gappers',       label: 'Top Gappers' },
+    { type: 'top-volume',        label: 'Top Volume' },
+    { type: 'news-feed',         label: 'News Feed' },
+    { type: 'company-news',      label: 'Company News' },
+    { type: 'quote',             label: 'Mini Quote' },
+    { type: 'enhanced-quote',    label: 'Quote' },
+    { type: 'enhanced-quote-v4', label: 'Enhanced Quote' },
+  ])('with $label clicked expect add-widget emitted with { type: $type, label: $label }', async ({ type, label }) => {
+    // Arrange
+    const calls = []
+    const wrapper = mount(WidgetMenu, {
+      attrs: { onAddWidget: (w) => calls.push(w) },
+    })
+    await wrapper.find('.menu-toggle').trigger('click')
+    const buttons = wrapper.findAll('.widget-button')
+    // Button text is "<icon><label>" — strip leading non-letter chars to isolate label
+    const btn = buttons.find(b => b.text().trim().replace(/^\P{L}+/u, '') === label)
+    expect(btn, `button for "${label}" not found`).toBeTruthy()
+
+    // Act
+    await btn.trigger('click')
+
     // Assert
-    expect(calls).toContain('enhanced-quote-v4')
+    expect(calls[0]).toMatchObject({ type, label })
+    expect(calls[0]).not.toHaveProperty('icon')
+    wrapper.unmount()
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes the regression introduced in PR #212 where widget headers showed raw type strings instead of friendly labels after adding from the Widget Menu.

## Changes

**`WidgetMenu.vue`**
- `selectWidget` now emits `{ type, label }` instead of a plain type string
- Template passes the full `widget` object to `selectWidget`, not just `widget.type`
- No `icon` in the emitted payload — keeps the surface minimal

**`DashboardGrid.vue`**
- `addWidget` destructures `{ type, label }` and sets `userLabel: label` on the new layout item
- Code comment explains the intentional fallback: widgets from saved layouts that predate this change have no `userLabel` and continue to fall back to raw type string in `WidgetWrapper` — by design
- Both `drawLayoutPreview` and `drawMiniPreview` updated to use `item.userLabel || item.type || 'widget'`

**`WidgetMenuAndWrapper.spec.js`**
- Updated existing emit test to assert `{ type, label }` object payload
- Added per-widget emit coverage: all 8 widgets verified for correct `{ type, label }` and absence of `icon`

**`DashboardGridColNum.spec.js`**
- Updated two `addWidget` call sites from plain string to `{ type, label }` object
- Added `addWidget userLabel` describe block (3 tests): quote, top-gainers, enhanced-quote-v4
- Added `exposed interface` describe block asserting `addWidget`, `layout`, `dashboardColNum` on vm

## Tests

245/245 passing.

refs #217