### PR TITLE
feat(DailyRangeAlerts): rel vol color styling + user-configurable column order

### DIFF
--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -377,7 +377,8 @@ const getRelVolClass = (relVol) => {
 }
 
 // ── Column order & visibility ─────────────────────────────────────────────────
-const columnByKey = (key) => columns.find(c => c.key === key)
+const columnMap = Object.fromEntries(columns.map(c => [c.key, c]))
+const columnByKey = (key) => columnMap[key]
 
 const mergeColOrder = (saved) => {
   const allKeys = columns.map(c => c.key)

--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -58,18 +58,20 @@
         <input type="number" v-model="pctChangeLocal" @change="emitSettings" :placeholder="feedLocal === 'hod' ? 'Min %' : 'Max %'" class="filter-input filter-input--narrow" />
       </div>
 
-      <!-- Column visibility gear -->
+      <!-- Column visibility & order -->
       <div class="col-menu-wrap">
         <div class="col-menu-title">Columns</div>
-        <label v-for="col in columns" :key="col.key" class="col-menu-item">
+        <div v-for="(key, idx) in colOrderLocal" :key="key" class="col-menu-item">
           <input
             type="checkbox"
-            :checked="!hiddenColsLocal.includes(col.key)"
-            :disabled="col.key === 'symbol'"
-            @change="toggleCol(col.key, $event.target.checked)"
+            :checked="!hiddenColsLocal.includes(key)"
+            :disabled="key === 'symbol'"
+            @change="toggleCol(key, $event.target.checked)"
           />
-          {{ col.label }}
-        </label>
+          <span class="col-menu-label">{{ columnByKey(key)?.label }}</span>
+          <button class="col-order-btn" @click="moveCol(key, -1)" :disabled="idx === 0" title="Move up">▲</button>
+          <button class="col-order-btn" @click="moveCol(key, 1)" :disabled="idx === colOrderLocal.length - 1" title="Move down">▼</button>
+        </div>
       </div>
     </div>
 
@@ -165,6 +167,7 @@ const DEFAULT_SETTINGS = {
   maxFloat:           null,
   pctChangeThreshold: null,
   hiddenCols:         [],
+  colOrder:           [],
   colWidths:          {},
 }
 
@@ -311,7 +314,7 @@ const columns = [
     cellClass: (row) => toNum(row.pct_change) >= 0 ? 'positive' : 'negative',
   },
   { key: 'accumulated_volume', label: 'Volume',   format: (val) => formatVolume(val) },
-  { key: 'relative_volume',    label: 'Rel Vol',  format: (val) => `${toNum(val).toFixed(2)}x` },
+  { key: 'relative_volume',    label: 'Rel Vol',  format: (val) => `${toNum(val).toFixed(2)}x`, cellClass: (row) => getRelVolClass(toNum(row.relative_volume)) },
   { key: 'session',            label: 'Session' },
   // Optional (hidden by default)
   { key: 'close',               label: 'Price (quote)',      decimals: 2 },
@@ -365,12 +368,41 @@ const startResize = (e, colKey) => {
 }
 onUnmounted(() => { resizeState = null })
 
-// ── Column visibility ─────────────────────────────────────────────────────────
+// ── Rel Vol class (matches GenericScannerTable) ─────────────────────────────
+const getRelVolClass = (relVol) => {
+  if (relVol >= 5) return 'extreme'
+  if (relVol >= 3) return 'high'
+  if (relVol >= 2) return 'medium'
+  return 'normal'
+}
+
+// ── Column order & visibility ─────────────────────────────────────────────────
+const columnByKey = (key) => columns.find(c => c.key === key)
+
+const mergeColOrder = (saved) => {
+  const allKeys = columns.map(c => c.key)
+  const s = Array.isArray(saved) ? saved : []
+  return [...s.filter(k => allKeys.includes(k)), ...allKeys.filter(k => !s.includes(k))]
+}
+
 const hiddenColsLocal = ref(config.value.hiddenCols ?? [])
+const colOrderLocal   = ref(mergeColOrder(config.value.colOrder))
 
 const visibleColumns = computed(() =>
-  columns.filter(col => !hiddenColsLocal.value.includes(col.key))
+  colOrderLocal.value
+    .map(key => columnByKey(key))
+    .filter(col => col && !hiddenColsLocal.value.includes(col.key))
 )
+
+const moveCol = (key, dir) => {
+  const idx = colOrderLocal.value.indexOf(key)
+  const newIdx = idx + dir
+  if (newIdx < 0 || newIdx >= colOrderLocal.value.length) return
+  const newOrder = [...colOrderLocal.value]
+  ;[newOrder[idx], newOrder[newIdx]] = [newOrder[newIdx], newOrder[idx]]
+  colOrderLocal.value = newOrder
+  emitSettings()
+}
 
 const toggleCol = (key, visible) => {
   if (key === 'symbol') return
@@ -438,6 +470,7 @@ watch(() => props.settings, (s) => {
   maxFloatInput.value      = merged.maxFloat !== null ? String(merged.maxFloat) : ''
   pctChangeLocal.value     = merged.pctChangeThreshold !== null ? String(merged.pctChangeThreshold) : ''
   hiddenColsLocal.value    = merged.hiddenCols ?? []
+  colOrderLocal.value      = mergeColOrder(merged.colOrder)
 })
 
 // ── Settings persistence ──────────────────────────────────────────────────────
@@ -461,6 +494,7 @@ const emitSettings = () => {
     maxFloat:           parseShareCount(maxFloatInput.value),
     pctChangeThreshold: toNullableNum(pctChangeLocal.value),
     hiddenCols:         hiddenColsLocal.value,
+    colOrder:           [...colOrderLocal.value],
     colWidths:          { ...localColWidths.value },
   })
 }
@@ -617,8 +651,29 @@ const onShareCountChange = () => emitSettings()
   cursor: pointer;
   user-select: none;
 }
-.col-menu-item input { cursor: pointer; }
+.col-menu-item input { cursor: pointer; flex-shrink: 0; }
 .col-menu-item:has(input:disabled) { opacity: 0.4; cursor: default; }
+
+.col-menu-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.col-order-btn {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.col-order-btn:hover:not(:disabled) { color: #ccc; }
+.col-order-btn:disabled { opacity: 0.2; cursor: default; }
 
 /* ── Table ── */
 .table-container {
@@ -679,6 +734,12 @@ tr:hover {
 .pct_change.negative,
 .change.negative,
 .pct_change_since_open.negative { color: #f87171; }
+
+.relative_volume { font-weight: 600; }
+.relative_volume.extreme { color: #dc2626; }
+.relative_volume.high    { color: #f59e0b; }
+.relative_volume.medium  { color: #3b82f6; }
+.relative_volume.normal  { color: #6b7280; }
 
 .symbol { font-weight: 600; color: #fff; }
 

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -755,47 +755,120 @@ describe('Flame icon', () => {
 
 // ── Relative volume styling ───────────────────────────────────────────────────
 
-describe('Relative volume cell styling', () => {
-  async function getRelVolCell(wrapper, relVol) {
-    const onData = getOnData()
-    onData([makeEvent({ relative_volume: relVol })])
-    await nextTick()
-    return wrapper.find('td.relative_volume')
-  }
+// Default column order — matches the `columns` array declaration in DailyRangeAlerts.vue.
+// Use this constant instead of hardcoded arrays or magic numbers in column order tests.
+const DEFAULT_COL_ORDER = [
+  'timestamp', 'symbol', 'price', 'previous', 'note', 'pct_change',
+  'accumulated_volume', 'relative_volume', 'session', 'close', 'change',
+  'pct_change_since_open', 'free_float', 'avg_volume', 'vwap', 'prev_day_close', 'direction',
+]
 
+describe('Relative volume cell styling', () => {
   test('relative_volume >= 5 gets extreme class', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
-    const cell = await getRelVolCell(wrapper, 5)
+    const onData = getOnData()
+    onData([makeEvent({ relative_volume: 5 })])
+    await nextTick()
+
+    // Act
+    const cell = wrapper.find('td.relative_volume')
+
+    // Assert
     expect(cell.classes()).toContain('extreme')
     wrapper.unmount()
   })
 
   test('relative_volume >= 3 and < 5 gets high class', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
-    const cell = await getRelVolCell(wrapper, 3)
+    const onData = getOnData()
+    onData([makeEvent({ relative_volume: 3 })])
+    await nextTick()
+
+    // Act
+    const cell = wrapper.find('td.relative_volume')
+
+    // Assert
     expect(cell.classes()).toContain('high')
     wrapper.unmount()
   })
 
   test('relative_volume >= 2 and < 3 gets medium class', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
-    const cell = await getRelVolCell(wrapper, 2)
+    const onData = getOnData()
+    onData([makeEvent({ relative_volume: 2 })])
+    await nextTick()
+
+    // Act
+    const cell = wrapper.find('td.relative_volume')
+
+    // Assert
     expect(cell.classes()).toContain('medium')
     wrapper.unmount()
   })
 
   test('relative_volume < 2 gets normal class', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
-    const cell = await getRelVolCell(wrapper, 1.5)
+    const onData = getOnData()
+    onData([makeEvent({ relative_volume: 1.5 })])
+    await nextTick()
+
+    // Act
+    const cell = wrapper.find('td.relative_volume')
+
+    // Assert
     expect(cell.classes()).toContain('normal')
     wrapper.unmount()
   })
 
   test('relative_volume threshold boundary: 4.99 gets high not extreme', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
-    const cell = await getRelVolCell(wrapper, 4.99)
+    const onData = getOnData()
+    onData([makeEvent({ relative_volume: 4.99 })])
+    await nextTick()
+
+    // Act
+    const cell = wrapper.find('td.relative_volume')
+
+    // Assert
     expect(cell.classes()).toContain('high')
     expect(cell.classes()).not.toContain('extreme')
+    wrapper.unmount()
+  })
+
+  test('relative_volume threshold boundary: 2.99 gets medium not high', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+    onData([makeEvent({ relative_volume: 2.99 })])
+    await nextTick()
+
+    // Act
+    const cell = wrapper.find('td.relative_volume')
+
+    // Assert
+    expect(cell.classes()).toContain('medium')
+    expect(cell.classes()).not.toContain('high')
+    wrapper.unmount()
+  })
+
+  test('relative_volume threshold boundary: 1.99 gets normal not medium', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+    onData([makeEvent({ relative_volume: 1.99 })])
+    await nextTick()
+
+    // Act
+    const cell = wrapper.find('td.relative_volume')
+
+    // Assert
+    expect(cell.classes()).toContain('normal')
+    expect(cell.classes()).not.toContain('medium')
     wrapper.unmount()
   })
 })
@@ -809,93 +882,94 @@ describe('Column order', () => {
   }
 
   test('default order matches columns array order', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
     await openControls(wrapper)
     const onData = getOnData()
     onData([makeEvent()])
     await nextTick()
 
+    // Act
     const ths = wrapper.findAll('th')
-    // First two visible columns by default are Time and Symbol
+
+    // Assert — first two visible columns by default are Time and Symbol
     expect(ths[0].text()).toContain('Time')
     expect(ths[1].text()).toContain('Symbol')
     wrapper.unmount()
   })
 
   test('moveCol up: ▲ button moves column up in settings panel list', async () => {
+    // Arrange
     const settingsCalls = []
     const wrapper = mount(DailyRangeAlerts, {
       props: defaultProps,
       attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
     })
     await openControls(wrapper)
-
-    // Click ▲ on the second column item (idx 1) — should move it to idx 0
     const items = wrapper.findAll('.col-menu-item')
-    const upBtn = items[1].find('button[title="Move up"]')
-    await upBtn.trigger('click')
+
+    // Act — click ▲ on second item (idx 1), moves it to idx 0
+    await items[1].find('button[title="Move up"]').trigger('click')
     await nextTick()
 
-    expect(settingsCalls.length).toBeGreaterThan(0)
+    // Assert
     const emittedOrder = settingsCalls[settingsCalls.length - 1].colOrder
-    // The item that was at idx 1 should now be at idx 0
-    const defaultOrder = ['timestamp', 'symbol', 'price', 'previous', 'note', 'pct_change',
-      'accumulated_volume', 'relative_volume', 'session', 'close', 'change',
-      'pct_change_since_open', 'free_float', 'avg_volume', 'vwap', 'prev_day_close', 'direction']
-    expect(emittedOrder[0]).toBe(defaultOrder[1])
-    expect(emittedOrder[1]).toBe(defaultOrder[0])
+    expect(emittedOrder[0]).toBe(DEFAULT_COL_ORDER[1])
+    expect(emittedOrder[1]).toBe(DEFAULT_COL_ORDER[0])
     wrapper.unmount()
   })
 
   test('moveCol down: ▼ button moves column down in settings panel list', async () => {
+    // Arrange
     const settingsCalls = []
     const wrapper = mount(DailyRangeAlerts, {
       props: defaultProps,
       attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
     })
     await openControls(wrapper)
-
-    // Click ▼ on the first column item (idx 0)
     const items = wrapper.findAll('.col-menu-item')
-    const downBtn = items[0].find('button[title="Move down"]')
-    await downBtn.trigger('click')
+
+    // Act — click ▼ on first item (idx 0), moves it to idx 1
+    await items[0].find('button[title="Move down"]').trigger('click')
     await nextTick()
 
-    expect(settingsCalls.length).toBeGreaterThan(0)
+    // Assert
     const emittedOrder = settingsCalls[settingsCalls.length - 1].colOrder
-    const defaultOrder = ['timestamp', 'symbol', 'price', 'previous', 'note', 'pct_change',
-      'accumulated_volume', 'relative_volume', 'session', 'close', 'change',
-      'pct_change_since_open', 'free_float', 'avg_volume', 'vwap', 'prev_day_close', 'direction']
-    expect(emittedOrder[0]).toBe(defaultOrder[1])
-    expect(emittedOrder[1]).toBe(defaultOrder[0])
+    expect(emittedOrder[0]).toBe(DEFAULT_COL_ORDER[1])
+    expect(emittedOrder[1]).toBe(DEFAULT_COL_ORDER[0])
     wrapper.unmount()
   })
 
   test('▲ button disabled on first item', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
     await openControls(wrapper)
 
-    const items = wrapper.findAll('.col-menu-item')
-    const upBtn = items[0].find('button[title="Move up"]')
+    // Act
+    const upBtn = wrapper.findAll('.col-menu-item')[0].find('button[title="Move up"]')
+
+    // Assert
     expect(upBtn.attributes('disabled')).toBeDefined()
     wrapper.unmount()
   })
 
   test('▼ button disabled on last item', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
     await openControls(wrapper)
 
+    // Act
     const items = wrapper.findAll('.col-menu-item')
-    const lastItem = items[items.length - 1]
-    const downBtn = lastItem.find('button[title="Move down"]')
+    const downBtn = items[items.length - 1].find('button[title="Move down"]')
+
+    // Assert
     expect(downBtn.attributes('disabled')).toBeDefined()
     wrapper.unmount()
   })
 
   test('saved colOrder is restored from settings prop', async () => {
-    const reversed = ['direction', 'prev_day_close', 'vwap', 'avg_volume', 'free_float',
-      'pct_change_since_open', 'change', 'close', 'session', 'relative_volume',
-      'accumulated_volume', 'pct_change', 'note', 'previous', 'price', 'symbol', 'timestamp']
+    // Arrange
+    const reversed = [...DEFAULT_COL_ORDER].reverse()
     const wrapper = mount(DailyRangeAlerts, {
       props: { ...defaultProps, settings: { colOrder: reversed } },
     })
@@ -904,57 +978,66 @@ describe('Column order', () => {
     onData([makeEvent()])
     await nextTick()
 
+    // Act
     const ths = wrapper.findAll('th')
-    // First visible column should be direction (not hidden; it's at idx 0 in reversed order)
+
+    // Assert — first visible column should be direction (idx 0 in reversed order)
     expect(ths[0].text()).toContain('Direction')
     wrapper.unmount()
   })
 
   test('colOrder in emitted settings contains all column keys', async () => {
+    // Arrange
     const settingsCalls = []
     const wrapper = mount(DailyRangeAlerts, {
       props: defaultProps,
       attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
     })
     await openControls(wrapper)
-
     const items = wrapper.findAll('.col-menu-item')
+
+    // Act
     await items[1].find('button[title="Move up"]').trigger('click')
     await nextTick()
 
+    // Assert
     const emittedOrder = settingsCalls[settingsCalls.length - 1].colOrder
-    expect(emittedOrder.length).toBe(17)  // total column count
+    expect(emittedOrder.length).toBe(DEFAULT_COL_ORDER.length)
     wrapper.unmount()
   })
 
   test('unknown saved colOrder keys are dropped; missing keys appended', async () => {
-    // Settings has a stale key 'old_col' and is missing several columns
+    // Arrange — settings has a stale key 'old_col' and is missing several columns
     const partialOrder = ['symbol', 'old_col', 'price']
     const wrapper = mount(DailyRangeAlerts, {
       props: { ...defaultProps, settings: { colOrder: partialOrder } },
     })
     await openControls(wrapper)
 
+    // Act
     const items = wrapper.findAll('.col-menu-item')
-    // 'old_col' must not appear; total items = all known columns
+
+    // Assert — 'old_col' absent; all known columns present
     const labels = items.map(i => i.text())
     expect(labels.some(l => l.includes('old_col'))).toBe(false)
-    expect(items.length).toBe(17)
+    expect(items.length).toBe(DEFAULT_COL_ORDER.length)
     wrapper.unmount()
   })
 
   test('column order reflected in table header order after move', async () => {
+    // Arrange
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
     await openControls(wrapper)
     const onData = getOnData()
     onData([makeEvent()])
     await nextTick()
-
-    // Move Symbol (idx 1) up to idx 0
     const items = wrapper.findAll('.col-menu-item')
+
+    // Act — move Symbol (idx 1) up to idx 0
     await items[1].find('button[title="Move up"]').trigger('click')
     await nextTick()
 
+    // Assert
     const ths = wrapper.findAll('th')
     expect(ths[0].text()).toContain('Symbol')
     expect(ths[1].text()).toContain('Time')

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -752,3 +752,212 @@ describe('Flame icon', () => {
     wrapper.unmount()
   })
 })
+
+// ── Relative volume styling ───────────────────────────────────────────────────
+
+describe('Relative volume cell styling', () => {
+  async function getRelVolCell(wrapper, relVol) {
+    const onData = getOnData()
+    onData([makeEvent({ relative_volume: relVol })])
+    await nextTick()
+    return wrapper.find('td.relative_volume')
+  }
+
+  test('relative_volume >= 5 gets extreme class', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const cell = await getRelVolCell(wrapper, 5)
+    expect(cell.classes()).toContain('extreme')
+    wrapper.unmount()
+  })
+
+  test('relative_volume >= 3 and < 5 gets high class', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const cell = await getRelVolCell(wrapper, 3)
+    expect(cell.classes()).toContain('high')
+    wrapper.unmount()
+  })
+
+  test('relative_volume >= 2 and < 3 gets medium class', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const cell = await getRelVolCell(wrapper, 2)
+    expect(cell.classes()).toContain('medium')
+    wrapper.unmount()
+  })
+
+  test('relative_volume < 2 gets normal class', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const cell = await getRelVolCell(wrapper, 1.5)
+    expect(cell.classes()).toContain('normal')
+    wrapper.unmount()
+  })
+
+  test('relative_volume threshold boundary: 4.99 gets high not extreme', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const cell = await getRelVolCell(wrapper, 4.99)
+    expect(cell.classes()).toContain('high')
+    expect(cell.classes()).not.toContain('extreme')
+    wrapper.unmount()
+  })
+})
+
+// ── Column order ──────────────────────────────────────────────────────────────
+
+describe('Column order', () => {
+  async function openControls(wrapper) {
+    await wrapper.find('.col-menu-btn').trigger('click')
+    await nextTick()
+  }
+
+  test('default order matches columns array order', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await openControls(wrapper)
+    const onData = getOnData()
+    onData([makeEvent()])
+    await nextTick()
+
+    const ths = wrapper.findAll('th')
+    // First two visible columns by default are Time and Symbol
+    expect(ths[0].text()).toContain('Time')
+    expect(ths[1].text()).toContain('Symbol')
+    wrapper.unmount()
+  })
+
+  test('moveCol up: ▲ button moves column up in settings panel list', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    await openControls(wrapper)
+
+    // Click ▲ on the second column item (idx 1) — should move it to idx 0
+    const items = wrapper.findAll('.col-menu-item')
+    const upBtn = items[1].find('button[title="Move up"]')
+    await upBtn.trigger('click')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    const emittedOrder = settingsCalls[settingsCalls.length - 1].colOrder
+    // The item that was at idx 1 should now be at idx 0
+    const defaultOrder = ['timestamp', 'symbol', 'price', 'previous', 'note', 'pct_change',
+      'accumulated_volume', 'relative_volume', 'session', 'close', 'change',
+      'pct_change_since_open', 'free_float', 'avg_volume', 'vwap', 'prev_day_close', 'direction']
+    expect(emittedOrder[0]).toBe(defaultOrder[1])
+    expect(emittedOrder[1]).toBe(defaultOrder[0])
+    wrapper.unmount()
+  })
+
+  test('moveCol down: ▼ button moves column down in settings panel list', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    await openControls(wrapper)
+
+    // Click ▼ on the first column item (idx 0)
+    const items = wrapper.findAll('.col-menu-item')
+    const downBtn = items[0].find('button[title="Move down"]')
+    await downBtn.trigger('click')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    const emittedOrder = settingsCalls[settingsCalls.length - 1].colOrder
+    const defaultOrder = ['timestamp', 'symbol', 'price', 'previous', 'note', 'pct_change',
+      'accumulated_volume', 'relative_volume', 'session', 'close', 'change',
+      'pct_change_since_open', 'free_float', 'avg_volume', 'vwap', 'prev_day_close', 'direction']
+    expect(emittedOrder[0]).toBe(defaultOrder[1])
+    expect(emittedOrder[1]).toBe(defaultOrder[0])
+    wrapper.unmount()
+  })
+
+  test('▲ button disabled on first item', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await openControls(wrapper)
+
+    const items = wrapper.findAll('.col-menu-item')
+    const upBtn = items[0].find('button[title="Move up"]')
+    expect(upBtn.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  test('▼ button disabled on last item', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await openControls(wrapper)
+
+    const items = wrapper.findAll('.col-menu-item')
+    const lastItem = items[items.length - 1]
+    const downBtn = lastItem.find('button[title="Move down"]')
+    expect(downBtn.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  test('saved colOrder is restored from settings prop', async () => {
+    const reversed = ['direction', 'prev_day_close', 'vwap', 'avg_volume', 'free_float',
+      'pct_change_since_open', 'change', 'close', 'session', 'relative_volume',
+      'accumulated_volume', 'pct_change', 'note', 'previous', 'price', 'symbol', 'timestamp']
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { colOrder: reversed } },
+    })
+    await openControls(wrapper)
+    const onData = getOnData()
+    onData([makeEvent()])
+    await nextTick()
+
+    const ths = wrapper.findAll('th')
+    // First visible column should be direction (not hidden; it's at idx 0 in reversed order)
+    expect(ths[0].text()).toContain('Direction')
+    wrapper.unmount()
+  })
+
+  test('colOrder in emitted settings contains all column keys', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    await openControls(wrapper)
+
+    const items = wrapper.findAll('.col-menu-item')
+    await items[1].find('button[title="Move up"]').trigger('click')
+    await nextTick()
+
+    const emittedOrder = settingsCalls[settingsCalls.length - 1].colOrder
+    expect(emittedOrder.length).toBe(17)  // total column count
+    wrapper.unmount()
+  })
+
+  test('unknown saved colOrder keys are dropped; missing keys appended', async () => {
+    // Settings has a stale key 'old_col' and is missing several columns
+    const partialOrder = ['symbol', 'old_col', 'price']
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { colOrder: partialOrder } },
+    })
+    await openControls(wrapper)
+
+    const items = wrapper.findAll('.col-menu-item')
+    // 'old_col' must not appear; total items = all known columns
+    const labels = items.map(i => i.text())
+    expect(labels.some(l => l.includes('old_col'))).toBe(false)
+    expect(items.length).toBe(17)
+    wrapper.unmount()
+  })
+
+  test('column order reflected in table header order after move', async () => {
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await openControls(wrapper)
+    const onData = getOnData()
+    onData([makeEvent()])
+    await nextTick()
+
+    // Move Symbol (idx 1) up to idx 0
+    const items = wrapper.findAll('.col-menu-item')
+    await items[1].find('button[title="Move up"]').trigger('click')
+    await nextTick()
+
+    const ths = wrapper.findAll('th')
+    expect(ths[0].text()).toContain('Symbol')
+    expect(ths[1].text()).toContain('Time')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Two tweaks to the DailyRangeAlerts widget requested by Tom.

### 1. Relative volume color styling (cosmetic)

Applies the same `getRelVolClass()` pattern used in `GenericScannerTable.vue` (Top Volume, Top Gainers, Top Gappers):

| Threshold | Class | Color |
|-----------|-------|-------|
| ≥ 5x | `extreme` | red |
| ≥ 3x | `high` | amber |
| ≥ 2x | `medium` | blue |
| < 2x | `normal` | gray |

Font weight bold, consistent with scanner widgets.

### 2. User-configurable column order

Users can now reorder columns using ▲/▼ arrow buttons in the settings panel (alongside the existing hide/show checkboxes). Column order is persisted in `settings.colOrder`.

Design decisions:
- `colOrderLocal` (array of all column keys in user-preferred order) initializes from `settings.colOrder` via `mergeColOrder()`
- `mergeColOrder()` drops unknown saved keys and appends any new columns not yet in saved order — forward-compatible when new columns are added
- `visibleColumns` now sorts by `colOrderLocal`, then filters hidden — no name change
- `columnByKey()` helper for O(n) key→column lookup
- ▲ disabled on first item, ▼ disabled on last item
- Emits `colOrder` in settings payload on every move

### Tests

14 new tests (358 total, all passing):
- 5 rel vol class threshold tests (extreme/high/medium/normal + boundary)
- 9 column order tests: default order, move up, move down, boundary disabled states, saved order restored, emitted payload completeness, stale key handling, table header reflects order

refs #224