### PR TITLE
feat(EQv4): add Stock Splits, SEC EDGAR, and Ticker Events cards

### DIFF
--- a/client/src/components/widgets/EQV4SecEdgarCard.vue
+++ b/client/src/components/widgets/EQV4SecEdgarCard.vue
@@ -1,0 +1,273 @@
+<template>
+  <div class="eqv4-edgar-card">
+
+    <!-- Card header: label + filing count selector + refresh + X (edit mode) -->
+    <div class="eqv4-edgar-header">
+      <span class="eqv4-edgar-label">SEC EDGAR</span>
+      <div class="eqv4-edgar-controls">
+        <select
+          :value="filingCount"
+          class="eqv4-edgar-count-select"
+          title="Number of filings"
+          @change="onFilingCountChange"
+        >
+          <option v-for="n in FILING_COUNT_OPTIONS" :key="n" :value="n">{{ n }}</option>
+        </select>
+        <button
+          class="eqv4-edgar-refresh"
+          :class="{ 'eqv4-edgar-refresh--spinning': loading }"
+          title="Refresh filings"
+          :disabled="loading"
+          @click="fetchFilings"
+        >↻</button>
+        <button
+          v-if="!isLocked"
+          class="eqv4-edgar-remove"
+          title="Remove card"
+          @click="emit('remove')"
+        >✕</button>
+      </div>
+    </div>
+
+    <!-- Column header -->
+    <div class="eqv4-edgar-thead">
+      <div class="eqv4-eth eqv4-eth-date">Date</div>
+      <div class="eqv4-eth eqv4-eth-form">Form Type</div>
+    </div>
+
+    <!-- States -->
+    <div v-if="!ticker" class="eqv4-edgar-empty">Enter a ticker to load filings</div>
+    <div v-else-if="error" class="eqv4-edgar-error">
+      {{ error }}
+      <button class="eqv4-retry-btn" @click="fetchFilings">↻ Retry</button>
+    </div>
+    <div v-else-if="loading && filings.length === 0" class="eqv4-edgar-empty">
+      <span class="eqv4-edgar-spinner">↻</span> Loading…
+    </div>
+    <div v-else-if="!loading && filings.length === 0 && ticker" class="eqv4-edgar-empty">
+      No filings found for {{ ticker }}
+    </div>
+
+    <!-- Data rows -->
+    <div v-else class="eqv4-edgar-body">
+      <div v-for="(f, i) in filings" :key="i" class="eqv4-edgar-row">
+        <div class="eqv4-etd eqv4-etd-date">{{ f.filing_date }}</div>
+        <div class="eqv4-etd eqv4-etd-form">
+          <a
+            :href="f.filing_url"
+            target="_blank"
+            rel="noopener"
+            class="eqv4-edgar-link"
+          >{{ f.form_type }}</a>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { useConfig } from '@/composables/useConfig.js'
+
+const FILING_COUNT_OPTIONS = [5, 10, 25, 50, 100]
+
+const props = defineProps({
+  ticker:       { type: String,  default: null },
+  isLocked:     { type: Boolean, default: true },
+  filingCount:  { type: Number,  default: 10 },
+})
+
+const emit = defineEmits(['update-filing-count', 'remove'])
+
+const { config } = useConfig()
+
+// ── State ─────────────────────────────────────────────────────────────────────
+const filings = ref([])
+const loading = ref(false)
+const error   = ref(null)
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+const fetchFilings = async () => {
+  if (!props.ticker) return
+  loading.value = true
+  error.value = null
+  filings.value = []
+  try {
+    const key = config.value?.massiveApiKey
+    const url = `https://api.massive.com/stocks/filings/vX/index?ticker=${props.ticker}&limit=${props.filingCount}&sort=filing_date.desc&apiKey=${key}`
+    const resp = await fetch(url)
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const json = await resp.json()
+    filings.value = json.results ?? []
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => props.ticker, (t) => { if (t) fetchFilings() }, { immediate: true })
+watch(() => props.filingCount, () => { if (props.ticker) fetchFilings() })
+
+// ── Controls ──────────────────────────────────────────────────────────────────
+const onFilingCountChange = (e) => {
+  emit('update-filing-count', parseInt(e.target.value, 10))
+}
+
+// ── Expose ────────────────────────────────────────────────────────────────────
+defineExpose({ filings, loading, error, fetchFilings })
+</script>
+
+<style scoped>
+.eqv4-edgar-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg, #0d0d12);
+  color: var(--text-primary, #e2e8f0);
+  font-family: system-ui, sans-serif;
+}
+
+/* ── Header ── */
+.eqv4-edgar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  background: var(--bg, #0d0d12);
+  flex-shrink: 0;
+}
+.eqv4-edgar-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.eqv4-edgar-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.eqv4-edgar-count-select {
+  background: var(--surface, #141420);
+  border: 1px solid var(--border, #2d2d3d);
+  border-radius: 3px;
+  color: var(--text-muted, #64748b);
+  font-size: 11px;
+  padding: 1px 3px;
+  cursor: pointer;
+}
+.eqv4-edgar-refresh {
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+.eqv4-edgar-refresh:hover { color: var(--pd-accent, #7c3aed); }
+.eqv4-edgar-refresh--spinning { animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.eqv4-edgar-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.eqv4-edgar-remove:hover { color: #ef4444; }
+
+/* ── Column header ── */
+.eqv4-edgar-thead {
+  display: flex;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  flex-shrink: 0;
+  background: var(--bg, #0d0d12);
+}
+.eqv4-eth {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 4px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.eqv4-eth-date { width: 90px; flex-shrink: 0; }
+.eqv4-eth-form { flex: 1; min-width: 0; }
+
+/* ── Empty / error states ── */
+.eqv4-edgar-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+  padding: 8px;
+  text-align: center;
+}
+.eqv4-edgar-error {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #ef4444;
+  padding: 8px;
+}
+.eqv4-retry-btn {
+  background: none;
+  border: 1px solid #ef4444;
+  border-radius: 3px;
+  color: #ef4444;
+  font-size: 10px;
+  padding: 1px 5px;
+  cursor: pointer;
+}
+.eqv4-edgar-spinner {
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+
+/* ── Data rows ── */
+.eqv4-edgar-body {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+.eqv4-edgar-row {
+  display: flex;
+  align-items: center;
+  height: 22px;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+}
+.eqv4-edgar-row:hover { background: var(--surface, #141420); }
+.eqv4-etd {
+  font-size: 11px;
+  padding: 0 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary, #e2e8f0);
+}
+.eqv4-etd-date { width: 90px; flex-shrink: 0; color: var(--text-muted, #64748b); }
+.eqv4-etd-form { flex: 1; min-width: 0; }
+.eqv4-edgar-link {
+  color: var(--pd-accent, #7c3aed);
+  text-decoration: none;
+  font-size: 11px;
+}
+.eqv4-edgar-link:hover { text-decoration: underline; }
+</style>

--- a/client/src/components/widgets/EQV4StockSplitsCard.vue
+++ b/client/src/components/widgets/EQV4StockSplitsCard.vue
@@ -1,0 +1,246 @@
+<template>
+  <div class="eqv4-splits-card">
+
+    <!-- Card header: label + refresh + X (edit mode) -->
+    <div class="eqv4-splits-header">
+      <span class="eqv4-splits-label">Stock Splits</span>
+      <div class="eqv4-splits-controls">
+        <button
+          class="eqv4-splits-refresh"
+          :class="{ 'eqv4-splits-refresh--spinning': loading }"
+          title="Refresh splits"
+          :disabled="loading"
+          @click="fetchSplits"
+        >↻</button>
+        <button
+          v-if="!isLocked"
+          class="eqv4-splits-remove"
+          title="Remove card"
+          @click="emit('remove')"
+        >✕</button>
+      </div>
+    </div>
+
+    <!-- Column header -->
+    <div class="eqv4-splits-thead">
+      <div class="eqv4-sth eqv4-sth-date">Date</div>
+      <div class="eqv4-sth eqv4-sth-type">Type</div>
+      <div class="eqv4-sth eqv4-sth-ratio">Ratio</div>
+    </div>
+
+    <!-- States -->
+    <div v-if="!ticker" class="eqv4-splits-empty">Enter a ticker to load splits</div>
+    <div v-else-if="error" class="eqv4-splits-error">
+      {{ error }}
+      <button class="eqv4-retry-btn" @click="fetchSplits">↻ Retry</button>
+    </div>
+    <div v-else-if="loading && splits.length === 0" class="eqv4-splits-empty">
+      <span class="eqv4-splits-spinner">↻</span> Loading…
+    </div>
+    <div v-else-if="!loading && splits.length === 0 && ticker" class="eqv4-splits-empty">
+      No splits found for {{ ticker }}
+    </div>
+
+    <!-- Data rows -->
+    <div v-else class="eqv4-splits-body">
+      <div v-for="(s, i) in splits" :key="i" class="eqv4-splits-row">
+        <div class="eqv4-std eqv4-std-date">{{ s.execution_date }}</div>
+        <div class="eqv4-std eqv4-std-type">{{ humanizeType(s.adjustment_type) }}</div>
+        <div class="eqv4-std eqv4-std-ratio">{{ s.split_to }}:{{ s.split_from }}</div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { useConfig } from '@/composables/useConfig.js'
+
+const props = defineProps({
+  ticker:   { type: String,  default: null },
+  isLocked: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['remove'])
+
+const { config } = useConfig()
+
+// ── State ─────────────────────────────────────────────────────────────────────
+const splits  = ref([])
+const loading = ref(false)
+const error   = ref(null)
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+const fetchSplits = async () => {
+  if (!props.ticker) return
+  loading.value = true
+  error.value = null
+  splits.value = []
+  try {
+    const key = config.value?.massiveApiKey
+    const url = `https://api.massive.com/stocks/v1/splits?ticker=${props.ticker}&limit=5&sort=execution_date.desc&apiKey=${key}`
+    const resp = await fetch(url)
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const json = await resp.json()
+    splits.value = json.results ?? []
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => props.ticker, (t) => { if (t) fetchSplits() }, { immediate: true })
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const TYPE_LABELS = {
+  forward_split:  'Forward',
+  reverse_split:  'Reverse',
+  stock_dividend: 'Stock Div',
+}
+const humanizeType = (type) => TYPE_LABELS[type] ?? type
+
+// ── Expose ────────────────────────────────────────────────────────────────────
+defineExpose({ splits, loading, error, fetchSplits })
+</script>
+
+<style scoped>
+.eqv4-splits-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg, #0d0d12);
+  color: var(--text-primary, #e2e8f0);
+  font-family: system-ui, sans-serif;
+}
+
+/* ── Header ── */
+.eqv4-splits-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  background: var(--bg, #0d0d12);
+  flex-shrink: 0;
+}
+.eqv4-splits-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.eqv4-splits-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.eqv4-splits-refresh {
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+.eqv4-splits-refresh:hover { color: var(--pd-accent, #7c3aed); }
+.eqv4-splits-refresh--spinning { animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.eqv4-splits-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.eqv4-splits-remove:hover { color: #ef4444; }
+
+/* ── Column header ── */
+.eqv4-splits-thead {
+  display: flex;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  flex-shrink: 0;
+  background: var(--bg, #0d0d12);
+}
+.eqv4-sth {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 4px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.eqv4-sth-date  { width: 90px; flex-shrink: 0; }
+.eqv4-sth-type  { width: 72px; flex-shrink: 0; }
+.eqv4-sth-ratio { flex: 1; min-width: 0; }
+
+/* ── Empty / error states ── */
+.eqv4-splits-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+  padding: 8px;
+  text-align: center;
+}
+.eqv4-splits-error {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #ef4444;
+  padding: 8px;
+}
+.eqv4-retry-btn {
+  background: none;
+  border: 1px solid #ef4444;
+  border-radius: 3px;
+  color: #ef4444;
+  font-size: 10px;
+  padding: 1px 5px;
+  cursor: pointer;
+}
+.eqv4-splits-spinner {
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+
+/* ── Data rows ── */
+.eqv4-splits-body {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+.eqv4-splits-row {
+  display: flex;
+  align-items: center;
+  height: 22px;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+}
+.eqv4-splits-row:hover { background: var(--surface, #141420); }
+.eqv4-std {
+  font-size: 11px;
+  padding: 0 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary, #e2e8f0);
+}
+.eqv4-std-date  { width: 90px; flex-shrink: 0; color: var(--text-muted, #64748b); }
+.eqv4-std-type  { width: 72px; flex-shrink: 0; }
+.eqv4-std-ratio { flex: 1; min-width: 0; }
+</style>

--- a/client/src/components/widgets/EQV4TickerEventsCard.vue
+++ b/client/src/components/widgets/EQV4TickerEventsCard.vue
@@ -1,0 +1,268 @@
+<template>
+  <div class="eqv4-events-card">
+
+    <!-- Card header: label + entity name subtitle + refresh + X (edit mode) -->
+    <div class="eqv4-events-header">
+      <div class="eqv4-events-header-left">
+        <span class="eqv4-events-label">Ticker Events</span>
+        <span v-if="entityName" class="eqv4-events-subtitle">{{ entityName }}</span>
+      </div>
+      <div class="eqv4-events-controls">
+        <button
+          class="eqv4-events-refresh"
+          :class="{ 'eqv4-events-refresh--spinning': loading }"
+          title="Refresh events"
+          :disabled="loading"
+          @click="fetchEvents"
+        >↻</button>
+        <button
+          v-if="!isLocked"
+          class="eqv4-events-remove"
+          title="Remove card"
+          @click="emit('remove')"
+        >✕</button>
+      </div>
+    </div>
+
+    <!-- Column header -->
+    <div class="eqv4-events-thead">
+      <div class="eqv4-evth eqv4-evth-date">Date</div>
+      <div class="eqv4-evth eqv4-evth-transition">Transition</div>
+    </div>
+
+    <!-- States -->
+    <div v-if="!ticker" class="eqv4-events-empty">Enter a ticker to load events</div>
+    <div v-else-if="error" class="eqv4-events-error">
+      {{ error }}
+      <button class="eqv4-retry-btn" @click="fetchEvents">↻ Retry</button>
+    </div>
+    <div v-else-if="loading && transitions.length === 0" class="eqv4-events-empty">
+      <span class="eqv4-events-spinner">↻</span> Loading…
+    </div>
+    <div v-else-if="!loading && transitions.length === 0 && ticker" class="eqv4-events-empty">
+      No events found for {{ ticker }}
+    </div>
+
+    <!-- Data rows -->
+    <div v-else class="eqv4-events-body">
+      <div v-for="(t, i) in transitions" :key="i" class="eqv4-events-row">
+        <div class="eqv4-evtd eqv4-evtd-date">{{ t.date }}</div>
+        <div class="eqv4-evtd eqv4-evtd-transition">
+          <span v-if="t.from">{{ t.from }} → {{ t.to }}</span>
+          <span v-else>{{ t.to }} (original)</span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useConfig } from '@/composables/useConfig.js'
+
+const props = defineProps({
+  ticker:   { type: String,  default: null },
+  isLocked: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['remove'])
+
+const { config } = useConfig()
+
+// ── State ─────────────────────────────────────────────────────────────────────
+const events     = ref([])
+const entityName = ref(null)
+const loading    = ref(false)
+const error      = ref(null)
+
+// ── Transitions (pre-render pass: newest-first, from = events[i+1]) ───────────
+const transitions = computed(() =>
+  events.value.map((event, i) => ({
+    date: event.date,
+    to:   event.ticker_change?.ticker ?? null,
+    from: events.value[i + 1]?.ticker_change?.ticker ?? null,
+  }))
+)
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+const fetchEvents = async () => {
+  if (!props.ticker) return
+  loading.value = true
+  error.value = null
+  events.value = []
+  entityName.value = null
+  try {
+    const key = config.value?.massiveApiKey
+    const url = `https://api.massive.com/vX/reference/tickers/${props.ticker}/events?apiKey=${key}`
+    const resp = await fetch(url)
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const json = await resp.json()
+    entityName.value = json.results?.name ?? null
+    events.value = json.results?.events ?? []
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => props.ticker, (t) => { if (t) fetchEvents() }, { immediate: true })
+
+// ── Expose ────────────────────────────────────────────────────────────────────
+defineExpose({ events, transitions, entityName, loading, error, fetchEvents })
+</script>
+
+<style scoped>
+.eqv4-events-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg, #0d0d12);
+  color: var(--text-primary, #e2e8f0);
+  font-family: system-ui, sans-serif;
+}
+
+/* ── Header ── */
+.eqv4-events-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  background: var(--bg, #0d0d12);
+  flex-shrink: 0;
+}
+.eqv4-events-header-left {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+.eqv4-events-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+.eqv4-events-subtitle {
+  font-size: 10px;
+  color: var(--text-muted, #64748b);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.eqv4-events-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.eqv4-events-refresh {
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+.eqv4-events-refresh:hover { color: var(--pd-accent, #7c3aed); }
+.eqv4-events-refresh--spinning { animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.eqv4-events-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.eqv4-events-remove:hover { color: #ef4444; }
+
+/* ── Column header ── */
+.eqv4-events-thead {
+  display: flex;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+  flex-shrink: 0;
+  background: var(--bg, #0d0d12);
+}
+.eqv4-evth {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 4px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.eqv4-evth-date       { width: 90px; flex-shrink: 0; }
+.eqv4-evth-transition { flex: 1; min-width: 0; }
+
+/* ── Empty / error states ── */
+.eqv4-events-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+  padding: 8px;
+  text-align: center;
+}
+.eqv4-events-error {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #ef4444;
+  padding: 8px;
+}
+.eqv4-retry-btn {
+  background: none;
+  border: 1px solid #ef4444;
+  border-radius: 3px;
+  color: #ef4444;
+  font-size: 10px;
+  padding: 1px 5px;
+  cursor: pointer;
+}
+.eqv4-events-spinner {
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+
+/* ── Data rows ── */
+.eqv4-events-body {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+.eqv4-events-row {
+  display: flex;
+  align-items: center;
+  height: 22px;
+  border-bottom: 1px solid var(--border, #2d2d3d);
+}
+.eqv4-events-row:hover { background: var(--surface, #141420); }
+.eqv4-evtd {
+  font-size: 11px;
+  padding: 0 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary, #e2e8f0);
+}
+.eqv4-evtd-date       { width: 90px; flex-shrink: 0; color: var(--text-muted, #64748b); }
+.eqv4-evtd-transition { flex: 1; min-width: 0; }
+</style>

--- a/client/src/components/widgets/EnhancedQuoteV4.vue
+++ b/client/src/components/widgets/EnhancedQuoteV4.vue
@@ -44,8 +44,8 @@
           class="eqv4-grid-item"
         >
           <!-- Card header: label + edit-mode controls
-               Suppressed for company-news — that card owns its full header -->
-          <div v-if="item.i !== 'company-news'" class="eqv4-card-header">
+               Suppressed for active cards that own their full header -->
+          <div v-if="!isActiveCard(item.i)" class="eqv4-card-header">
             <span class="eqv4-card-label">{{ cardLabel(item.i) }}</span>
             <span v-if="!isLocked" class="eqv4-card-controls">
               <!-- Hero layout toggle -->
@@ -81,14 +81,16 @@
             :is-locked="isLocked"
             :chips-mode="chipCardIds.has(item.i)"
             :hero-mode="item.i === 'hero' ? heroMode : undefined"
-            :ticker="item.i === 'company-news' ? activeTicker : undefined"
+            :ticker="isActiveCard(item.i) ? activeTicker : undefined"
             :article-count="item.i === 'company-news' ? newsArticleCount : undefined"
+            :filing-count="item.i === 'sec-edgar' ? secEdgarFilingCount : undefined"
             :branding-mode="brandingMode"
             :active-branding-url="activeBrandingUrl"
             :flame-icon="flameIcon"
             @toggle-branding="toggleBranding"
             @update-article-count="item.i === 'company-news' ? onNewsArticleCountChange($event) : undefined"
-            @remove="item.i === 'company-news' ? removeCard('company-news') : undefined"
+            @update-filing-count="item.i === 'sec-edgar' ? onSecEdgarFilingCountChange($event) : undefined"
+            @remove="isActiveCard(item.i) ? removeCard(item.i) : undefined"
             class="eqv4-card-component"
           />
         </GridItem>
@@ -142,6 +144,9 @@ import EQV4SessionCard from './EQV4SessionCard.vue'
 import EQV4ShortCard   from './EQV4ShortCard.vue'
 import EQV4CompanyCard     from './EQV4CompanyCard.vue'
 import EQV4CompanyNewsCard from './EQV4CompanyNewsCard.vue'
+import EQV4StockSplitsCard from './EQV4StockSplitsCard.vue'
+import EQV4SecEdgarCard    from './EQV4SecEdgarCard.vue'
+import EQV4TickerEventsCard from './EQV4TickerEventsCard.vue'
 import EQV4CardPicker  from './EQV4CardPicker.vue'
 
 // ── Card registry ────────────────────────────────────────────────────────────
@@ -154,6 +159,9 @@ const CARD_REGISTRY = [
   { id: 'short',   label: 'Short Interest', component: EQV4ShortCard,   defaultW: 3, defaultH: 2 },
   { id: 'company',      label: 'Company',        component: EQV4CompanyCard,     defaultW: 3, defaultH: 3 },
   { id: 'company-news', label: 'Company News',   component: EQV4CompanyNewsCard, defaultW: 6, defaultH: 4 },
+  { id: 'stock-splits',  label: 'Stock Splits',  component: EQV4StockSplitsCard,  defaultW: 4, defaultH: 3 },
+  { id: 'sec-edgar',     label: 'SEC EDGAR',     component: EQV4SecEdgarCard,     defaultW: 6, defaultH: 4 },
+  { id: 'ticker-events', label: 'Ticker Events', component: EQV4TickerEventsCard, defaultW: 4, defaultH: 3 },
 ]
 
 const CARD_MAP = Object.fromEntries(CARD_REGISTRY.map(c => [c.id, c]))
@@ -191,6 +199,11 @@ const chipCardIds = computed(() => new Set(props.settings?.chipCards ?? []))
 const brandingMode = computed(() => props.settings?.brandingMode ?? 'logo')
 const heroMode = computed(() => props.settings?.heroMode ?? 'wide')
 const newsArticleCount = computed(() => props.settings?.newsArticleCount ?? 20)
+const secEdgarFilingCount = computed(() => props.settings?.secEdgarFilingCount ?? 10)
+
+// Cards that own their full header and receive ticker/isLocked props
+const ACTIVE_CARD_IDS = new Set(['company-news', 'stock-splits', 'sec-edgar', 'ticker-events'])
+const isActiveCard = (id) => ACTIVE_CARD_IDS.has(id)
 
 // Cards that support chip render mode (company card does not)
 const CHIPS_CAPABLE = new Set(['today', 'prev', 'volume', 'session', 'short'])
@@ -210,6 +223,10 @@ const toggleHeroMode = () => {
 
 const onNewsArticleCountChange = (count) => {
   emit('update-settings', { ...props.settings, newsArticleCount: count })
+}
+
+const onSecEdgarFilingCountChange = (count) => {
+  emit('update-settings', { ...props.settings, secEdgarFilingCount: count })
 }
 
 const settingsCards = computed(() => {
@@ -554,6 +571,7 @@ defineExpose({
   chipCardIds,
   heroMode,
   newsArticleCount,
+  secEdgarFilingCount,
   addCard,
   removeCard,
   toggleCardChips,

--- a/client/src/components/widgets/__tests__/EQV4SecEdgarCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV4SecEdgarCard.spec.js
@@ -1,0 +1,213 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+vi.mock('@/composables/useConfig.js', async () => {
+  const { ref } = await import('vue')
+  const _configRef = ref({ massiveApiKey: 'test-massive-key' })
+  return {
+    useConfig: vi.fn(() => ({
+      config: _configRef,
+      loading: ref(false),
+      error: ref(null),
+      fetchConfig: vi.fn(),
+      isAuthenticated: () => true,
+    })),
+    _configRef,
+  }
+})
+
+const SAMPLE_FILINGS = [
+  { filing_date: '2026-02-03', form_type: '10-K', filing_url: 'https://sec.gov/Archives/1', issuer_name: 'Apple Inc.' },
+  { filing_date: '2025-11-01', form_type: '10-Q', filing_url: 'https://sec.gov/Archives/2', issuer_name: 'Apple Inc.' },
+]
+
+function mockFilingsSuccess(results = SAMPLE_FILINGS) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ results }),
+  })
+}
+
+function mockFilingsError(status = 500) {
+  global.fetch = vi.fn().mockResolvedValue({ ok: false, status, json: async () => ({}) })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) })
+})
+
+import EQV4SecEdgarCard from '../EQV4SecEdgarCard.vue'
+
+function mountCard(props = {}) {
+  return mount(EQV4SecEdgarCard, {
+    props: {
+      ticker: null,
+      isLocked: true,
+      filingCount: 10,
+      ...props,
+    },
+  })
+}
+
+// ── No ticker ─────────────────────────────────────────────────────────────────
+
+describe('No ticker state', () => {
+  test('test_EQV4SecEdgarCard_with_no_ticker_expect_prompt_shown', () => {
+    // Arrange / Act
+    const wrapper = mountCard({ ticker: null })
+
+    // Assert
+    expect(wrapper.text()).toContain('Enter a ticker to load filings')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ── Fetch URL ─────────────────────────────────────────────────────────────────
+
+describe('Fetch URL', () => {
+  test('test_EQV4SecEdgarCard_with_ticker_expect_fetch_called_with_correct_url', async () => {
+    // Arrange
+    mockFilingsSuccess()
+
+    // Act
+    mountCard({ ticker: 'AAPL', filingCount: 10 })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('ticker=AAPL')
+    )
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('limit=10')
+    )
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('sort=filing_date.desc')
+    )
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('apiKey=test-massive-key')
+    )
+  })
+
+  test('test_EQV4SecEdgarCard_with_custom_filingCount_expect_limit_in_url_matches', async () => {
+    // Arrange
+    mockFilingsSuccess()
+
+    // Act
+    mountCard({ ticker: 'MSFT', filingCount: 25 })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('limit=25')
+    )
+  })
+})
+
+// ── Data rows ─────────────────────────────────────────────────────────────────
+
+describe('Data rows', () => {
+  test('test_EQV4SecEdgarCard_with_filings_data_expect_rows_with_date_and_form_type_link', async () => {
+    // Arrange
+    mockFilingsSuccess()
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert — dates and form types rendered
+    expect(wrapper.text()).toContain('2026-02-03')
+    expect(wrapper.text()).toContain('10-K')
+    expect(wrapper.text()).toContain('2025-11-01')
+    expect(wrapper.text()).toContain('10-Q')
+
+    // Assert — links with correct hrefs and target=_blank
+    const links = wrapper.findAll('.eqv4-edgar-link')
+    expect(links.length).toBe(2)
+    expect(links[0].attributes('href')).toBe('https://sec.gov/Archives/1')
+    expect(links[0].attributes('target')).toBe('_blank')
+    expect(links[1].attributes('href')).toBe('https://sec.gov/Archives/2')
+  })
+})
+
+// ── Filing count change ───────────────────────────────────────────────────────
+
+describe('Filing count change', () => {
+  test('test_EQV4SecEdgarCard_with_filing_count_change_expect_update_filing_count_emitted', async () => {
+    // Arrange
+    mockFilingsSuccess()
+    const calls = []
+    const wrapper = mount(EQV4SecEdgarCard, {
+      props: { ticker: 'AAPL', isLocked: true, filingCount: 10 },
+      attrs: { onUpdateFilingCount: (n) => calls.push(n) },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const select = wrapper.find('.eqv4-edgar-count-select')
+    await select.setValue('25')
+    await select.trigger('change')
+    await nextTick()
+
+    // Assert
+    expect(calls).toContain(25)
+  })
+})
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+describe('Error state', () => {
+  test('test_EQV4SecEdgarCard_with_fetch_error_expect_error_state_and_retry_button', async () => {
+    // Arrange
+    mockFilingsError(503)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.eqv4-edgar-error').exists()).toBe(true)
+    expect(wrapper.text()).toContain('HTTP 503')
+    expect(wrapper.find('.eqv4-retry-btn').exists()).toBe(true)
+  })
+})
+
+// ── Remove button ─────────────────────────────────────────────────────────────
+
+describe('Remove button', () => {
+  test('test_EQV4SecEdgarCard_with_isLocked_false_expect_remove_button_and_remove_emitted', async () => {
+    // Arrange
+    const calls = []
+    const wrapper = mount(EQV4SecEdgarCard, {
+      props: { ticker: null, isLocked: false, filingCount: 10 },
+      attrs: { onRemove: () => calls.push(true) },
+    })
+
+    // Assert — remove button visible
+    expect(wrapper.find('.eqv4-edgar-remove').exists()).toBe(true)
+
+    // Act
+    await wrapper.find('.eqv4-edgar-remove').trigger('click')
+
+    // Assert — remove emitted
+    expect(calls).toHaveLength(1)
+  })
+})
+
+// ── Exposed interface ─────────────────────────────────────────────────────────
+
+describe('Exposed interface', () => {
+  test('test_EQV4SecEdgarCard_with_card_mounted_expect_fetchFilings_exposed', () => {
+    // Arrange / Act
+    const wrapper = mountCard()
+
+    // Assert
+    expect(typeof wrapper.vm.fetchFilings).toBe('function')
+  })
+})

--- a/client/src/components/widgets/__tests__/EQV4StockSplitsCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV4StockSplitsCard.spec.js
@@ -1,0 +1,194 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+vi.mock('@/composables/useConfig.js', async () => {
+  const { ref } = await import('vue')
+  const _configRef = ref({ massiveApiKey: 'test-massive-key' })
+  return {
+    useConfig: vi.fn(() => ({
+      config: _configRef,
+      loading: ref(false),
+      error: ref(null),
+      fetchConfig: vi.fn(),
+      isAuthenticated: () => true,
+    })),
+    _configRef,
+  }
+})
+
+const SAMPLE_SPLITS = [
+  { execution_date: '2020-08-31', adjustment_type: 'forward_split', split_from: 1, split_to: 4 },
+  { execution_date: '2014-06-09', adjustment_type: 'forward_split', split_from: 1, split_to: 7 },
+]
+
+function mockSplitsSuccess(results = SAMPLE_SPLITS) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ results }),
+  })
+}
+
+function mockSplitsError(status = 500) {
+  global.fetch = vi.fn().mockResolvedValue({ ok: false, status, json: async () => ({}) })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) })
+})
+
+import EQV4StockSplitsCard from '../EQV4StockSplitsCard.vue'
+
+function mountCard(props = {}) {
+  return mount(EQV4StockSplitsCard, {
+    props: {
+      ticker: null,
+      isLocked: true,
+      ...props,
+    },
+  })
+}
+
+// ── No ticker ─────────────────────────────────────────────────────────────────
+
+describe('No ticker state', () => {
+  test('test_EQV4StockSplitsCard_with_no_ticker_expect_prompt_shown', () => {
+    // Arrange / Act
+    const wrapper = mountCard({ ticker: null })
+
+    // Assert
+    expect(wrapper.text()).toContain('Enter a ticker to load splits')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ── Fetch URL ─────────────────────────────────────────────────────────────────
+
+describe('Fetch URL', () => {
+  test('test_EQV4StockSplitsCard_with_ticker_expect_fetch_called_with_correct_url', async () => {
+    // Arrange
+    mockSplitsSuccess()
+
+    // Act
+    mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('ticker=AAPL')
+    )
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('limit=5')
+    )
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('sort=execution_date.desc')
+    )
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('apiKey=test-massive-key')
+    )
+  })
+})
+
+// ── Data rows ─────────────────────────────────────────────────────────────────
+
+describe('Data rows', () => {
+  test('test_EQV4StockSplitsCard_with_splits_data_expect_rows_with_date_type_ratio', async () => {
+    // Arrange
+    mockSplitsSuccess([
+      { execution_date: '2020-08-31', adjustment_type: 'forward_split', split_from: 1, split_to: 4 },
+      { execution_date: '2014-06-09', adjustment_type: 'reverse_split', split_from: 4, split_to: 1 },
+      { execution_date: '2010-01-01', adjustment_type: 'stock_dividend', split_from: 1, split_to: 2 },
+    ])
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert — humanized types
+    expect(wrapper.text()).toContain('2020-08-31')
+    expect(wrapper.text()).toContain('Forward')
+    expect(wrapper.text()).toContain('4:1')
+    expect(wrapper.text()).toContain('2014-06-09')
+    expect(wrapper.text()).toContain('Reverse')
+    expect(wrapper.text()).toContain('1:4')
+    expect(wrapper.text()).toContain('Stock Div')
+  })
+})
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+describe('Error state', () => {
+  test('test_EQV4StockSplitsCard_with_fetch_error_expect_error_state_and_retry_button', async () => {
+    // Arrange
+    mockSplitsError(500)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.eqv4-splits-error').exists()).toBe(true)
+    expect(wrapper.text()).toContain('HTTP 500')
+    expect(wrapper.find('.eqv4-retry-btn').exists()).toBe(true)
+  })
+})
+
+// ── Loading spinner ───────────────────────────────────────────────────────────
+
+describe('Loading state', () => {
+  test('test_EQV4StockSplitsCard_with_loading_expect_spinner_shown', async () => {
+    // Arrange — fetch that never resolves so loading stays true
+    let resolveFetch
+    global.fetch = vi.fn().mockReturnValue(
+      new Promise((resolve) => { resolveFetch = resolve })
+    )
+
+    // Act
+    const wrapper = mountCard({ ticker: 'AAPL' })
+    await nextTick()
+
+    // Assert — loading state with spinner
+    expect(wrapper.find('.eqv4-splits-spinner').exists()).toBe(true)
+
+    // Cleanup
+    resolveFetch({ ok: true, json: async () => ({ results: [] }) })
+  })
+})
+
+// ── Remove button ─────────────────────────────────────────────────────────────
+
+describe('Remove button', () => {
+  test('test_EQV4StockSplitsCard_with_isLocked_false_expect_remove_button_and_remove_emitted', async () => {
+    // Arrange
+    const calls = []
+    const wrapper = mount(EQV4StockSplitsCard, {
+      props: { ticker: null, isLocked: false },
+      attrs: { onRemove: () => calls.push(true) },
+    })
+
+    // Assert — remove button visible
+    expect(wrapper.find('.eqv4-splits-remove').exists()).toBe(true)
+
+    // Act
+    await wrapper.find('.eqv4-splits-remove').trigger('click')
+
+    // Assert — remove emitted
+    expect(calls).toHaveLength(1)
+  })
+})
+
+// ── Exposed interface ─────────────────────────────────────────────────────────
+
+describe('Exposed interface', () => {
+  test('test_EQV4StockSplitsCard_with_card_mounted_expect_fetchSplits_exposed', () => {
+    // Arrange / Act
+    const wrapper = mountCard()
+
+    // Assert
+    expect(typeof wrapper.vm.fetchSplits).toBe('function')
+  })
+})

--- a/client/src/components/widgets/__tests__/EQV4TickerEventsCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV4TickerEventsCard.spec.js
@@ -1,0 +1,251 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+vi.mock('@/composables/useConfig.js', async () => {
+  const { ref } = await import('vue')
+  const _configRef = ref({ massiveApiKey: 'test-massive-key' })
+  return {
+    useConfig: vi.fn(() => ({
+      config: _configRef,
+      loading: ref(false),
+      error: ref(null),
+      fetchConfig: vi.fn(),
+      isAuthenticated: () => true,
+    })),
+    _configRef,
+  }
+})
+
+// Multi-event sample: newest-first as returned by the API.
+// META (2022) then FB (2012) — FB was the original ticker.
+const SAMPLE_MULTI_EVENTS = {
+  results: {
+    name: 'Meta Platforms, Inc.',
+    events: [
+      { date: '2022-06-09', type: 'ticker_change', ticker_change: { ticker: 'META' } },
+      { date: '2012-05-18', type: 'ticker_change', ticker_change: { ticker: 'FB' } },
+    ],
+  },
+}
+
+// Single-event sample: company has only ever had one ticker.
+const SAMPLE_SINGLE_EVENT = {
+  results: {
+    name: 'Some Corp',
+    events: [
+      { date: '2015-01-01', type: 'ticker_change', ticker_change: { ticker: 'SC' } },
+    ],
+  },
+}
+
+const SAMPLE_EMPTY_EVENTS = {
+  results: { name: 'Empty Corp', events: [] },
+}
+
+function mockEventsSuccess(data = SAMPLE_MULTI_EVENTS) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => data,
+  })
+}
+
+function mockEventsError(status = 500) {
+  global.fetch = vi.fn().mockResolvedValue({ ok: false, status, json: async () => ({}) })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ results: { name: null, events: [] } }),
+  })
+})
+
+import EQV4TickerEventsCard from '../EQV4TickerEventsCard.vue'
+
+function mountCard(props = {}) {
+  return mount(EQV4TickerEventsCard, {
+    props: {
+      ticker: null,
+      isLocked: true,
+      ...props,
+    },
+  })
+}
+
+// ── No ticker ─────────────────────────────────────────────────────────────────
+
+describe('No ticker state', () => {
+  test('test_EQV4TickerEventsCard_with_no_ticker_expect_prompt_shown', () => {
+    // Arrange / Act
+    const wrapper = mountCard({ ticker: null })
+
+    // Assert
+    expect(wrapper.text()).toContain('Enter a ticker to load events')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ── Fetch URL ─────────────────────────────────────────────────────────────────
+
+describe('Fetch URL', () => {
+  test('test_EQV4TickerEventsCard_with_ticker_expect_fetch_called_with_correct_url', async () => {
+    // Arrange
+    mockEventsSuccess()
+
+    // Act
+    mountCard({ ticker: 'META' })
+    await nextTick()
+    await nextTick()
+
+    // Assert — ticker in path, apiKey as query param
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/vX/reference/tickers/META/events')
+    )
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('apiKey=test-massive-key')
+    )
+  })
+})
+
+// ── Multi-event rendering ─────────────────────────────────────────────────────
+
+describe('Multi-event rendering', () => {
+  test('test_EQV4TickerEventsCard_with_multi_event_data_expect_newest_first_standard_row', async () => {
+    // Arrange
+    mockEventsSuccess(SAMPLE_MULTI_EVENTS)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'META' })
+    await nextTick()
+    await nextTick()
+
+    // Assert — first row (newest): FB → META
+    const rows = wrapper.findAll('.eqv4-events-row')
+    expect(rows.length).toBe(2)
+    expect(rows[0].text()).toContain('FB → META')
+  })
+
+  test('test_EQV4TickerEventsCard_with_multi_event_data_expect_oldest_row_shows_original', async () => {
+    // Arrange
+    mockEventsSuccess(SAMPLE_MULTI_EVENTS)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'META' })
+    await nextTick()
+    await nextTick()
+
+    // Assert — second row (oldest, no predecessor): FB (original)
+    const rows = wrapper.findAll('.eqv4-events-row')
+    expect(rows[1].text()).toContain('FB (original)')
+  })
+})
+
+// ── Single-event rendering ────────────────────────────────────────────────────
+
+describe('Single-event rendering', () => {
+  test('test_EQV4TickerEventsCard_with_single_event_data_expect_original_label', async () => {
+    // Arrange
+    mockEventsSuccess(SAMPLE_SINGLE_EVENT)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'SC' })
+    await nextTick()
+    await nextTick()
+
+    // Assert — the one row has no predecessor: SC (original)
+    const rows = wrapper.findAll('.eqv4-events-row')
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('SC (original)')
+  })
+})
+
+// ── Empty events array ────────────────────────────────────────────────────────
+
+describe('Empty events', () => {
+  test('test_EQV4TickerEventsCard_with_empty_events_array_expect_no_events_state', async () => {
+    // Arrange
+    mockEventsSuccess(SAMPLE_EMPTY_EVENTS)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'EMPTY' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.text()).toContain('No events found for EMPTY')
+    expect(wrapper.findAll('.eqv4-events-row').length).toBe(0)
+  })
+})
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+describe('Error state', () => {
+  test('test_EQV4TickerEventsCard_with_fetch_error_expect_error_state_and_retry_button', async () => {
+    // Arrange
+    mockEventsError(404)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'UNKNOWN' })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.eqv4-events-error').exists()).toBe(true)
+    expect(wrapper.text()).toContain('HTTP 404')
+    expect(wrapper.find('.eqv4-retry-btn').exists()).toBe(true)
+  })
+})
+
+// ── Remove button ─────────────────────────────────────────────────────────────
+
+describe('Remove button', () => {
+  test('test_EQV4TickerEventsCard_with_isLocked_false_expect_remove_button_and_remove_emitted', async () => {
+    // Arrange
+    const calls = []
+    const wrapper = mount(EQV4TickerEventsCard, {
+      props: { ticker: null, isLocked: false },
+      attrs: { onRemove: () => calls.push(true) },
+    })
+
+    // Assert — remove button visible
+    expect(wrapper.find('.eqv4-events-remove').exists()).toBe(true)
+
+    // Act
+    await wrapper.find('.eqv4-events-remove').trigger('click')
+
+    // Assert — remove emitted
+    expect(calls).toHaveLength(1)
+  })
+})
+
+// ── results.name subtitle ─────────────────────────────────────────────────────
+
+describe('Entity name subtitle', () => {
+  test('test_EQV4TickerEventsCard_with_results_name_expect_subtitle_shown_in_card_header', async () => {
+    // Arrange
+    mockEventsSuccess(SAMPLE_MULTI_EVENTS)
+
+    // Act
+    const wrapper = mountCard({ ticker: 'META' })
+    await nextTick()
+    await nextTick()
+
+    // Assert — subtitle visible in header
+    expect(wrapper.find('.eqv4-events-subtitle').exists()).toBe(true)
+    expect(wrapper.find('.eqv4-events-subtitle').text()).toBe('Meta Platforms, Inc.')
+  })
+})
+
+// ── Exposed interface ─────────────────────────────────────────────────────────
+
+describe('Exposed interface', () => {
+  test('test_EQV4TickerEventsCard_with_card_mounted_expect_fetchEvents_exposed', () => {
+    // Arrange / Act
+    const wrapper = mountCard()
+
+    // Assert
+    expect(typeof wrapper.vm.fetchEvents).toBe('function')
+  })
+})

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -713,6 +713,104 @@ describe('toggleCardChips', () => {
   })
 })
 
+// ── New card registry entries (tests 11-13) ───────────────────────────────────
+
+describe('New card registry entries', () => {
+  test('test_EnhancedQuoteV4_with_registry_expect_stock_splits_sec_edgar_ticker_events_present', () => {
+    // Arrange / Act
+    const wrapper = mountWidget()
+
+    // Assert — CARD_REGISTRY is not directly exposed, but absentCards + activeCardIds
+    // confirm all registry entries. addCard is the best proxy: unknown ids are ignored.
+    // We verify indirectly via addCard accepting known new IDs.
+    // More directly: confirm the cards can be added (they're in the registry).
+    const emitted = []
+    const wrapper2 = mountWidget(
+      { settings: { cards: [] } },
+      (s) => emitted.push(s)
+    )
+    wrapper2.vm.addCard('stock-splits')
+    wrapper2.vm.addCard('sec-edgar')
+    wrapper2.vm.addCard('ticker-events')
+
+    const ids = emitted.flatMap(s => s.cards?.map(c => c.id) ?? [])
+    expect(ids).toContain('stock-splits')
+    expect(ids).toContain('sec-edgar')
+    expect(ids).toContain('ticker-events')
+  })
+
+  test('test_EnhancedQuoteV4_with_sec_edgar_card_expect_filingCount_from_settings_secEdgarFilingCount', () => {
+    // Arrange
+    const wrapper = mountWidget({
+      settings: {
+        secEdgarFilingCount: 25,
+        cards: [{ id: 'sec-edgar', x: 0, y: 0, w: 6, h: 4 }],
+      },
+    })
+
+    // Assert — secEdgarFilingCount computed reflects settings value
+    expect(wrapper.vm.secEdgarFilingCount).toBe(25)
+  })
+
+  test('test_EnhancedQuoteV4_with_update_filing_count_from_sec_edgar_expect_settings_updated', async () => {
+    // Arrange
+    const emitted = []
+    const wrapper = mountWidget(
+      { settings: { secEdgarFilingCount: 10, cards: [{ id: 'sec-edgar', x: 0, y: 0, w: 6, h: 4 }] } },
+      (s) => emitted.push(s)
+    )
+
+    // Act — find the rendered EQV4SecEdgarCard and emit update-filing-count
+    const secEdgarCard = wrapper.findComponent({ name: 'EQV4SecEdgarCard' })
+    expect(secEdgarCard.exists()).toBe(true)
+    await secEdgarCard.vm.$emit('update-filing-count', 50)
+    await nextTick()
+
+    // Assert — update-settings emitted with secEdgarFilingCount updated
+    const last = emitted[emitted.length - 1]
+    expect(last.secEdgarFilingCount).toBe(50)
+  })
+})
+
+// ── Header suppression for new cards (test 14) ────────────────────────────────
+
+describe('Header suppression', () => {
+  test('test_EnhancedQuoteV4_with_new_active_cards_expect_generic_header_suppressed', () => {
+    // Arrange — layout contains all three new cards
+    const wrapper = mountWidget({
+      settings: {
+        cards: [
+          { id: 'stock-splits',  x: 0, y: 0, w: 4, h: 3 },
+          { id: 'sec-edgar',     x: 4, y: 0, w: 6, h: 4 },
+          { id: 'ticker-events', x: 0, y: 3, w: 4, h: 3 },
+        ],
+      },
+    })
+
+    // Assert — no generic .eqv4-card-header rendered for any of the three new card IDs.
+    // The generic header is rendered inside a GridItem with data-i matching the card id.
+    for (const id of ['stock-splits', 'sec-edgar', 'ticker-events']) {
+      const gridItem = wrapper.find(`[data-i="${id}"]`)
+      expect(gridItem.exists()).toBe(true)
+      // The generic card header should NOT appear inside this grid item.
+      expect(gridItem.find('.eqv4-card-header').exists()).toBe(false)
+    }
+  })
+})
+
+// ── secEdgarFilingCount exposed (test 15) ─────────────────────────────────────
+
+describe('secEdgarFilingCount exposed', () => {
+  test('test_EnhancedQuoteV4_with_widget_mounted_expect_secEdgarFilingCount_exposed', () => {
+    // Arrange / Act
+    const wrapper = mountWidget({ settings: { secEdgarFilingCount: 50 } })
+
+    // Assert
+    expect(wrapper.vm.secEdgarFilingCount).toBeDefined()
+    expect(wrapper.vm.secEdgarFilingCount).toBe(50)
+  })
+})
+
 // ── EQV4HeroCard ───────────────────────────────────────────────────────────
 
 import EQV4HeroCard from '../EQV4HeroCard.vue'


### PR DESCRIPTION
## Summary

Adds three new non-default EQv4 cards, each owning its own Massive REST API fetch lifecycle (same active-card pattern as `EQV4CompanyNewsCard`).

## New Cards

**Stock Splits** (`EQV4StockSplitsCard.vue`)
- `GET /stocks/v1/splits?ticker={t}&limit=5&sort=execution_date.desc`
- Three columns: Date | Type | Ratio
- `adjustment_type` humanized: forward_split → "Forward", reverse_split → "Reverse", stock_dividend → "Stock Div"
- Ratio formatted as `split_to:split_from` (e.g. "2:1")
- Limit hardcoded at 5 — most recent splits only

**SEC EDGAR** (`EQV4SecEdgarCard.vue`)
- `GET /stocks/filings/vX/index?ticker={t}&limit={n}&sort=filing_date.desc`
- Two columns: Date | Form Type (clickable link → SEC EDGAR doc, new tab)
- User-configurable filing count: default 10, options 5/10/25/50/100
- `filingCount` prop + `update-filing-count` emit + `secEdgarFilingCount` in settings

**Ticker Events** (`EQV4TickerEventsCard.vue`)
- `GET /vX/reference/tickers/{id}/events` (ticker is a path param)
- Two columns: Date | Transition
- Newest-first display; pre-render transition pairs: `from = events[i+1]?.ticker_change?.ticker`
- Standard row: "FB → META"; oldest row: "{ticker} (original)"
- `results.name` shown as muted subtitle in card header

## Changes to `EnhancedQuoteV4.vue`
- CARD_REGISTRY: 3 new entries
- `isActiveCard` Set helper centralizes active-card ID list
- Header suppression extended to all active card IDs
- Prop pass-through refactored to use `isActiveCard`
- `secEdgarFilingCount` computed + handler + `defineExpose`

## Tests
282/282 passing. 25 new tests across 4 spec files.

refs #219