### PR TITLE
feat(DailyRangeAlerts): new Range Alerts widget for HOD/LOD alert feed

### DIFF
--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -36,6 +36,7 @@ const availableWidgets = [
   { type: 'quote', label: 'Mini Quote', icon: '⚡' },
   { type: 'enhanced-quote', label: 'Quote', icon: '✨' },
   { type: 'enhanced-quote-v4', label: 'Enhanced Quote', icon: '💎' },
+  { type: 'range-alerts', label: 'Range Alerts', icon: '🔔' },
 ]
 
 const selectWidget = (widget) => {

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -72,6 +72,7 @@ import NewsFeed from './widgets/NewsFeed.vue'
 import Quote from './widgets/Quote.vue'
 import EnhancedQuoteV3 from './widgets/EnhancedQuoteV3.vue'
 import EnhancedQuoteV4 from './widgets/EnhancedQuoteV4.vue'
+import DailyRangeAlerts from './widgets/DailyRangeAlerts.vue'
 import { LINK_COLORS, LINK_COLOR_MAP } from '@/composables/useWidgetBus.js'
 
 const props = defineProps({
@@ -95,6 +96,7 @@ const widgetComponents = {
   'enhanced-quote':    EnhancedQuoteV3,
   'enhanced-quote-v3': EnhancedQuoteV3,  // backward-compat alias
   'enhanced-quote-v4': EnhancedQuoteV4,
+  'range-alerts':      DailyRangeAlerts,
 }
 
 const widgetComponent = computed(() => widgetComponents[props.widgetType])

--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -1,0 +1,647 @@
+<template>
+  <div class="range-alerts-widget">
+    <!-- Gear button toggles controls panel -->
+    <div class="controls-toggle">
+      <button class="col-menu-btn" @click="showControls = !showControls" title="Settings">⚙️</button>
+    </div>
+
+    <!-- Collapsible controls panel (collapsed by default) -->
+    <div v-if="showControls" class="controls-panel">
+      <!-- Section 1: Feed configuration (destructive) -->
+      <div class="controls-section controls-section--destructive">
+        <span class="section-label">Feed</span>
+        <select v-model="feedLocal" class="filter-select">
+          <option value="hod">HOD — High of Day</option>
+          <option value="lod">LOD — Low of Day</option>
+        </select>
+        <label class="filter-label">Max Events</label>
+        <input
+          type="number"
+          step="1"
+          :value="maxEventsInput"
+          @input="maxEventsInput = $event.target.value"
+          @change="onMaxEventsBlur"
+          class="filter-input filter-input--narrow"
+          data-testid="max-events-input"
+        />
+        <span class="helper-text">⚠️ Changing max events clears current data</span>
+      </div>
+
+      <!-- Section 2: View filters (reversible) -->
+      <div class="controls-section">
+        <label class="filter-label">Session</label>
+        <select v-model="sessionFilterLocal" class="filter-select">
+          <option value="">Any</option>
+          <option value="pre">Pre-market</option>
+          <option value="regular">Regular</option>
+          <option value="after">After-hours</option>
+        </select>
+
+        <label class="filter-label">Min Price</label>
+        <input type="number" v-model="minPriceLocal" @change="emitSettings" placeholder="Min $" class="filter-input filter-input--narrow" />
+        <label class="filter-label">Max Price</label>
+        <input type="number" v-model="maxPriceLocal" @change="emitSettings" placeholder="Max $" class="filter-input filter-input--narrow" />
+
+        <label class="filter-label">Min Volume</label>
+        <input type="text" v-model="minVolumeInput" @change="onShareCountChange" placeholder="e.g. 1 M" class="filter-input" />
+        <label class="filter-label">Min Rel Vol</label>
+        <input type="number" v-model="minRelVolLocal" @change="emitSettings" placeholder="Min Rel Vol" class="filter-input filter-input--narrow" />
+        <label class="filter-label">Min Avg Vol</label>
+        <input type="text" v-model="minAvgVolInput" @change="onShareCountChange" placeholder="e.g. 5 M" class="filter-input" />
+
+        <label class="filter-label">Min Float</label>
+        <input type="text" v-model="minFloatInput" @change="onShareCountChange" placeholder="e.g. 1 M" class="filter-input" />
+        <label class="filter-label">Max Float</label>
+        <input type="text" v-model="maxFloatInput" @change="onShareCountChange" placeholder="e.g. 100 M" class="filter-input" />
+
+        <label class="filter-label">{{ feedLocal === 'hod' ? 'Min Change %' : 'Max Change %' }}</label>
+        <input type="number" v-model="pctChangeLocal" @change="emitSettings" :placeholder="feedLocal === 'hod' ? 'Min %' : 'Max %'" class="filter-input filter-input--narrow" />
+      </div>
+
+      <!-- Column visibility gear -->
+      <div class="col-menu-wrap">
+        <div class="col-menu-title">Columns</div>
+        <label v-for="col in columns" :key="col.key" class="col-menu-item">
+          <input
+            type="checkbox"
+            :checked="!hiddenColsLocal.includes(col.key)"
+            :disabled="col.key === 'symbol'"
+            @change="toggleCol(col.key, $event.target.checked)"
+          />
+          {{ col.label }}
+        </label>
+      </div>
+    </div>
+
+    <!-- Table -->
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th
+              v-for="col in visibleColumns"
+              :key="col.key"
+              :style="colStyle(col)"
+              style="position: relative;"
+            >
+              {{ col.label }}
+              <span
+                v-if="!isLocked"
+                class="col-resize-handle"
+                @mousedown.prevent="startResize($event, col.key)"
+                title="Drag to resize"
+              ></span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="filteredEvents.length === 0">
+            <td :colspan="visibleColumns.length" class="empty-state">
+              {{ events.length === 0 ? 'No alerts yet' : 'No events match your filters' }}
+            </td>
+          </tr>
+          <tr
+            v-for="row in filteredEvents"
+            :key="row._seq"
+            :class="{ 'row-active': activeTicker === row.symbol }"
+            @click="onRowClick(row)"
+          >
+            <td v-for="col in visibleColumns" :key="col.key" :class="getCellClass(col, row)">
+              {{ formatCell(col, row) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onUnmounted } from 'vue'
+import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+import { parseShareCount } from '@/utils/parseShareCount.js'
+
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  colWidths: { type: Object,  default: () => ({}) },
+  linkColor: { type: String,  default: null },
+  isMobile:  { type: Boolean, default: false },
+  settings:  { type: Object,  default: () => ({}) },
+})
+
+const emit = defineEmits(['update-settings', 'update-col-widths'])
+
+const appConfig = window.__APP_CONFIG__ || {}
+
+const DEFAULT_SETTINGS = {
+  feed:               'hod',
+  maxEvents:          100,
+  sessionFilter:      null,
+  minPrice:           null,
+  maxPrice:           null,
+  minVolume:          null,
+  minRelVol:          null,
+  minAvgVol:          null,
+  minFloat:           null,
+  maxFloat:           null,
+  pctChangeThreshold: null,
+  hiddenCols:         [],
+  colWidths:          {},
+}
+
+const FEED_MAP = {
+  hod: { feedName: 'daily_range_hod_alert', cacheKey: 'daily_range_hod_alert' },
+  lod: { feedName: 'daily_range_lod_alert', cacheKey: 'daily_range_lod_alert' },
+}
+
+const config = computed(() => ({ ...DEFAULT_SETTINGS, ...props.settings }))
+
+// ── In-memory event store ─────────────────────────────────────────────────────
+// _seq must be declared inside <script setup> (per-instance, not module scope)
+let _seq = 0
+const events = ref([])
+
+const enforceMaxEvents = () => {
+  const maxEv = config.value.maxEvents
+  if (maxEv > 0 && events.value.length > maxEv) {
+    events.value = events.value.slice(0, maxEv)
+  }
+}
+
+// ── WebSocket ─────────────────────────────────────────────────────────────────
+const initFeed = FEED_MAP[config.value.feed] || FEED_MAP.hod
+
+const { lastDataAt, isConnected, reconnecting, feedName, cacheKey, connect, disconnect } =
+  useWebSocketClient({
+    wsUrl:    appConfig.wsEndpoint || 'ws://localhost:4202/ws',
+    authKey:  appConfig.apiKey     || 'secret',
+    feedName: initFeed.feedName,
+    cacheKey: initFeed.cacheKey,
+    onData: (data) => {
+      if (Array.isArray(data)) {
+        // Cache hydration — sort timestamp DESC, then assign _seq
+        const sorted = [...data].sort((a, b) => b.timestamp - a.timestamp)
+        events.value = sorted.map(e => ({ ...e, _seq: _seq++ }))
+      } else {
+        // Live event — prepend
+        events.value.unshift({ ...data, _seq: _seq++ })
+      }
+      enforceMaxEvents()
+    },
+    autoConnect: true,
+  })
+
+defineExpose({ lastDataAt, isConnected, reconnecting })
+
+// ── Feed switching ────────────────────────────────────────────────────────────
+watch(() => config.value.feed, (newFeed) => {
+  const feed = FEED_MAP[newFeed] || FEED_MAP.hod
+  disconnect()
+  _seq = 0
+  events.value = []
+  feedName.value = feed.feedName
+  cacheKey.value = feed.cacheKey
+  connect()
+}, { immediate: false })
+
+// ── Filtering ─────────────────────────────────────────────────────────────────
+const filteredEvents = computed(() => {
+  const c = config.value
+  return events.value.filter(e => {
+    if (c.sessionFilter !== null && e.session !== c.sessionFilter) return false
+    if (c.minPrice !== null && e.price < c.minPrice) return false
+    if (c.maxPrice !== null && e.price > c.maxPrice) return false
+    if (c.minVolume !== null && e.accumulated_volume < c.minVolume) return false
+    if (c.minRelVol !== null && e.relative_volume < c.minRelVol) return false
+    if (c.minAvgVol !== null && e.avg_volume < c.minAvgVol) return false
+    if (c.minFloat !== null && e.free_float < c.minFloat) return false
+    if (c.maxFloat !== null && e.free_float > c.maxFloat) return false
+    if (c.pctChangeThreshold !== null) {
+      if (c.feed === 'hod' && e.pct_change < c.pctChangeThreshold) return false
+      if (c.feed === 'lod' && e.pct_change > c.pctChangeThreshold) return false
+    }
+    return true
+  })
+})
+
+// ── Row click / scanner link ──────────────────────────────────────────────────
+const { activeTicker, onRowClick } = useScannerLink(computed(() => props.linkColor))
+
+// ── Column definitions ────────────────────────────────────────────────────────
+const toNum = (val) => {
+  const n = Number(val)
+  return Number.isFinite(n) ? n : 0
+}
+
+const formatVolume = (vol) => {
+  const v = toNum(vol)
+  if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`
+  if (v >= 1_000_000)     return `${(v / 1_000_000).toFixed(1)}M`
+  if (v >= 1_000)         return `${(v / 1_000).toFixed(1)}K`
+  return v.toString()
+}
+
+const columns = [
+  // Default visible
+  {
+    key: 'timestamp',
+    label: 'Time',
+    format: (val) => val == null ? '' : new Date(val * 1000).toLocaleTimeString('en-US', {
+      timeZone: 'America/New_York',
+      hour12: false,
+    }),
+  },
+  { key: 'symbol', label: 'Symbol' },
+  { key: 'price',    label: 'Alert $', decimals: 2 },
+  { key: 'previous', label: 'Prev $',  decimals: 2 },
+  { key: 'note',     label: 'Note' },
+  {
+    key: 'pct_change',
+    label: 'Change %',
+    format: (val) => { const v = toNum(val); return `${v >= 0 ? '+' : ''}${v.toFixed(2)}%` },
+    cellClass: (row) => toNum(row.pct_change) >= 0 ? 'positive' : 'negative',
+  },
+  { key: 'accumulated_volume', label: 'Volume',   format: (val) => formatVolume(val) },
+  { key: 'relative_volume',    label: 'Rel Vol',  format: (val) => `${toNum(val).toFixed(2)}x` },
+  { key: 'session',            label: 'Session' },
+  // Optional (hidden by default)
+  { key: 'close',               label: 'Price (quote)',      decimals: 2 },
+  {
+    key: 'change',
+    label: 'Change $',
+    format: (val) => { const v = toNum(val); return `${v >= 0 ? '+' : ''}${v.toFixed(2)}` },
+    cellClass: (row) => toNum(row.change) >= 0 ? 'positive' : 'negative',
+  },
+  {
+    key: 'pct_change_since_open',
+    label: 'Change % (Open)',
+    format: (val) => { const v = toNum(val); return `${v >= 0 ? '+' : ''}${v.toFixed(2)}%` },
+    cellClass: (row) => toNum(row.pct_change_since_open) >= 0 ? 'positive' : 'negative',
+  },
+  { key: 'free_float',    label: 'Float',    format: (val) => formatVolume(val) },
+  { key: 'avg_volume',    label: 'Avg Vol',  format: (val) => formatVolume(val) },
+  { key: 'vwap',          label: 'VWAP',     decimals: 2 },
+  { key: 'prev_day_close', label: 'PD Close', decimals: 2 },
+  { key: 'direction',     label: 'Direction' },
+]
+
+// ── Column widths & resize ────────────────────────────────────────────────────
+const localColWidths = ref({ ...props.colWidths })
+watch(() => props.colWidths, (v) => { if (v) localColWidths.value = { ...v } })
+
+const colStyle = (col) => {
+  const w = localColWidths.value[col.key]
+  return w ? { width: `${w}px`, minWidth: `${w}px` } : {}
+}
+
+let resizeState = null
+const startResize = (e, colKey) => {
+  if (props.isLocked) return
+  const startWidth = localColWidths.value[colKey] || e.target.closest('th')?.offsetWidth || 80
+  resizeState = { colKey, startX: e.clientX, startWidth }
+  const onMove = (me) => {
+    if (!resizeState) return
+    const newWidth = Math.max(40, resizeState.startWidth + me.clientX - resizeState.startX)
+    localColWidths.value = { ...localColWidths.value, [resizeState.colKey]: newWidth }
+  }
+  const onUp = () => {
+    resizeState = null
+    document.removeEventListener('mousemove', onMove)
+    document.removeEventListener('mouseup', onUp)
+    emit('update-col-widths', { ...localColWidths.value })
+    emitSettings()
+  }
+  document.addEventListener('mousemove', onMove)
+  document.addEventListener('mouseup', onUp)
+}
+onUnmounted(() => { resizeState = null })
+
+// ── Column visibility ─────────────────────────────────────────────────────────
+const hiddenColsLocal = ref([...(config.value.hiddenCols ?? [])])
+
+const visibleColumns = computed(() =>
+  columns.filter(col => !hiddenColsLocal.value.includes(col.key))
+)
+
+const toggleCol = (key, visible) => {
+  if (key === 'symbol') return
+  if (visible) {
+    hiddenColsLocal.value = hiddenColsLocal.value.filter(k => k !== key)
+  } else {
+    if (!hiddenColsLocal.value.includes(key)) {
+      hiddenColsLocal.value = [...hiddenColsLocal.value, key]
+    }
+  }
+  emitSettings()
+}
+
+// ── Cell helpers ──────────────────────────────────────────────────────────────
+const getCellClass = (col, row) => {
+  const classes = [col.key]
+  if (col.cellClass) {
+    const custom = typeof col.cellClass === 'function' ? col.cellClass(row) : col.cellClass
+    classes.push(custom)
+  }
+  return classes
+}
+
+const formatCell = (col, row) => {
+  const value = row[col.key]
+  if (value == null) return ''
+  if (col.format) return col.format(value, row)
+  if (col.decimals !== undefined) {
+    const num = Number(value)
+    return Number.isFinite(num) ? num.toFixed(col.decimals) : ''
+  }
+  return value
+}
+
+// ── Local filter state (for controls) ────────────────────────────────────────
+const feedLocal          = ref(config.value.feed)
+const prevMaxEvents      = ref(config.value.maxEvents)
+const maxEventsInput     = ref(config.value.maxEvents)
+const sessionFilterLocal = ref(config.value.sessionFilter ?? '')
+const minPriceLocal      = ref(config.value.minPrice !== null ? String(config.value.minPrice) : '')
+const maxPriceLocal      = ref(config.value.maxPrice !== null ? String(config.value.maxPrice) : '')
+const minVolumeInput     = ref(config.value.minVolume !== null ? String(config.value.minVolume) : '')
+const minRelVolLocal     = ref(config.value.minRelVol !== null ? String(config.value.minRelVol) : '')
+const minAvgVolInput     = ref(config.value.minAvgVol !== null ? String(config.value.minAvgVol) : '')
+const minFloatInput      = ref(config.value.minFloat !== null ? String(config.value.minFloat) : '')
+const maxFloatInput      = ref(config.value.maxFloat !== null ? String(config.value.maxFloat) : '')
+const pctChangeLocal     = ref(config.value.pctChangeThreshold !== null ? String(config.value.pctChangeThreshold) : '')
+
+// UI state
+const showControls = ref(false)
+
+// ── Sync local refs when settings prop changes ────────────────────────────────
+watch(() => props.settings, (s) => {
+  const merged = { ...DEFAULT_SETTINGS, ...s }
+  feedLocal.value          = merged.feed
+  prevMaxEvents.value      = merged.maxEvents
+  maxEventsInput.value     = merged.maxEvents
+  sessionFilterLocal.value = merged.sessionFilter ?? ''
+  minPriceLocal.value      = merged.minPrice !== null ? String(merged.minPrice) : ''
+  maxPriceLocal.value      = merged.maxPrice !== null ? String(merged.maxPrice) : ''
+  minVolumeInput.value     = merged.minVolume !== null ? String(merged.minVolume) : ''
+  minRelVolLocal.value     = merged.minRelVol !== null ? String(merged.minRelVol) : ''
+  minAvgVolInput.value     = merged.minAvgVol !== null ? String(merged.minAvgVol) : ''
+  minFloatInput.value      = merged.minFloat !== null ? String(merged.minFloat) : ''
+  maxFloatInput.value      = merged.maxFloat !== null ? String(merged.maxFloat) : ''
+  pctChangeLocal.value     = merged.pctChangeThreshold !== null ? String(merged.pctChangeThreshold) : ''
+  hiddenColsLocal.value    = [...merged.hiddenCols]
+})
+
+// ── Settings persistence ──────────────────────────────────────────────────────
+const toNullableNum = (str) => {
+  if (str === '' || str === null || str === undefined) return null
+  const n = Number(str)
+  return Number.isFinite(n) ? n : null
+}
+
+const emitSettings = () => {
+  emit('update-settings', {
+    feed:               feedLocal.value,
+    maxEvents:          prevMaxEvents.value,
+    sessionFilter:      sessionFilterLocal.value || null,
+    minPrice:           toNullableNum(minPriceLocal.value),
+    maxPrice:           toNullableNum(maxPriceLocal.value),
+    minVolume:          parseShareCount(minVolumeInput.value),
+    minRelVol:          toNullableNum(minRelVolLocal.value),
+    minAvgVol:          parseShareCount(minAvgVolInput.value),
+    minFloat:           parseShareCount(minFloatInput.value),
+    maxFloat:           parseShareCount(maxFloatInput.value),
+    pctChangeThreshold: toNullableNum(pctChangeLocal.value),
+    hiddenCols:         hiddenColsLocal.value,
+    colWidths:          { ...localColWidths.value },
+  })
+}
+
+// Emit whenever non-immediate filter controls change
+watch(
+  [feedLocal, sessionFilterLocal, pctChangeLocal,
+   () => [...hiddenColsLocal.value]],
+  () => { emitSettings() }
+)
+
+// ── maxEvents input validation ────────────────────────────────────────────────
+const onMaxEventsBlur = () => {
+  const raw = String(maxEventsInput.value).trim()
+  if (raw === '') {
+    maxEventsInput.value = prevMaxEvents.value
+    return
+  }
+  const n = Number(raw)
+  if (!Number.isFinite(n)) {
+    maxEventsInput.value = prevMaxEvents.value
+    return
+  }
+  const clamped = Math.max(0, Math.min(100_000, Math.floor(n)))
+  maxEventsInput.value = clamped
+  prevMaxEvents.value = clamped
+  emitSettings()
+}
+
+// ── parseShareCount input handlers ───────────────────────────────────────────
+const onShareCountChange = () => emitSettings()
+
+
+</script>
+
+<style scoped>
+.range-alerts-widget {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.controls-toggle {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 6px;
+  background: #2a2a2a;
+  border-bottom: 1px solid #333;
+}
+
+.col-menu-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.col-menu-btn:hover { background: #3a3a3a; }
+
+.controls-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  background: #1e1e1e;
+  border-bottom: 1px solid #333;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.controls-section {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.controls-section--destructive {
+  background: #3a2a2a;
+}
+
+.section-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-right: 4px;
+}
+
+.filter-label {
+  font-size: 12px;
+  color: #aaa;
+  white-space: nowrap;
+}
+
+.filter-select {
+  padding: 4px 8px;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.filter-input {
+  padding: 4px 8px;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-size: 12px;
+  min-width: 80px;
+}
+
+.filter-input--narrow {
+  min-width: 60px;
+  max-width: 90px;
+}
+
+.filter-input:focus { outline: none; border-color: #8b5cf6; }
+
+.helper-text {
+  font-size: 11px;
+  color: #f87171;
+}
+
+.col-menu-wrap {
+  padding: 8px 10px;
+}
+
+.col-menu-title {
+  font-size: 11px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.col-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #ccc;
+  padding: 3px 0;
+  cursor: pointer;
+  user-select: none;
+}
+.col-menu-item input { cursor: pointer; }
+.col-menu-item:has(input:disabled) { opacity: 0.4; cursor: default; }
+
+/* ── Table ── */
+.table-container {
+  flex: 1;
+  overflow-y: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th {
+  user-select: none;
+  background: #2d2d2d;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+  border-bottom: 1px solid #333;
+  white-space: nowrap;
+}
+
+td {
+  padding: 2px 8px;
+  font-size: 13px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+tr:hover {
+  background: #2a2a2a;
+}
+
+/* ── Column resize handle ── */
+.col-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  user-select: none;
+  z-index: 1;
+}
+.col-resize-handle:hover,
+.col-resize-handle:active {
+  background: rgba(139, 92, 246, 0.5);
+}
+
+/* ── Cell classes ── */
+.pct_change.positive,
+.change.positive,
+.pct_change_since_open.positive { color: #4ade80; }
+
+.pct_change.negative,
+.change.negative,
+.pct_change_since_open.negative { color: #f87171; }
+
+.symbol { font-weight: 600; color: #fff; }
+
+/* ── Active row ── */
+tr.row-active { outline: 1px solid #a78bfa; outline-offset: -1px; background: transparent !important; }
+
+/* ── Empty state ── */
+.empty-state {
+  text-align: center;
+  padding: 24px;
+  color: #555;
+  font-size: 13px;
+}
+</style>

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -1,0 +1,675 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+// ── Mock useWebSocketClient ───────────────────────────────────────────────────
+vi.mock('@/composables/useWebSocketClient.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useWebSocketClient: vi.fn((config) => ({
+      lastDataAt:  ref(null),
+      isConnected: ref(true),
+      reconnecting: ref(false),
+      feedName:    ref(config.feedName || ''),
+      cacheKey:    ref(config.cacheKey || ''),
+      connect:     vi.fn(),
+      disconnect:  vi.fn(),
+    })),
+  }
+})
+
+// ── Mock useScannerLink ───────────────────────────────────────────────────────
+vi.mock('@/composables/useScannerLink.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useScannerLink: vi.fn(() => ({
+      activeTicker: ref(null),
+      onRowClick:   vi.fn(),
+    })),
+  }
+})
+
+import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import DailyRangeAlerts from '../DailyRangeAlerts.vue'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const defaultProps = {
+  isLocked:  true,
+  colWidths: {},
+  linkColor: null,
+  isMobile:  false,
+  settings:  {},
+}
+
+function makeEvent(overrides = {}) {
+  return {
+    symbol:             'AAPL',
+    timestamp:          1_000_000,
+    price:              10,
+    previous:           9,
+    note:               '',
+    pct_change:         10,
+    accumulated_volume: 1_000_000,
+    relative_volume:    2,
+    session:            'regular',
+    avg_volume:         500_000,
+    free_float:         10_000_000,
+    change:             1,
+    close:              10,
+    direction:          'high',
+    ...overrides,
+  }
+}
+
+function getOnData(callIndex = 0) {
+  return vi.mocked(useWebSocketClient).mock.calls[callIndex][0].onData
+}
+
+function getWsReturn(callIndex = 0) {
+  return vi.mocked(useWebSocketClient).mock.results[callIndex].value
+}
+
+function countDataRows(wrapper) {
+  // data rows appear when filteredEvents.length > 0 (empty-state row hidden)
+  const trs = wrapper.findAll('tbody tr')
+  if (trs.length === 0) return 0
+  // If the only row is the empty-state, return 0
+  if (trs.length === 1 && trs[0].find('.empty-state').exists()) return 0
+  return trs.length
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── Filter isolation tests ────────────────────────────────────────────────────
+
+describe('Filter isolation', () => {
+  test('minPrice excludes events where price < threshold', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { minPrice: 5 } },
+    })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'LOW', price: 3 }), makeEvent({ symbol: 'HIGH', price: 7 })])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('HIGH')
+    expect(wrapper.text()).not.toContain('LOW')
+    wrapper.unmount()
+  })
+
+  test('maxPrice excludes events where price > threshold', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { maxPrice: 10 } },
+    })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'OK', price: 8 }), makeEvent({ symbol: 'TOO_HIGH', price: 15 })])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('OK')
+    expect(wrapper.text()).not.toContain('TOO_HIGH')
+    wrapper.unmount()
+  })
+
+  test('minPrice === 0 is valid; all events with price >= 0 pass', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { minPrice: 0 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'FREE', price: 0 }),
+      makeEvent({ symbol: 'PAID', price: 5 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(2)
+    wrapper.unmount()
+  })
+
+  test('minVolume excludes events where accumulated_volume < threshold', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { minVolume: 1_000_000 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'LOWVOL', accumulated_volume: 500_000 }),
+      makeEvent({ symbol: 'HIVOL',  accumulated_volume: 2_000_000 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('HIVOL')
+    wrapper.unmount()
+  })
+
+  test('minRelVol excludes events where relative_volume < threshold', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { minRelVol: 3 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'LOWRV', relative_volume: 1.5 }),
+      makeEvent({ symbol: 'HIRV',  relative_volume: 5 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('HIRV')
+    wrapper.unmount()
+  })
+
+  test('minAvgVol excludes events where avg_volume < threshold', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { minAvgVol: 1_000_000 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'LOAVG', avg_volume: 100_000 }),
+      makeEvent({ symbol: 'HIAVG', avg_volume: 2_000_000 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('HIAVG')
+    wrapper.unmount()
+  })
+
+  test('minFloat excludes events where free_float < threshold', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { minFloat: 5_000_000 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'SMFL', free_float: 1_000_000 }),
+      makeEvent({ symbol: 'LGFL', free_float: 10_000_000 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('LGFL')
+    wrapper.unmount()
+  })
+
+  test('maxFloat excludes events where free_float > threshold', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { maxFloat: 5_000_000 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'SMFL', free_float: 1_000_000 }),
+      makeEvent({ symbol: 'LGFL', free_float: 10_000_000 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('SMFL')
+    wrapper.unmount()
+  })
+
+  test('sessionFilter "regular" includes only regular session events', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { sessionFilter: 'regular' } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'REG', session: 'regular' }),
+      makeEvent({ symbol: 'PRE', session: 'pre' }),
+      makeEvent({ symbol: 'AH',  session: 'after' }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('REG')
+    expect(wrapper.text()).not.toContain('PRE')
+    wrapper.unmount()
+  })
+
+  test('pctChangeThreshold HOD feed value 5 excludes events where pct_change < 5', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { feed: 'hod', pctChangeThreshold: 5 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'LOW', pct_change: 3 }),
+      makeEvent({ symbol: 'HIGH', pct_change: 8 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('HIGH')
+    wrapper.unmount()
+  })
+
+  test('pctChangeThreshold LOD feed value -5 excludes events where pct_change > -5', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { feed: 'lod', pctChangeThreshold: -5 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'ABOVE', pct_change: -2 }),   // -2 > -5, excluded
+      makeEvent({ symbol: 'BELOW', pct_change: -8 }),   // -8 <= -5, passes
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(1)
+    expect(wrapper.text()).toContain('BELOW')
+    expect(wrapper.text()).not.toContain('ABOVE')
+    wrapper.unmount()
+  })
+
+  test('pctChangeThreshold === 0 HOD: pct_change >= 0 passes, negative excluded', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { feed: 'hod', pctChangeThreshold: 0 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'ZERO', pct_change: 0 }),
+      makeEvent({ symbol: 'POS',  pct_change: 5 }),
+      makeEvent({ symbol: 'NEG',  pct_change: -1 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(2)
+    expect(wrapper.text()).toContain('ZERO')
+    expect(wrapper.text()).toContain('POS')
+    expect(wrapper.text()).not.toContain('NEG')
+    wrapper.unmount()
+  })
+
+  test('pctChangeThreshold === 0 LOD: pct_change <= 0 passes, positive excluded', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { feed: 'lod', pctChangeThreshold: 0 } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'ZERO', pct_change: 0 }),
+      makeEvent({ symbol: 'NEG',  pct_change: -5 }),
+      makeEvent({ symbol: 'POS',  pct_change: 1 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(2)
+    expect(wrapper.text()).toContain('ZERO')
+    expect(wrapper.text()).toContain('NEG')
+    expect(wrapper.text()).not.toContain('POS')
+    wrapper.unmount()
+  })
+
+  test('pctChangeThreshold === null disables filter; no events excluded', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { feed: 'hod', pctChangeThreshold: null } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'NEG', pct_change: -10 }),
+      makeEvent({ symbol: 'POS', pct_change: 10 }),
+    ])
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(2)
+    wrapper.unmount()
+  })
+})
+
+// ── Data flow tests ───────────────────────────────────────────────────────────
+
+describe('Data flow', () => {
+  test('cache hydration: events sorted timestamp DESC regardless of server order', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+
+    // Server sends in ascending order
+    onData([
+      makeEvent({ symbol: 'FIRST',  timestamp: 1000 }),
+      makeEvent({ symbol: 'SECOND', timestamp: 2000 }),
+      makeEvent({ symbol: 'THIRD',  timestamp: 3000 }),
+    ])
+    await nextTick()
+
+    const rows = wrapper.findAll('tbody tr')
+    // THIRD should be first (highest timestamp)
+    expect(rows[0].text()).toContain('THIRD')
+    expect(rows[1].text()).toContain('SECOND')
+    expect(rows[2].text()).toContain('FIRST')
+    wrapper.unmount()
+  })
+
+  test('live event prepend: new event appears at index 0', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+
+    // Hydrate with one event
+    onData([makeEvent({ symbol: 'OLD', timestamp: 1000 })])
+    await nextTick()
+
+    // Live event arrives
+    onData(makeEvent({ symbol: 'NEW', timestamp: 2000 }))
+    await nextTick()
+
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows[0].text()).toContain('NEW')
+    expect(rows[1].text()).toContain('OLD')
+    wrapper.unmount()
+  })
+
+  test('maxEvents cap value 3: when 4th event arrives oldest is dropped', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { maxEvents: 3 } },
+    })
+    const onData = getOnData()
+
+    // Hydrate with 3 events
+    onData([
+      makeEvent({ symbol: 'E1', timestamp: 1000 }),
+      makeEvent({ symbol: 'E2', timestamp: 2000 }),
+      makeEvent({ symbol: 'E3', timestamp: 3000 }),
+    ])
+    await nextTick()
+    expect(countDataRows(wrapper)).toBe(3)
+
+    // 4th live event arrives — oldest (E1) should be dropped
+    onData(makeEvent({ symbol: 'E4', timestamp: 4000 }))
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(3)
+    expect(wrapper.text()).toContain('E4')
+    expect(wrapper.text()).toContain('E3')
+    expect(wrapper.text()).toContain('E2')
+    expect(wrapper.text()).not.toContain('E1')
+    wrapper.unmount()
+  })
+
+  test('maxEvents === 0 is unlimited: events accumulate without cap', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { maxEvents: 0 } },
+    })
+    const onData = getOnData()
+
+    const manyEvents = Array.from({ length: 10 }, (_, i) =>
+      makeEvent({ symbol: `E${i}`, timestamp: i * 1000 })
+    )
+    onData(manyEvents)
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(10)
+    wrapper.unmount()
+  })
+
+  test('LOD widget connects to LOD feed on mount (not HOD)', () => {
+    // Regression: initFeed must use config.value.feed, not DEFAULT_SETTINGS.feed.
+    // A widget saved with feed: 'lod' must connect to daily_range_lod_alert on mount.
+    mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { feed: 'lod' } },
+    })
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[
+      vi.mocked(useWebSocketClient).mock.calls.length - 1
+    ][0]
+    expect(callArgs.feedName).toBe('daily_range_lod_alert')
+    expect(callArgs.cacheKey).toBe('daily_range_lod_alert')
+  })
+
+  test('HOD widget connects to HOD feed on mount', () => {
+    mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { feed: 'hod' } },
+    })
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[
+      vi.mocked(useWebSocketClient).mock.calls.length - 1
+    ][0]
+    expect(callArgs.feedName).toBe('daily_range_hod_alert')
+    expect(callArgs.cacheKey).toBe('daily_range_hod_alert')
+  })
+
+  test('feed switch: events cleared before reconnect', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { feed: 'hod' } },
+    })
+    const onData = getOnData()
+
+    // Inject some events
+    onData([makeEvent({ symbol: 'AAPL' }), makeEvent({ symbol: 'TSLA' })])
+    await nextTick()
+    expect(countDataRows(wrapper)).toBe(2)
+
+    // Switch feed — events should be cleared
+    await wrapper.setProps({ settings: { feed: 'lod' } })
+    await nextTick()
+
+    expect(countDataRows(wrapper)).toBe(0)
+    expect(wrapper.find('.empty-state').text()).toBe('No alerts yet')
+
+    // Verify disconnect and connect were called
+    const ws = getWsReturn(0)
+    expect(ws.disconnect).toHaveBeenCalled()
+    expect(ws.connect).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})
+
+// ── maxEvents input validation ────────────────────────────────────────────────
+
+describe('maxEvents input validation', () => {
+  async function getMaxEventsInput(wrapper) {
+    // Open controls panel first
+    await wrapper.find('.col-menu-btn').trigger('click')
+    await nextTick()
+    return wrapper.find('[data-testid="max-events-input"]')
+  }
+
+  // Note: wrapper.emitted() does not capture Vue emissions from <script setup> components
+  // in VTU 2.4.x / jsdom. The attrs listener pattern is used here intentionally.
+
+  test('input -1 is clamped to 0', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    const input = await getMaxEventsInput(wrapper)
+
+    // VTU's setValue dispatches both input and change events — no separate trigger needed
+    await input.setValue('-1')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    expect(settingsCalls[settingsCalls.length - 1].maxEvents).toBe(0)
+    wrapper.unmount()
+  })
+
+  test('input 100001 is clamped to 100000', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    const input = await getMaxEventsInput(wrapper)
+
+    await input.setValue('100001')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    expect(settingsCalls[settingsCalls.length - 1].maxEvents).toBe(100_000)
+    wrapper.unmount()
+  })
+
+  test('input 50 is stored as 50', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    const input = await getMaxEventsInput(wrapper)
+
+    await input.setValue('50')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    expect(settingsCalls[settingsCalls.length - 1].maxEvents).toBe(50)
+    wrapper.unmount()
+  })
+
+  test('input 0 is stored as 0 (unlimited)', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    const input = await getMaxEventsInput(wrapper)
+
+    await input.setValue('0')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    expect(settingsCalls[settingsCalls.length - 1].maxEvents).toBe(0)
+    wrapper.unmount()
+  })
+
+  test('empty input reverts to prior valid value — no new emission', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { maxEvents: 50 } },
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    const input = await getMaxEventsInput(wrapper)
+    const countBefore = settingsCalls.length
+
+    // setValue dispatches input + change; empty triggers revert path (no emit)
+    await input.setValue('')
+    await nextTick()
+
+    expect(settingsCalls.length).toBe(countBefore)
+    wrapper.unmount()
+  })
+
+  test('NaN input reverts to prior valid value — no new emission', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { maxEvents: 75 } },
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    const input = await getMaxEventsInput(wrapper)
+    const countBefore = settingsCalls.length
+
+    // setValue dispatches input + change; NaN triggers revert path (no emit)
+    await input.setValue('not-a-number')
+    await nextTick()
+
+    expect(settingsCalls.length).toBe(countBefore)
+    wrapper.unmount()
+  })
+})
+
+// ── _seq uniqueness and per-instance scope ────────────────────────────────────
+
+describe('_seq uniqueness and per-instance scope', () => {
+  test('two events with identical data get distinct _seq values (both rows rendered)', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData(0)
+
+    const identical = makeEvent({ symbol: 'AAPL', timestamp: 1000, direction: 'high' })
+    onData([identical, identical])
+    await nextTick()
+
+    // Both events must appear as separate rows (proves distinct _seq keys)
+    expect(countDataRows(wrapper)).toBe(2)
+    wrapper.unmount()
+  })
+
+  test('two independently mounted instances each start _seq from 0', async () => {
+    const w1 = mount(DailyRangeAlerts, { props: defaultProps })
+    const w2 = mount(DailyRangeAlerts, { props: defaultProps })
+
+    const onData1 = getOnData(0)
+    const onData2 = getOnData(1)
+
+    // Instance 1: 3 events
+    onData1([
+      makeEvent({ symbol: 'A1', timestamp: 3000 }),
+      makeEvent({ symbol: 'A2', timestamp: 2000 }),
+      makeEvent({ symbol: 'A3', timestamp: 1000 }),
+    ])
+    // Instance 2: 2 events (after instance 1 has consumed _seq 0, 1, 2 if module-scoped)
+    onData2([
+      makeEvent({ symbol: 'B1', timestamp: 2000 }),
+      makeEvent({ symbol: 'B2', timestamp: 1000 }),
+    ])
+    await nextTick()
+
+    // Each instance should render exactly its own events independently
+    expect(countDataRows(w1)).toBe(3)
+    expect(countDataRows(w2)).toBe(2)
+
+    w1.unmount()
+    w2.unmount()
+  })
+})
+
+// ── Column resize persistence (DOM/integration test) ─────────────────────────
+
+describe('Column resize', () => {
+  // DOM/integration test: dragging a column handle emits update-col-widths and update-settings
+  // Note: wrapper.emitted() does not capture Vue emissions from <script setup> in VTU 2.4.x.
+  // Using attrs listener pattern instead.
+  test('dragging resize handle emits update-col-widths and update-settings with colWidths', async () => {
+    const colWidthsCalls = []
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, isLocked: false },
+      attrs: {
+        'onUpdate-col-widths': (w) => colWidthsCalls.push(w),
+        'onUpdate-settings': (s) => settingsCalls.push(s),
+      },
+      attachTo: document.body,
+    })
+
+    const th = wrapper.findAll('th')[0]
+    const handle = th.find('.col-resize-handle')
+    expect(handle.exists()).toBe(true)
+
+    // mousedown on handle
+    await handle.trigger('mousedown', { clientX: 100 })
+
+    // mousemove on document (simulates drag)
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, bubbles: true }))
+
+    // mouseup on document (simulates release)
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+
+    await nextTick()
+
+    expect(colWidthsCalls.length).toBeGreaterThan(0)
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    expect(settingsCalls[settingsCalls.length - 1]).toHaveProperty('colWidths')
+
+    wrapper.unmount()
+  })
+})
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe('Empty state', () => {
+  test('events empty and connected renders "No alerts yet"', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await nextTick()
+
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+    expect(wrapper.find('.empty-state').text()).toBe('No alerts yet')
+    wrapper.unmount()
+  })
+
+  test('events present but all filtered renders "No events match your filters"', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { minPrice: 100 } },
+    })
+    const onData = getOnData()
+
+    // Inject events that all fail the minPrice filter
+    onData([makeEvent({ symbol: 'CHEAP', price: 5 })])
+    await nextTick()
+
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+    expect(wrapper.find('.empty-state').text()).toBe('No events match your filters')
+    wrapper.unmount()
+  })
+})

--- a/client/src/utils/__tests__/parseShareCount.spec.js
+++ b/client/src/utils/__tests__/parseShareCount.spec.js
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'vitest'
+import { parseShareCount } from '../parseShareCount.js'
+
+describe('parseShareCount', () => {
+  // ── Valid shorthand ───────────────────────────────────────────────────────
+
+  test('"5 M" returns 5_000_000', () => {
+    expect(parseShareCount('5 M')).toBe(5_000_000)
+  })
+
+  test('"250 K" returns 250_000', () => {
+    expect(parseShareCount('250 K')).toBe(250_000)
+  })
+
+  test('"0.5 M" returns 500_000', () => {
+    expect(parseShareCount('0.5 M')).toBe(500_000)
+  })
+
+  test('"1.5 B" returns 1_500_000_000', () => {
+    expect(parseShareCount('1.5 B')).toBe(1_500_000_000)
+  })
+
+  test('"1 K" returns 1_000 (exactly at minimum)', () => {
+    expect(parseShareCount('1 K')).toBe(1_000)
+  })
+
+  // ── Invalid shorthand (return null) ──────────────────────────────────────
+
+  test('"0.5 K" returns null (500 < 1,000)', () => {
+    expect(parseShareCount('0.5 K')).toBeNull()
+  })
+
+  test('"1K" returns null (no space between number and suffix)', () => {
+    expect(parseShareCount('1K')).toBeNull()
+  })
+
+  test('"5 X" returns null (unknown suffix)', () => {
+    expect(parseShareCount('5 X')).toBeNull()
+  })
+
+  test('"5 m" returns null (lowercase suffix — case-sensitive)', () => {
+    expect(parseShareCount('5 m')).toBeNull()
+  })
+
+  // ── Valid raw ─────────────────────────────────────────────────────────────
+
+  test('"5000000" returns 5_000_000', () => {
+    expect(parseShareCount('5000000')).toBe(5_000_000)
+  })
+
+  test('"0" returns 0', () => {
+    expect(parseShareCount('0')).toBe(0)
+  })
+
+  test('"  250000  " returns 250_000 (whitespace stripped)', () => {
+    expect(parseShareCount('  250000  ')).toBe(250_000)
+  })
+
+  // ── Invalid input (return null) ───────────────────────────────────────────
+
+  test('"abc" returns null', () => {
+    expect(parseShareCount('abc')).toBeNull()
+  })
+
+  test('"" (empty string) returns null', () => {
+    expect(parseShareCount('')).toBeNull()
+  })
+
+  test('null returns null', () => {
+    expect(parseShareCount(null)).toBeNull()
+  })
+
+  test('undefined returns null', () => {
+    expect(parseShareCount(undefined)).toBeNull()
+  })
+})

--- a/client/src/utils/parseShareCount.js
+++ b/client/src/utils/parseShareCount.js
@@ -1,0 +1,34 @@
+/**
+ * Parse a user-entered share count string. Returns a number or null.
+ *
+ * Format 1 — shorthand: "{number} {suffix}" (space required)
+ *   Suffix: K (×1,000), M (×1,000,000), B (×1,000,000,000) — case-sensitive
+ *   Minimum parsed result: 1,000. Below 1,000 → null.
+ *   No space between number and suffix → null.
+ *   Unknown suffix → null.
+ *
+ * Format 2 — raw: a plain number string (no suffix)
+ *   Integer or decimal, any value ≥ 0. Leading/trailing whitespace stripped.
+ *   0 is valid and returns 0.
+ *
+ * Invalid input → null.
+ */
+export function parseShareCount(input) {
+  if (input == null) return null
+  const str = String(input).trim()
+  if (!str) return null
+
+  // Shorthand: "{number} {suffix}" — space required between number and suffix
+  const shorthand = str.match(/^(\d+(?:\.\d+)?)\s+(K|M|B)$/)
+  if (shorthand) {
+    const num = parseFloat(shorthand[1])
+    const multipliers = { K: 1_000, M: 1_000_000, B: 1_000_000_000 }
+    const result = num * multipliers[shorthand[2]]
+    return result >= 1_000 ? result : null
+  }
+
+  // Raw number (no suffix)
+  const raw = Number(str)
+  if (!Number.isFinite(raw) || raw < 0) return null
+  return raw
+}


### PR DESCRIPTION
## Summary

New `DailyRangeAlerts` widget (`range-alerts` type) that subscribes to the HOD or LOD alert feed from `kuhl-haus-mdp` and displays a live, filterable event log. One component handles both feeds — the user picks HOD or LOD in settings.

## Changes

- `DailyRangeAlerts.vue` — new widget component
- `parseShareCount.js` — standalone utility for share count shorthand parsing (`5 M`, `250 K`, `1.5 B`)
- `WidgetMenu.vue` — adds 🔔 Range Alerts entry
- `WidgetWrapper.vue` — registers `range-alerts` type

## Features

- Feed selector (HOD / LOD) per widget instance
- `maxEvents` cap (0 = unlimited, default 100) — visually separated from view filters with destructive-action warning
- View filters: session, breach price, volume, rel vol, avg vol, float, directional change %
- Float shorthand input parsing: `5 M` → 5,000,000; raw integers also accepted
- Row click → `useScannerLink` (activates ticker in linked widgets)
- Column visibility gear menu; resizable columns (widths persisted to settings)
- Arrival-order display (newest first); no client-side sorting
- Empty state messages: "No alerts yet" / "No events match your filters"
- Auto-reconnect via `useWebSocketClient`; connection status surfaced by `WidgetWrapper` chrome
- Widget rename handled by `WidgetWrapper.vue` (no widget-specific implementation)

## Tests

339 passing (was 293). 46 new tests covering:
- All filter conditions in isolation (including `=== 0` edge cases)
- Cache hydration order independence, live prepend, `maxEvents` cap, feed switch
- `_seq` uniqueness + per-instance scope
- `maxEvents` input clamping, NaN/empty revert
- Column resize persistence (DOM/integration)
- Empty state rendering
- `parseShareCount` — all format variants + invalid inputs

refs #224