### PR TITLE
fix(CandlestickChart): restore dark-themed DataZoom slider for tablet navigation

### DIFF
--- a/client/src/components/widgets/CandlestickChart.vue
+++ b/client/src/components/widgets/CandlestickChart.vue
@@ -451,8 +451,25 @@ const chartOption = computed(() => {
     xAxis: xAxes,
     yAxis: yAxes,
     dataZoom: [
-      // Inside zoom only — no slider bar cluttering the bottom
+      // Inside (scroll/pinch) zoom
       { type: 'inside', xAxisIndex: dataZoomXIdx, start: 70, end: 100, zoomLock: false },
+      // Slider for tablet/touch navigation — dark-themed to match chart
+      {
+        type: 'slider',
+        xAxisIndex: dataZoomXIdx,
+        start: 70,
+        end: 100,
+        height: 18,
+        bottom: 4,
+        backgroundColor: '#111',
+        borderColor: '#333',
+        fillerColor: 'rgba(139,92,246,0.1)',
+        handleStyle: { color: '#555', borderColor: '#555' },
+        moveHandleStyle: { color: '#555' },
+        textStyle: { color: '#6b7280', fontSize: 10 },
+        dataBackground: { lineStyle: { color: '#333' }, areaStyle: { color: '#1a1a1a' } },
+        selectedDataBackground: { lineStyle: { color: '#555' }, areaStyle: { color: '#222' } },
+      },
     ],
     series,
   }

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -461,9 +461,13 @@ describe('DataZoom slider', () => {
     const option = wrapper.findComponent({ name: 'VChart' }).props('option')
     const slider = option.dataZoom.find(dz => dz.type === 'slider')
 
-    // Assert — slider has dark background (not default white)
+    // Assert — concrete dark theme values; prevents regression to default white/light style
     expect(slider).toBeDefined()
-    expect(slider.backgroundColor).toBeDefined()
+    expect(slider.backgroundColor).toBe('#111')
+    expect(slider.borderColor).toBe('#333')
+    expect(slider.fillerColor).toBe('rgba(139,92,246,0.1)')
+    expect(slider.handleStyle.color).toBe('#555')
+    expect(slider.textStyle.color).toBe('#6b7280')
     wrapper.unmount()
   })
 })

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -416,3 +416,54 @@ describe('Settings persistence', () => {
     wrapper.unmount()
   })
 })
+
+// ── DataZoom slider ───────────────────────────────────────────────────────────
+
+describe('DataZoom slider', () => {
+  test('chartOption includes a slider-type DataZoom for tablet/touch navigation', async () => {
+    // Arrange
+    global.fetch = mockFetch({
+      results: Array.from({ length: 5 }, (_, i) => ({
+        t: (1_700_000_000 + i * 60) * 1000,
+        o: 100, h: 105, l: 95, c: 102, v: 1_000_000, vw: 101,
+      })),
+    })
+    const wrapper = mount(CandlestickChart, {
+      props: { ...defaultProps, settings: { tickerSource: 'manual', ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const option = wrapper.findComponent({ name: 'VChart' }).props('option')
+
+    // Assert — dataZoom contains a slider entry
+    expect(option.dataZoom).toBeDefined()
+    expect(option.dataZoom.some(dz => dz.type === 'slider')).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('slider DataZoom is styled for dark theme', async () => {
+    // Arrange
+    global.fetch = mockFetch({
+      results: Array.from({ length: 5 }, (_, i) => ({
+        t: (1_700_000_000 + i * 60) * 1000,
+        o: 100, h: 105, l: 95, c: 102, v: 1_000_000, vw: 101,
+      })),
+    })
+    const wrapper = mount(CandlestickChart, {
+      props: { ...defaultProps, settings: { tickerSource: 'manual', ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const option = wrapper.findComponent({ name: 'VChart' }).props('option')
+    const slider = option.dataZoom.find(dz => dz.type === 'slider')
+
+    // Assert — slider has dark background (not default white)
+    expect(slider).toBeDefined()
+    expect(slider.backgroundColor).toBeDefined()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
Restores the DataZoom slider that was removed during the dark theme styling pass. Tablet users benefit from the drag handle for scroll navigation; scroll/pinch zoom alone is awkward on touch screens.

Slider is styled for the dark theme: dark background, muted handle/border colors, matching the existing chart aesthetic.

TDD arc: red commit `668c8db` (no slider in chartOption) → green commit (pending).

refs #234