### PR TITLE
fix(EQv4): bump active card body font from 11px to 13px

### DIFF
--- a/client/src/components/widgets/EQV4CompanyNewsCard.vue
+++ b/client/src/components/widgets/EQV4CompanyNewsCard.vue
@@ -237,7 +237,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   flex-shrink: 0;
 }
 .eqv4-news-label {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--text-muted, #64748b);
   text-transform: uppercase;
@@ -253,7 +253,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   border: 1px solid var(--border, #2d2d3d);
   border-radius: 3px;
   color: var(--text-muted, #64748b);
-  font-size: 11px;
+  font-size: 13px;
   padding: 1px 3px;
   cursor: pointer;
 }
@@ -275,7 +275,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   border: none;
   color: var(--text-muted, #64748b);
   cursor: pointer;
-  font-size: 11px;
+  font-size: 13px;
   padding: 0 2px;
   line-height: 1;
 }
@@ -296,7 +296,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   border: 1px solid var(--border, #2d2d3d);
   border-radius: 3px;
   color: var(--text-primary, #e2e8f0);
-  font-size: 11px;
+  font-size: 13px;
   padding: 2px 6px;
   outline: none;
 }
@@ -338,7 +338,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 13px;
   color: var(--text-muted, #64748b);
   font-style: italic;
   padding: 8px;
@@ -350,7 +350,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
   align-items: center;
   justify-content: center;
   gap: 6px;
-  font-size: 11px;
+  font-size: 13px;
   color: #ef4444;
   padding: 8px;
 }
@@ -382,7 +382,7 @@ defineExpose({ articles, filteredArticles, loading, error, selected, fetchNews }
 }
 .eqv4-news-row:hover { background: var(--surface, #141420); }
 .eqv4-ntd {
-  font-size: 11px;
+  font-size: 13px;
   padding: 0 4px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/client/src/components/widgets/EQV4SecEdgarCard.vue
+++ b/client/src/components/widgets/EQV4SecEdgarCard.vue
@@ -157,7 +157,7 @@ defineExpose({ filings, loading, error, fetchFilings, edgarIndexUrl })
   flex-shrink: 0;
 }
 .eqv4-edgar-label {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--text-muted, #64748b);
   text-transform: uppercase;
@@ -173,7 +173,7 @@ defineExpose({ filings, loading, error, fetchFilings, edgarIndexUrl })
   border: 1px solid var(--border, #2d2d3d);
   border-radius: 3px;
   color: var(--text-muted, #64748b);
-  font-size: 11px;
+  font-size: 13px;
   padding: 1px 3px;
   cursor: pointer;
 }
@@ -195,7 +195,7 @@ defineExpose({ filings, loading, error, fetchFilings, edgarIndexUrl })
   border: none;
   color: var(--text-muted, #64748b);
   cursor: pointer;
-  font-size: 11px;
+  font-size: 13px;
   padding: 0 2px;
   line-height: 1;
 }
@@ -227,7 +227,7 @@ defineExpose({ filings, loading, error, fetchFilings, edgarIndexUrl })
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 13px;
   color: var(--text-muted, #64748b);
   font-style: italic;
   padding: 8px;
@@ -239,7 +239,7 @@ defineExpose({ filings, loading, error, fetchFilings, edgarIndexUrl })
   align-items: center;
   justify-content: center;
   gap: 6px;
-  font-size: 11px;
+  font-size: 13px;
   color: #ef4444;
   padding: 8px;
 }
@@ -271,7 +271,7 @@ defineExpose({ filings, loading, error, fetchFilings, edgarIndexUrl })
 }
 .eqv4-edgar-row:hover { background: var(--surface, #141420); }
 .eqv4-etd {
-  font-size: 11px;
+  font-size: 13px;
   padding: 0 4px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -283,12 +283,12 @@ defineExpose({ filings, loading, error, fetchFilings, edgarIndexUrl })
 .eqv4-edgar-link {
   color: var(--pd-accent, #7c3aed);
   text-decoration: none;
-  font-size: 11px;
+  font-size: 13px;
 }
 .eqv4-edgar-link:hover { text-decoration: underline; }
 .eqv4-edgar-raw-link {
   color: var(--text-muted, #64748b);
-  font-size: 10px;
+  font-size: 11px;
   text-decoration: none;
   margin-left: 5px;
   flex-shrink: 0;

--- a/client/src/components/widgets/EQV4StockSplitsCard.vue
+++ b/client/src/components/widgets/EQV4StockSplitsCard.vue
@@ -127,7 +127,7 @@ defineExpose({ splits, loading, error, fetchSplits })
   flex-shrink: 0;
 }
 .eqv4-splits-label {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--text-muted, #64748b);
   text-transform: uppercase;
@@ -156,7 +156,7 @@ defineExpose({ splits, loading, error, fetchSplits })
   border: none;
   color: var(--text-muted, #64748b);
   cursor: pointer;
-  font-size: 11px;
+  font-size: 13px;
   padding: 0 2px;
   line-height: 1;
 }
@@ -189,7 +189,7 @@ defineExpose({ splits, loading, error, fetchSplits })
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 13px;
   color: var(--text-muted, #64748b);
   font-style: italic;
   padding: 8px;
@@ -201,7 +201,7 @@ defineExpose({ splits, loading, error, fetchSplits })
   align-items: center;
   justify-content: center;
   gap: 6px;
-  font-size: 11px;
+  font-size: 13px;
   color: #ef4444;
   padding: 8px;
 }
@@ -233,7 +233,7 @@ defineExpose({ splits, loading, error, fetchSplits })
 }
 .eqv4-splits-row:hover { background: var(--surface, #141420); }
 .eqv4-std {
-  font-size: 11px;
+  font-size: 13px;
   padding: 0 4px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/client/src/components/widgets/EQV4TickerEventsCard.vue
+++ b/client/src/components/widgets/EQV4TickerEventsCard.vue
@@ -142,7 +142,7 @@ defineExpose({ events, transitions, entityName, loading, error, fetchEvents })
   overflow: hidden;
 }
 .eqv4-events-label {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--text-muted, #64748b);
   text-transform: uppercase;
@@ -180,7 +180,7 @@ defineExpose({ events, transitions, entityName, loading, error, fetchEvents })
   border: none;
   color: var(--text-muted, #64748b);
   cursor: pointer;
-  font-size: 11px;
+  font-size: 13px;
   padding: 0 2px;
   line-height: 1;
 }
@@ -212,7 +212,7 @@ defineExpose({ events, transitions, entityName, loading, error, fetchEvents })
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 13px;
   color: var(--text-muted, #64748b);
   font-style: italic;
   padding: 8px;
@@ -224,7 +224,7 @@ defineExpose({ events, transitions, entityName, loading, error, fetchEvents })
   align-items: center;
   justify-content: center;
   gap: 6px;
-  font-size: 11px;
+  font-size: 13px;
   color: #ef4444;
   padding: 8px;
 }
@@ -256,7 +256,7 @@ defineExpose({ events, transitions, entityName, loading, error, fetchEvents })
 }
 .eqv4-events-row:hover { background: var(--surface, #141420); }
 .eqv4-evtd {
-  font-size: 11px;
+  font-size: 13px;
   padding: 0 4px;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

All four active cards (Company News, SEC EDGAR, Stock Splits, Ticker Events) used 11px for body text — data rows, empty/error states, search input, selects, links. Bumped to 13px per Tom's direction.

The `txt` raw-link in `EQV4SecEdgarCard` bumped from 10px to 11px specifically.

Column headers, article/filing counts, source attributions, subtitle text, and retry buttons remain at 10px — intentionally smaller as secondary UI elements.

CSS-only change. 283/283 passing.