### PR TITLE
feat(DailyRangeAlerts): ticker filter input + row-click filter mode

### DIFF
--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -1,8 +1,32 @@
 <template>
   <div class="range-alerts-widget">
-    <!-- Gear button toggles controls panel -->
-    <div class="controls-toggle">
-      <button class="col-menu-btn" @click="showControls = !showControls" title="Settings">⚙️</button>
+    <!-- Widget header: ticker filter (left) + mode toggle + gear (right) -->
+    <div class="widget-header">
+      <div class="ticker-filter-wrap">
+        <input
+          class="ticker-filter-input"
+          :value="tickerFilter"
+          @input="onTickerFilterInput($event.target.value)"
+          placeholder="Filter ticker…"
+          data-testid="ticker-filter-input"
+        />
+        <button
+          v-if="tickerFilter"
+          class="ticker-filter-clear"
+          @click="clearTickerFilter"
+          title="Clear ticker filter"
+          data-testid="ticker-filter-clear"
+        >✕</button>
+      </div>
+      <div class="header-actions">
+        <button
+          :class="['filter-btn', rowClickModeLocal === 'filter' ? 'filter-btn--active' : '']"
+          @click="toggleRowClickMode"
+          :title="rowClickModeLocal === 'filter' ? 'Row click: filter feed — click to switch to select mode' : 'Row click: select ticker — click to switch to filter mode'"
+          data-testid="row-click-mode-toggle"
+        >{{ rowClickModeLocal === 'filter' ? 'filter' : 'select' }}</button>
+        <button class="col-menu-btn" @click="showControls = !showControls" title="Settings">⚙️</button>
+      </div>
     </div>
 
     <!-- Collapsible controls panel (collapsed by default) -->
@@ -105,8 +129,8 @@
           <tr
             v-for="row in filteredEvents"
             :key="row._seq"
-            :class="{ 'row-active': activeTicker === row.symbol }"
-            @click="onRowClick(row)"
+            :class="{ 'row-active': isRowActive(row) }"
+            @click="handleRowClick(row)"
           >
             <td v-for="col in visibleColumns" :key="col.key" :class="getCellClass(col, row)">
               <template v-if="col.key === 'symbol'">
@@ -169,6 +193,7 @@ const DEFAULT_SETTINGS = {
   hiddenCols:         [],
   colOrder:           [],
   colWidths:          {},
+  rowClickMode:       'link',
 }
 
 const FEED_MAP = {
@@ -234,6 +259,7 @@ const filteredEvents = computed(() => {
     if (c.minPrice !== null && e.price < c.minPrice) return false
     if (c.maxPrice !== null && e.price > c.maxPrice) return false
     if (c.minVolume !== null && e.accumulated_volume < c.minVolume) return false
+    if (tickerFilter.value && e.symbol.toUpperCase() !== tickerFilter.value) return false
     if (c.minRelVol !== null && e.relative_volume < c.minRelVol) return false
     if (c.minAvgVol !== null && e.avg_volume < c.minAvgVol) return false
     if (c.minFloat !== null && e.free_float < c.minFloat) return false
@@ -248,6 +274,48 @@ const filteredEvents = computed(() => {
 
 // ── Row click / scanner link ──────────────────────────────────────────────────
 const { activeTicker, onRowClick } = useScannerLink(computed(() => props.linkColor))
+
+// ── Ticker filter (transient — not persisted) ───────────────────────────────
+const tickerFilter    = ref('')
+const filterSetByClick = ref(false)  // true only when filter set via row click; suppresses all-rows-highlighted noise when typing
+
+const onTickerFilterInput = (val) => {
+  tickerFilter.value = val.toUpperCase()
+  filterSetByClick.value = false
+}
+
+const clearTickerFilter = () => {
+  tickerFilter.value = ''
+  filterSetByClick.value = false
+}
+
+// ── Row-click mode (persisted) ──────────────────────────────────────────────
+const rowClickModeLocal = ref(config.value.rowClickMode ?? 'link')
+
+const toggleRowClickMode = () => {
+  rowClickModeLocal.value = rowClickModeLocal.value === 'link' ? 'filter' : 'link'
+  emitSettings()  // explicit — NOT added to the auto-emit watcher
+}
+
+const handleRowClick = (row) => {
+  if (rowClickModeLocal.value === 'filter') {
+    const sym = row.symbol.toUpperCase()
+    if (tickerFilter.value === sym) {
+      clearTickerFilter()
+    } else {
+      tickerFilter.value = sym
+      filterSetByClick.value = true
+    }
+  }
+  onRowClick(row)  // always activate linked widgets
+}
+
+const isRowActive = (row) => {
+  if (rowClickModeLocal.value === 'filter') {
+    return filterSetByClick.value && tickerFilter.value === row.symbol.toUpperCase()
+  }
+  return activeTicker.value === row.symbol
+}
 
 // ── Flame freshness icons ───────────────────────────────────────────────────────
 const FLAME_SRCS = {
@@ -472,6 +540,7 @@ watch(() => props.settings, (s) => {
   pctChangeLocal.value     = merged.pctChangeThreshold !== null ? String(merged.pctChangeThreshold) : ''
   hiddenColsLocal.value    = merged.hiddenCols ?? []
   colOrderLocal.value      = mergeColOrder(merged.colOrder)
+  rowClickModeLocal.value  = merged.rowClickMode ?? 'link'
 })
 
 // ── Settings persistence ──────────────────────────────────────────────────────
@@ -496,6 +565,7 @@ const emitSettings = () => {
     pctChangeThreshold: toNullableNum(pctChangeLocal.value),
     hiddenCols:         hiddenColsLocal.value,
     colOrder:           [...colOrderLocal.value],
+    rowClickMode:       rowClickModeLocal.value,
     colWidths:          { ...localColWidths.value },
   })
 }
@@ -539,12 +609,73 @@ const onShareCountChange = () => emitSettings()
   overflow: hidden;
 }
 
-.controls-toggle {
+.widget-header {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   padding: 4px 6px;
   background: #2a2a2a;
   border-bottom: 1px solid #333;
+  gap: 6px;
+}
+
+.ticker-filter-wrap {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.ticker-filter-input {
+  flex: 1;
+  min-width: 60px;
+  max-width: 120px;
+  padding: 3px 6px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 3px;
+  color: #e0e0e0;
+  font-size: 12px;
+}
+.ticker-filter-input:focus { outline: none; border-color: #8b5cf6; }
+.ticker-filter-input::placeholder { color: #555; }
+
+.ticker-filter-clear {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 3px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.ticker-filter-clear:hover { color: #ccc; }
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.filter-btn {
+  padding: 3px 8px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 3px;
+  color: #888;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.filter-btn:hover { background: #1a1a1a; color: #aaa; }
+.filter-btn--active {
+  background: rgba(139, 92, 246, 0.15);
+  border-color: rgba(139, 92, 246, 0.5);
+  color: #a78bfa;
 }
 
 .col-menu-btn {

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -42,6 +42,7 @@ vi.mock('@/composables/useWidgetBus.js', async () => {
 })
 
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useScannerLink } from '@/composables/useScannerLink.js'
 import { getFlameVariant } from '@/composables/useWidgetBus.js'
 import DailyRangeAlerts from '../DailyRangeAlerts.vue'
 
@@ -1166,13 +1167,14 @@ describe('Ticker filter input', () => {
       attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
     })
 
-    // Act — open controls and toggle a column to trigger emitSettings
-    await wrapper.find('.col-menu-btn').trigger('click')
-    await nextTick()
+    // Act — set ticker filter, then trigger a real emitSettings via mode toggle
     await wrapper.find('[data-testid="ticker-filter-input"]').setValue('AAPL')
     await nextTick()
+    await wrapper.find('[data-testid="row-click-mode-toggle"]').trigger('click')
+    await nextTick()
 
-    // Assert — no tickerFilter key in any emitted settings object
+    // Assert — guard against vacuous truth, then verify tickerFilter absent from all payloads
+    expect(settingsCalls.length).toBeGreaterThan(0)
     expect(settingsCalls.every(s => !('tickerFilter' in s))).toBe(true)
     wrapper.unmount()
   })
@@ -1265,12 +1267,8 @@ describe('Row-click mode toggle', () => {
     wrapper.unmount()
   })
 
-  test('filter mode: row click sets tickerFilter and calls onRowClick', async () => {
+  test('filter mode: row click sets tickerFilter', async () => {
     // Arrange
-    const { onRowClick: mockOnRowClick } = vi.mocked(
-      (await import('@/composables/useScannerLink.js')).useScannerLink
-    ).mock.results[0]?.value ?? {}
-
     const wrapper = mount(DailyRangeAlerts, {
       props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
     })
@@ -1282,8 +1280,28 @@ describe('Row-click mode toggle', () => {
     await wrapper.find('tbody tr').trigger('click')
     await nextTick()
 
-    // Assert — ticker filter set to AAPL
+    // Assert
     expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('AAPL')
+    wrapper.unmount()
+  })
+
+  test('filter mode: row click also activates linked widgets via onRowClick', async () => {
+    // Arrange — capture the onRowClick mock for this specific wrapper instance
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const mockOnRowClick = vi.mocked(useScannerLink).mock.results[callsBefore].value.onRowClick
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL' })])
+    await nextTick()
+
+    // Act
+    await wrapper.find('tbody tr').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(mockOnRowClick).toHaveBeenCalled()
     wrapper.unmount()
   })
 
@@ -1308,8 +1326,8 @@ describe('Row-click mode toggle', () => {
     wrapper.unmount()
   })
 
-  test('select mode: row click does not set tickerFilter', async () => {
-    // Arrange
+  test('select (link) mode: row click does not set tickerFilter', async () => {
+    // Arrange — rowClickMode: 'link' is the code value for the "select" UI label
     const wrapper = mount(DailyRangeAlerts, {
       props: { ...defaultProps, settings: { rowClickMode: 'link' } },
     })

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -1044,3 +1044,330 @@ describe('Column order', () => {
     wrapper.unmount()
   })
 })
+
+// ── Ticker filter input ───────────────────────────────────────────────────────
+
+describe('Ticker filter input', () => {
+  test('filter input is rendered by default', () => {
+    // Arrange + Act
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('typing a ticker filters rows to matching symbol only', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'AAPL' }),
+      makeEvent({ symbol: 'TSLA' }),
+    ])
+    await nextTick()
+
+    // Act
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('AAPL')
+    await nextTick()
+
+    // Assert
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('AAPL')
+    wrapper.unmount()
+  })
+
+  test('typing a non-matching ticker shows empty state', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL' })])
+    await nextTick()
+
+    // Act
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('ZZZZ')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('ticker filter is case-insensitive: lowercase input matches uppercase symbol', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'AAPL' }),
+      makeEvent({ symbol: 'TSLA' }),
+    ])
+    await nextTick()
+
+    // Act
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('aapl')
+    await nextTick()
+
+    // Assert — AAPL row is visible despite lowercase input
+    const rows = wrapper.findAll('tbody tr').filter(r => !r.find('.empty-state').exists())
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('AAPL')
+    wrapper.unmount()
+  })
+
+  test('clear button is absent when filter is empty', () => {
+    // Arrange + Act
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.find('[data-testid="ticker-filter-clear"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('clear button is present when filter is non-empty', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+
+    // Act
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('AAPL')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('[data-testid="ticker-filter-clear"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('clicking clear button removes the filter and shows all rows', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'AAPL' }),
+      makeEvent({ symbol: 'TSLA' }),
+    ])
+    await nextTick()
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('AAPL')
+    await nextTick()
+
+    // Act
+    await wrapper.find('[data-testid="ticker-filter-clear"]').trigger('click')
+    await nextTick()
+
+    // Assert — both rows visible again
+    expect(countDataRows(wrapper)).toBe(2)
+    wrapper.unmount()
+  })
+
+  test('tickerFilter is NOT included in emitted settings', async () => {
+    // Arrange
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+
+    // Act — open controls and toggle a column to trigger emitSettings
+    await wrapper.find('.col-menu-btn').trigger('click')
+    await nextTick()
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('AAPL')
+    await nextTick()
+
+    // Assert — no tickerFilter key in any emitted settings object
+    expect(settingsCalls.every(s => !('tickerFilter' in s))).toBe(true)
+    wrapper.unmount()
+  })
+})
+
+// ── Row-click mode toggle ─────────────────────────────────────────────────────
+
+describe('Row-click mode toggle', () => {
+  test('mode toggle button renders when isLocked is true', () => {
+    // Arrange + Act
+    const wrapper = mount(DailyRangeAlerts, { props: { ...defaultProps, isLocked: true } })
+
+    // Assert
+    expect(wrapper.find('[data-testid="row-click-mode-toggle"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('mode toggle button renders when isLocked is false', () => {
+    // Arrange + Act
+    const wrapper = mount(DailyRangeAlerts, { props: { ...defaultProps, isLocked: false } })
+
+    // Assert
+    expect(wrapper.find('[data-testid="row-click-mode-toggle"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('default mode is select (link) — button shows "select"', () => {
+    // Arrange + Act
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.find('[data-testid="row-click-mode-toggle"]').text()).toBe('select')
+    wrapper.unmount()
+  })
+
+  test('default mode is select when saved settings have no rowClickMode field', () => {
+    // Arrange + Act — saved settings pre-feature have no rowClickMode
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { hiddenCols: [] } },
+    })
+
+    // Assert
+    expect(wrapper.find('[data-testid="row-click-mode-toggle"]').text()).toBe('select')
+    wrapper.unmount()
+  })
+
+  test('clicking toggle switches mode to filter — button shows "filter"', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+
+    // Act
+    await wrapper.find('[data-testid="row-click-mode-toggle"]').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('[data-testid="row-click-mode-toggle"]').text()).toBe('filter')
+    wrapper.unmount()
+  })
+
+  test('clicking toggle again switches back to select', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await wrapper.find('[data-testid="row-click-mode-toggle"]').trigger('click')
+    await nextTick()
+
+    // Act
+    await wrapper.find('[data-testid="row-click-mode-toggle"]').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('[data-testid="row-click-mode-toggle"]').text()).toBe('select')
+    wrapper.unmount()
+  })
+
+  test('rowClickMode is included in emitted settings', async () => {
+    // Arrange
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+
+    // Act
+    await wrapper.find('[data-testid="row-click-mode-toggle"]').trigger('click')
+    await nextTick()
+
+    // Assert
+    const last = settingsCalls[settingsCalls.length - 1]
+    expect(last.rowClickMode).toBe('filter')
+    wrapper.unmount()
+  })
+
+  test('filter mode: row click sets tickerFilter and calls onRowClick', async () => {
+    // Arrange
+    const { onRowClick: mockOnRowClick } = vi.mocked(
+      (await import('@/composables/useScannerLink.js')).useScannerLink
+    ).mock.results[0]?.value ?? {}
+
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL' })])
+    await nextTick()
+
+    // Act
+    await wrapper.find('tbody tr').trigger('click')
+    await nextTick()
+
+    // Assert — ticker filter set to AAPL
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('AAPL')
+    wrapper.unmount()
+  })
+
+  test('filter mode: clicking same-symbol row clears tickerFilter', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL' })])
+    await nextTick()
+    // Set filter by first click
+    await wrapper.find('tbody tr').trigger('click')
+    await nextTick()
+
+    // Act — click same row again
+    await wrapper.find('tbody tr').trigger('click')
+    await nextTick()
+
+    // Assert — filter cleared
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('')
+    wrapper.unmount()
+  })
+
+  test('select mode: row click does not set tickerFilter', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'link' } },
+    })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL' })])
+    await nextTick()
+
+    // Act
+    await wrapper.find('tbody tr').trigger('click')
+    await nextTick()
+
+    // Assert — filter remains empty
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('')
+    wrapper.unmount()
+  })
+})
+
+// ── Shared state (ticker filter + row-click mode) ─────────────────────────────
+
+describe('Shared ticker filter state', () => {
+  test('clear button removes filter set by row click', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'AAPL' }),
+      makeEvent({ symbol: 'TSLA' }),
+    ])
+    await nextTick()
+    await wrapper.find('tbody tr').trigger('click')  // sets filter to AAPL
+    await nextTick()
+
+    // Act
+    await wrapper.find('[data-testid="ticker-filter-clear"]').trigger('click')
+    await nextTick()
+
+    // Assert — both rows visible again
+    expect(countDataRows(wrapper)).toBe(2)
+    wrapper.unmount()
+  })
+
+  test('row click in filter mode populates the text input', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'TSLA' })])
+    await nextTick()
+
+    // Act
+    await wrapper.find('tbody tr').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('TSLA')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Two new features for `DailyRangeAlerts` — two facets of the same shared `tickerFilter` state.

### US-1: Ticker filter input
- Text input on the **left side** of the widget header; gear/toggle on the right — opposite ends prevent accidental gear clicks when reaching for ✕
- Typing a symbol filters the feed to matching events only (case-insensitive, normalized to uppercase)
- ✕ button appears when filter is active; clicking it clears the filter
- **Transient** — not persisted to settings, cleared on page refresh

### US-2: Row-click filter mode
- Text toggle button (`filter` / `select`) to the left of the gear — always visible regardless of `isLocked` state
- Matches `filter-btn` / `filter-btn--active` visual pattern from `NewsFeed.vue` — no emoji; `filter` in purple when active, `select` muted when inactive
- Default mode: **select** (existing behavior — row click activates linked widgets via scanner bus)
- Filter mode: row click sets the ticker filter **and** activates linked widgets (both behaviors)
- Clicking a row whose symbol is already the active filter clears the filter; linked widget activation still fires
- **Persisted** to settings as `rowClickMode: link | filter`

### Shared state
- Both stories set the same `tickerFilter` ref
- Single ✕ button clears both; clicking the active filtered row again also clears
- `filterSetByClick` flag: row highlight in filter mode only fires when filter was set by row click (suppresses all-rows-highlighted noise when typing)

### Key implementation notes
- `rowClickModeLocal = ref(config.value.rowClickMode ?? link)` — guards against `undefined` in pre-feature saved settings
- `tickerFilter` is already uppercase from `onTickerFilterInput`; `filteredEvents` compares `e.symbol.toUpperCase() !== tickerFilter.value` (no redundant transform)
- `toggleRowClickMode` calls `emitSettings()` explicitly — NOT added to the auto-emit watcher
- `handleRowClick` always calls `onRowClick(row)` (linked widgets); ticker filter logic is additive

## Tests

19 new tests (380 total, all passing). TDD arc visible: red commit `9c8ae38` → green commit `6f061d9`.

- 8 ticker filter input tests
- 9 row-click mode toggle tests
- 2 shared state tests

refs #230