### PR TITLE
fix(DailyRangeAlerts): break reactive infinite loop on hiddenCols

### DIFF
--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -318,7 +318,7 @@ const startResize = (e, colKey) => {
 onUnmounted(() => { resizeState = null })
 
 // ── Column visibility ─────────────────────────────────────────────────────────
-const hiddenColsLocal = ref([...(config.value.hiddenCols ?? [])])
+const hiddenColsLocal = ref(config.value.hiddenCols ?? [])
 
 const visibleColumns = computed(() =>
   columns.filter(col => !hiddenColsLocal.value.includes(col.key))
@@ -389,7 +389,7 @@ watch(() => props.settings, (s) => {
   minFloatInput.value      = merged.minFloat !== null ? String(merged.minFloat) : ''
   maxFloatInput.value      = merged.maxFloat !== null ? String(merged.maxFloat) : ''
   pctChangeLocal.value     = merged.pctChangeThreshold !== null ? String(merged.pctChangeThreshold) : ''
-  hiddenColsLocal.value    = [...merged.hiddenCols]
+  hiddenColsLocal.value    = merged.hiddenCols ?? []
 })
 
 // ── Settings persistence ──────────────────────────────────────────────────────

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -673,3 +673,32 @@ describe('Empty state', () => {
     wrapper.unmount()
   })
 })
+
+// ── Reactive loop regression ──────────────────────────────────────────────────────────────
+
+describe('Reactive loop regression', () => {
+  // Regression: spreading hiddenColsLocal in the settings watcher always created a new
+  // array reference, triggering the watch → emitSettings → props change → watch → ∞ loop.
+  // Fix: preserve the array reference (no spread) so Vue detects no change when the
+  // same hiddenCols reference comes back from the parent after emitSettings.
+  // This test would have failed with the original spread code.
+  test('settings watcher does not loop when hiddenCols reference is stable', async () => {
+    const emitted = []
+    const hiddenCols = []  // stable reference
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { hiddenCols } },
+      attrs: { 'onUpdate-settings': (s) => emitted.push(s) },
+    })
+    const before = emitted.length
+
+    // Simulate parent passing back the same hiddenCols reference (as updateSettings does
+    // via { ...settings } spread which preserves the array reference)
+    await wrapper.setProps({ settings: { hiddenCols } })
+    await nextTick()
+    await nextTick()
+
+    // No additional emissions — the loop is broken
+    expect(emitted.length - before).toBe(0)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Problem

Adding a `range-alerts` widget to the dashboard froze the browser. Root cause: infinite reactive loop triggered on mount.

## Root Cause

`watch(() => props.settings, ...)` updated `hiddenColsLocal` by spreading into a new array:

```js
hiddenColsLocal.value = [...merged.hiddenCols]   // new array every time
```

The new array reference triggered the `watch([..., () => [...hiddenColsLocal.value]], ...)` even when the contents were identical. That watch called `emitSettings()`, the parent updated `item.settings`, props changed again, and the cycle repeated infinitely.

The same loop was also seeded by the initializer using a spread.

## Fix

Remove the spreads so the array reference is preserved when content hasn't changed:

```js
// Before:
const hiddenColsLocal = ref([...(config.value.hiddenCols ?? [])])
// ...
hiddenColsLocal.value = [...merged.hiddenCols]

// After:
const hiddenColsLocal = ref(config.value.hiddenCols ?? [])
// ...
hiddenColsLocal.value = merged.hiddenCols ?? []
```

This is the same pattern used in `TopGainers.vue` (which has the same watch structure and does not have this bug).

## Tests

341 passing.

refs #224