### PR TITLE
fix(EQV4SecEdgarCard): link to EDGAR index page instead of raw filing_url

### DIFF
--- a/client/src/components/widgets/EQV4SecEdgarCard.vue
+++ b/client/src/components/widgets/EQV4SecEdgarCard.vue
@@ -54,11 +54,18 @@
         <div class="eqv4-etd eqv4-etd-date">{{ f.filing_date }}</div>
         <div class="eqv4-etd eqv4-etd-form">
           <a
-            :href="f.filing_url"
+            :href="edgarIndexUrl(f)"
             target="_blank"
             rel="noopener"
             class="eqv4-edgar-link"
           >{{ f.form_type }}</a>
+          <a
+            :href="f.filing_url"
+            target="_blank"
+            rel="noopener"
+            class="eqv4-edgar-raw-link"
+            title="Raw filing (.txt)"
+          >txt</a>
         </div>
       </div>
     </div>
@@ -116,7 +123,16 @@ const onFilingCountChange = (e) => {
 }
 
 // ── Expose ────────────────────────────────────────────────────────────────────
-defineExpose({ filings, loading, error, fetchFilings })
+// SEC EDGAR serves filing_url with Content-Type: text/plain, which browsers
+// render as raw text regardless of actual HTML content. The filing index page
+// (.../accession_nodash/accession-index.htm) is served as text/html and links
+// to all documents in the filing with proper formatting.
+const edgarIndexUrl = (filing) => {
+  const accessionNodash = filing.accession_number?.replace(/-/g, '') ?? ''
+  return `https://www.sec.gov/Archives/edgar/data/${filing.cik}/${accessionNodash}/${filing.accession_number}-index.htm`
+}
+
+defineExpose({ filings, loading, error, fetchFilings, edgarIndexUrl })
 </script>
 
 <style scoped>
@@ -270,4 +286,13 @@ defineExpose({ filings, loading, error, fetchFilings })
   font-size: 11px;
 }
 .eqv4-edgar-link:hover { text-decoration: underline; }
+.eqv4-edgar-raw-link {
+  color: var(--text-muted, #64748b);
+  font-size: 10px;
+  text-decoration: none;
+  margin-left: 5px;
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+.eqv4-edgar-raw-link:hover { text-decoration: underline; opacity: 1; }
 </style>

--- a/client/src/components/widgets/__tests__/EQV4SecEdgarCard.spec.js
+++ b/client/src/components/widgets/__tests__/EQV4SecEdgarCard.spec.js
@@ -18,8 +18,8 @@ vi.mock('@/composables/useConfig.js', async () => {
 })
 
 const SAMPLE_FILINGS = [
-  { filing_date: '2026-02-03', form_type: '10-K', filing_url: 'https://sec.gov/Archives/1', issuer_name: 'Apple Inc.' },
-  { filing_date: '2025-11-01', form_type: '10-Q', filing_url: 'https://sec.gov/Archives/2', issuer_name: 'Apple Inc.' },
+  { filing_date: '2026-02-03', form_type: '10-K', filing_url: 'https://sec.gov/Archives/1', issuer_name: 'Apple Inc.', cik: '0000320193', accession_number: '0000320193-26-000001' },
+  { filing_date: '2025-11-01', form_type: '10-Q', filing_url: 'https://sec.gov/Archives/2', issuer_name: 'Apple Inc.', cik: '0000320193', accession_number: '0000320193-25-000002' },
 ]
 
 function mockFilingsSuccess(results = SAMPLE_FILINGS) {
@@ -125,12 +125,23 @@ describe('Data rows', () => {
     expect(wrapper.text()).toContain('2025-11-01')
     expect(wrapper.text()).toContain('10-Q')
 
-    // Assert — links with correct hrefs and target=_blank
+    // Assert — primary links use EDGAR index URL (text/html)
     const links = wrapper.findAll('.eqv4-edgar-link')
     expect(links.length).toBe(2)
-    expect(links[0].attributes('href')).toBe('https://sec.gov/Archives/1')
+    expect(links[0].attributes('href')).toBe(
+      'https://www.sec.gov/Archives/edgar/data/0000320193/000032019326000001/0000320193-26-000001-index.htm'
+    )
     expect(links[0].attributes('target')).toBe('_blank')
-    expect(links[1].attributes('href')).toBe('https://sec.gov/Archives/2')
+    expect(links[1].attributes('href')).toBe(
+      'https://www.sec.gov/Archives/edgar/data/0000320193/000032019325000002/0000320193-25-000002-index.htm'
+    )
+
+    // Assert — secondary raw links use filing_url (.txt backup)
+    const rawLinks = wrapper.findAll('.eqv4-edgar-raw-link')
+    expect(rawLinks.length).toBe(2)
+    expect(rawLinks[0].attributes('href')).toBe('https://sec.gov/Archives/1')
+    expect(rawLinks[0].attributes('target')).toBe('_blank')
+    expect(rawLinks[0].text()).toBe('txt')
   })
 })
 
@@ -209,5 +220,19 @@ describe('Exposed interface', () => {
 
     // Assert
     expect(typeof wrapper.vm.fetchFilings).toBe('function')
+  })
+
+  test('test_EQV4SecEdgarCard_with_filing_having_cik_and_accession_expect_edgarIndexUrl_returns_index_htm', () => {
+    // Arrange
+    const wrapper = mountCard()
+    const filing = { cik: '0000320193', accession_number: '0000320193-26-000079' }
+
+    // Act
+    const url = wrapper.vm.edgarIndexUrl(filing)
+
+    // Assert — index page (text/html) rather than raw filing_url (text/plain)
+    expect(url).toBe(
+      'https://www.sec.gov/Archives/edgar/data/0000320193/000032019326000079/0000320193-26-000079-index.htm'
+    )
   })
 })


### PR DESCRIPTION
## Problem

SEC serves `filing_url` with `Content-Type: text/plain` regardless of content. Browsers render the HTML as plain text — unreadable.

## Fix

**Primary link (form type label)** → EDGAR filing index page (`accession-index.htm`), served as `text/html`. Renders correctly, lists all documents in the filing.

**Secondary link (`txt`)** → original `filing_url` from the API response. Muted, small, backup for users who want the raw source directly.

Both links open in a new tab.

The dual-link approach was Tom's direction after seeing the initial index-only fix.

## Implementation

Adds `edgarIndexUrl(filing)` helper that constructs the index URL from `cik` and `accession_number`:
```
https://www.sec.gov/Archives/edgar/data/{cik}/{accession_nodash}/{accession}-index.htm
```

## Changes
- `EQV4SecEdgarCard.vue`: `edgarIndexUrl()` helper; template updated with primary + secondary links; CSS for `eqv4-edgar-raw-link`; `edgarIndexUrl` added to `defineExpose`
- `EQV4SecEdgarCard.spec.js`: fixtures updated with `cik`/`accession_number`; href assertions for both links; new `edgarIndexUrl` unit test

283/283 passing.