### PR TITLE
fix(DailyRangeAlerts): null symbol guard + bus sync in filter mode

### DIFF
--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -259,7 +259,7 @@ const filteredEvents = computed(() => {
     if (c.minPrice !== null && e.price < c.minPrice) return false
     if (c.maxPrice !== null && e.price > c.maxPrice) return false
     if (c.minVolume !== null && e.accumulated_volume < c.minVolume) return false
-    if (tickerFilter.value && e.symbol.toUpperCase() !== tickerFilter.value) return false
+    if (tickerFilter.value && (e.symbol ?? '').toUpperCase() !== tickerFilter.value) return false
     if (c.minRelVol !== null && e.relative_volume < c.minRelVol) return false
     if (c.minAvgVol !== null && e.avg_volume < c.minAvgVol) return false
     if (c.minFloat !== null && e.free_float < c.minFloat) return false
@@ -298,7 +298,7 @@ const toggleRowClickMode = () => {
 }
 
 const handleRowClick = (row) => {
-  if (rowClickModeLocal.value === 'filter') {
+  if (rowClickModeLocal.value === 'filter' && row.symbol) {
     const sym = row.symbol.toUpperCase()
     if (tickerFilter.value === sym) {
       clearTickerFilter()
@@ -312,7 +312,7 @@ const handleRowClick = (row) => {
 
 const isRowActive = (row) => {
   if (rowClickModeLocal.value === 'filter') {
-    return filterSetByClick.value && tickerFilter.value === row.symbol.toUpperCase()
+    return filterSetByClick.value && tickerFilter.value === (row.symbol ?? '').toUpperCase()
   }
   return activeTicker.value === row.symbol
 }

--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -317,6 +317,17 @@ const isRowActive = (row) => {
   return activeTicker.value === row.symbol
 }
 
+// ── Bus sync: follow activeTicker in filter mode ──────────────────────────
+watch(() => activeTicker.value, (ticker) => {
+  if (rowClickModeLocal.value !== 'filter') return
+  if (ticker) {
+    tickerFilter.value = ticker.toUpperCase()
+    filterSetByClick.value = true
+  } else {
+    clearTickerFilter()
+  }
+})
+
 // ── Flame freshness icons ───────────────────────────────────────────────────────
 const FLAME_SRCS = {
   red:    new URL('@/assets/icons/flame-red.svg',    import.meta.url).href,

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -1389,3 +1389,97 @@ describe('Shared ticker filter state', () => {
     wrapper.unmount()
   })
 })
+
+// ── Regression: symbol-less events crash filteredEvents when ticker filter active ──────
+// Vue's production build catches thrown computeds and calls console.error.
+// Spying on console.error gives a reliable red signal before the null guard fix.
+
+describe('Null symbol regression', () => {
+  test('undefined symbol in event does not trigger console.error when ticker filter is active', async () => {
+    // Arrange
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL' })])
+    await nextTick()
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('AAPL')
+    await nextTick()
+    consoleError.mockClear()  // clear any Vue setup noise before the Act step
+
+    // Act — live event without symbol field (e.g. non-alert WS message in the feed)
+    onData({ price: 100, pct_change: 5 })
+    await nextTick()
+
+    // Assert — no console.error from Vue catching a thrown computed
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+    wrapper.unmount()
+  })
+
+  test('null symbol in event does not trigger console.error when ticker filter is active', async () => {
+    // Arrange
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'TSLA' })])
+    await nextTick()
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('TSLA')
+    await nextTick()
+    consoleError.mockClear()
+
+    // Act
+    onData({ ...makeEvent({ symbol: null }) })
+    await nextTick()
+
+    // Assert
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+    wrapper.unmount()
+  })
+
+  test('undefined symbol in event does not trigger console.error when filterSetByClick is true', async () => {
+    // Arrange: row click in filter mode sets filterSetByClick=true, exposing isRowActive’s toUpperCase path
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL' })])
+    await nextTick()
+    // Set filter via row click (sets filterSetByClick=true)
+    await wrapper.find('tbody tr').trigger('click')
+    await nextTick()
+    consoleError.mockClear()
+
+    // Act — new event without symbol arrives while filter+filterSetByClick are active
+    onData({ price: 50, pct_change: 3 })
+    await nextTick()
+
+    // Assert — isRowActive’s toUpperCase call is guarded; no console.error
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+    wrapper.unmount()
+  })
+
+  test('clicking a row without symbol in filter mode does not trigger console.error', async () => {
+    // Arrange
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const onData = getOnData()
+    onData([{ price: 10, pct_change: 5 }])  // no symbol
+    await nextTick()
+    consoleError.mockClear()
+
+    // Act — click the symbol-less row (handleRowClick’s toUpperCase path)
+    await wrapper.find('tbody tr').trigger('click')
+    await nextTick()
+
+    // Assert — no crash; filter stays empty
+    expect(consoleError).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('')
+    consoleError.mockRestore()
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -1509,7 +1509,7 @@ describe('Bus sync in filter mode', () => {
   })
 
   test('filter mode: activeTicker cleared on bus clears tickerFilter', async () => {
-    // Arrange — establish a non-empty filter first (via typing), then check bus clear resets it
+    // Arrange — set filter via bus first (activeTicker null→TSLA), then clear (TSLA→null)
     const callsBefore = vi.mocked(useScannerLink).mock.calls.length
     const wrapper = mount(DailyRangeAlerts, {
       props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
@@ -1518,9 +1518,10 @@ describe('Bus sync in filter mode', () => {
     const onData = getOnData()
     onData([makeEvent({ symbol: 'TSLA' })])
     await nextTick()
-    // Set filter via typing so it is non-empty before the bus clear
-    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('TSLA')
+    activeTicker.value = 'TSLA'
     await nextTick()
+    // Pre-condition: filter must be set by bus before we test clearing it
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('TSLA')
 
     // Act — bus ticker cleared (e.g. user clicks same row again in another widget)
     activeTicker.value = null

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -1483,3 +1483,72 @@ describe('Null symbol regression', () => {
     wrapper.unmount()
   })
 })
+
+// ── Bus sync in filter mode ───────────────────────────────────────────────────
+
+describe('Bus sync in filter mode', () => {
+  test('filter mode: activeTicker change on bus updates tickerFilter', async () => {
+    // Arrange
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'TSLA' }), makeEvent({ symbol: 'AAPL' })])
+    await nextTick()
+
+    // Act — simulate another widget activating TSLA on the bus
+    activeTicker.value = 'TSLA'
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('TSLA')
+    expect(countDataRows(wrapper)).toBe(1)
+    wrapper.unmount()
+  })
+
+  test('filter mode: activeTicker cleared on bus clears tickerFilter', async () => {
+    // Arrange — establish a non-empty filter first (via typing), then check bus clear resets it
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'filter' } },
+    })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'TSLA' })])
+    await nextTick()
+    // Set filter via typing so it is non-empty before the bus clear
+    await wrapper.find('[data-testid="ticker-filter-input"]').setValue('TSLA')
+    await nextTick()
+
+    // Act — bus ticker cleared (e.g. user clicks same row again in another widget)
+    activeTicker.value = null
+    await nextTick()
+
+    // Assert — filter cleared; all rows visible again
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('')
+    expect(countDataRows(wrapper)).toBe(1)
+    wrapper.unmount()
+  })
+
+  test('select (link) mode: activeTicker change on bus does not update tickerFilter', async () => {
+    // Arrange
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { rowClickMode: 'link' } },
+    })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'TSLA' })])
+    await nextTick()
+
+    // Act
+    activeTicker.value = 'TSLA'
+    await nextTick()
+
+    // Assert — ticker filter unchanged in select mode
+    expect(wrapper.find('[data-testid="ticker-filter-input"]').element.value).toBe('')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Fixes

### 1. TypeError: Cannot read properties of undefined (reading 'toUpperCase')

When filter mode is active and events with missing `symbol` fields are present (e.g. stale Redis cache entries from before quote fields were added to the alert payload), `filteredEvents` throws, Vue returns the cached value (which may still contain symbol-less events), and those events then reach `isRowActive` with `filterSetByClick=true`, throwing inside the render function. Vue empties the component. Repeats on every WebSocket event — hence the blank widget and repeated errors.

**Fix:** null guards at all three `.toUpperCase()` call sites:
- `filteredEvents`: `(e.symbol ?? '').toUpperCase()`
- `isRowActive`: `(row.symbol ?? '').toUpperCase()`
- `handleRowClick`: guard before entering filter logic; `onRowClick` still fires

### 2. Filter mode does not follow bus activeTicker

In filter mode, clicking a row in another widget on the same scanner link bus (Top Gainers, Top Volume, etc.) did not update the ticker filter. The filter only responded to clicks within the Range Alerts widget itself.

**Fix:** Added a watcher on `activeTicker` (from `useScannerLink`) that syncs `tickerFilter` in filter mode:
- Bus activates ticker → `tickerFilter` follows
- Bus clears ticker → `tickerFilter` clears
- Select (link) mode → no change to existing behavior

## Tests

7 new tests across two TDD arcs (both arcs have public red CI runs):
- 4 null symbol regression tests (console.error spying)
- 3 bus sync tests (activeTicker change/clear in filter mode; mode guard)

refs #230