### PR TITLE
fix(DailyRangeAlerts): use browser local timezone for Time column

### DIFF
--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -294,8 +294,10 @@ const columns = [
     key: 'timestamp',
     label: 'Time',
     format: (val) => val == null ? '' : new Date(val * 1000).toLocaleTimeString('en-US', {
-      timeZone: 'America/New_York',
-      hour12: false,
+      hour12:  false,
+      hour:    '2-digit',
+      minute:  '2-digit',
+      second:  '2-digit',
     }),
   },
   { key: 'symbol', label: 'Symbol' },


### PR DESCRIPTION
## Problem

The Time column was hardcoded to `America/New_York` (ET), so users outside the Eastern timezone saw alert times hours ahead of their local clock.

## Fix

Remove the hardcoded `timeZone` option from the `toLocaleTimeString` call. The browser's local timezone is used, so alerts display at the time the user's clock shows — consistent with every other widget on the dashboard.

```js
// Before
new Date(val * 1000).toLocaleTimeString('en-US', { timeZone: 'America/New_York', hour12: false })

// After
new Date(val * 1000).toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
```

refs #224