### PR TITLE
fix+feat(CandlestickChart): candle colors, connection indicator, indicator counts, color pickers, header ticker input

### DIFF
--- a/client/src/components/widgets/CandlestickChart.vue
+++ b/client/src/components/widgets/CandlestickChart.vue
@@ -2,8 +2,19 @@
   <div class="candlestick-chart-widget">
     <!-- Header -->
     <div class="chart-header">
-      <div class="ticker-display">
-        <span class="ticker-label">{{ tickerLocal || '—' }}</span>
+      <div class="ticker-input-wrap">
+        <input
+          type="text"
+          class="header-ticker-input"
+          :value="headerTickerInput"
+          @input="headerTickerInput = $event.target.value.toUpperCase()"
+          @keydown.enter="onGoTicker"
+          placeholder="Ticker…"
+          data-testid="header-ticker-input"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <button class="go-btn" @click="onGoTicker" title="Go">Go</button>
       </div>
       <div class="interval-btns">
         <button
@@ -19,26 +30,6 @@
 
     <!-- Settings panel -->
     <div v-if="showSettings" class="settings-panel">
-      <!-- Ticker source -->
-      <div class="settings-row">
-        <span class="settings-label">Ticker</span>
-        <label class="radio-label">
-          <input type="radio" v-model="tickerSourceLocal" value="bus" @change="emitSettings" /> Bus
-        </label>
-        <label class="radio-label">
-          <input type="radio" v-model="tickerSourceLocal" value="manual" @change="emitSettings" /> Manual
-        </label>
-        <input
-          v-if="tickerSourceLocal === 'manual'"
-          type="text"
-          v-model="manualTickerLocal"
-          @change="emitSettings"
-          placeholder="Ticker…"
-          class="ticker-input"
-          data-testid="manual-ticker-input"
-        />
-      </div>
-
       <!-- Bar count -->
       <div class="settings-row">
         <span class="settings-label">Bars</span>
@@ -64,24 +55,28 @@
 
       <!-- Overlays -->
       <div class="settings-section-title">Overlays</div>
-      <div class="settings-row" v-for="(cfg, idx) in emaLocal" :key="`ema-${idx}`">
+      <div class="settings-row" v-for="(cfg, idx) in emaLocal" :key="`ema-${idx}`" :data-testid="`ema-row-${idx}`">
         <input type="checkbox" v-model="cfg.enabled" @change="emitSettings" />
         <span class="settings-label">EMA</span>
         <input type="number" v-model.number="cfg.period" @change="emitSettings" min="1" class="narrow-input" />
+        <input type="color" v-model="cfg.color" @change="emitSettings" class="color-picker" :title="`EMA${cfg.period} color`" />
       </div>
       <div class="settings-row" v-for="(cfg, idx) in smaLocal" :key="`sma-${idx}`">
         <input type="checkbox" v-model="cfg.enabled" @change="emitSettings" />
         <span class="settings-label">SMA</span>
         <input type="number" v-model.number="cfg.period" @change="emitSettings" min="1" class="narrow-input" />
+        <input type="color" v-model="cfg.color" @change="emitSettings" class="color-picker" :title="`SMA${cfg.period} color`" />
       </div>
       <div class="settings-row" v-for="(cfg, idx) in vwmaLocal" :key="`vwma-${idx}`">
         <input type="checkbox" v-model="cfg.enabled" @change="emitSettings" />
         <span class="settings-label">VWMA</span>
         <input type="number" v-model.number="cfg.period" @change="emitSettings" min="1" class="narrow-input" />
+        <input type="color" v-model="cfg.color" @change="emitSettings" class="color-picker" :title="`VWMA${cfg.period} color`" />
       </div>
       <div class="settings-row">
         <input type="checkbox" v-model="vwapLocal.enabled" @change="emitSettings" />
         <span class="settings-label">VWAP</span>
+        <input type="color" v-model="vwapLocal.color" @change="emitSettings" class="color-picker" title="VWAP color" />
       </div>
 
       <!-- Panes -->
@@ -108,7 +103,7 @@
 
     <!-- No ticker placeholder -->
     <div v-if="!tickerLocal" class="no-ticker" data-testid="no-ticker">
-      <span>No ticker selected. {{ tickerSourceLocal === 'bus' ? 'Click a row in a linked scanner.' : 'Enter a ticker in Settings.' }}</span>
+      <span>No ticker selected. Click a row in a linked scanner or enter a ticker above.</span>
     </div>
 
     <!-- Error state -->
@@ -189,12 +184,16 @@ const DEFAULT_SETTINGS = {
   ema:   [
     { period: 9,  enabled: true,  color: '#f59e0b' },
     { period: 21, enabled: true,  color: '#3b82f6' },
+    { period: 50, enabled: false, color: '#34d399' },
   ],
   sma:   [
     { period: 50,  enabled: false, color: '#a78bfa' },
     { period: 200, enabled: false, color: '#f87171' },
   ],
-  vwma:  [{ period: 20, enabled: false, color: '#34d399' }],
+  vwma:  [
+    { period: 20, enabled: false, color: '#84cc16' },
+    { period: 50, enabled: false, color: '#fb923c' },
+  ],
   vwap:  { enabled: true,  color: '#e879f9' },
   volume:    { enabled: true },
   avgVolume: { enabled: true, period: 20, color: '#6b7280' },
@@ -212,11 +211,13 @@ const { activeTicker } = useScannerLink(computed(() => props.linkColor))
 
 // ── Local state ───────────────────────────────────────────────────────────────
 const bars    = ref([])
-const loading = ref(false)
-const error   = ref(null)
+const loading    = ref(false)
+const error      = ref(null)
+const lastDataAt  = ref(null)   // set after each successful fetch; drives WidgetWrapper freshness indicator
+const isConnected  = ref(true)  // REST widget — always connected
+const reconnecting = ref(false) // REST widget — never reconnecting
 
-const tickerSourceLocal   = ref(config.value.tickerSource)
-const manualTickerLocal   = ref(config.value.ticker ?? '')
+const headerTickerInput   = ref(config.value.ticker?.trim().toUpperCase() ?? '')
 const intervalLocal       = ref(config.value.interval)
 const barCountLocal       = ref(config.value.barCount)
 const autoRefreshLocal    = ref(config.value.autoRefresh)
@@ -231,12 +232,18 @@ const macdLocal           = ref({ ...config.value.macd })
 const showSettings        = ref(false)
 
 // ── Resolved ticker ───────────────────────────────────────────────────────────
-const tickerLocal = computed(() => {
-  if (tickerSourceLocal.value === 'manual') {
-    return manualTickerLocal.value?.trim().toUpperCase() || null
-  }
-  return activeTicker.value || null
+const tickerLocal = computed(() => headerTickerInput.value?.trim().toUpperCase() || null)
+
+// Bus auto-fills the header input when it fires
+watch(activeTicker, (t) => {
+  if (t) headerTickerInput.value = t
 })
+
+const onGoTicker = () => {
+  const sym = headerTickerInput.value.trim().toUpperCase()
+  headerTickerInput.value = sym
+  emitSettings()
+}
 
 // ── Date range helper ─────────────────────────────────────────────────────────
 function buildDateRange(interval) {
@@ -262,6 +269,7 @@ async function fetchBars() {
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
     const json = await resp.json()
     bars.value = json.results ?? []
+    lastDataAt.value = Date.now()
   } catch (e) {
     error.value = e.message
   } finally {
@@ -290,6 +298,8 @@ function clearRefresh() {
 scheduleRefresh()
 onUnmounted(() => clearRefresh())
 
+defineExpose({ lastDataAt, isConnected, reconnecting })
+
 function onAutoRefreshChange() {
   scheduleRefresh()
   emitSettings()
@@ -309,8 +319,7 @@ function selectInterval(iv) {
 // ── Settings ──────────────────────────────────────────────────────────────────
 function emitSettings() {
   emit('update-settings', {
-    ticker:          manualTickerLocal.value?.trim().toUpperCase() || null,
-    tickerSource:    tickerSourceLocal.value,
+    ticker:          headerTickerInput.value?.trim().toUpperCase() || null,
     interval:        intervalLocal.value,
     barCount:        barCountLocal.value,
     autoRefresh:     autoRefreshLocal.value,
@@ -327,8 +336,7 @@ function emitSettings() {
 
 watch(() => props.settings, (s) => {
   const m = { ...DEFAULT_SETTINGS, ...s }
-  tickerSourceLocal.value    = m.tickerSource
-  manualTickerLocal.value    = m.ticker ?? ''
+  headerTickerInput.value    = m.ticker?.trim().toUpperCase() ?? ''
   intervalLocal.value        = m.interval
   barCountLocal.value        = m.barCount
   autoRefreshLocal.value     = m.autoRefresh
@@ -412,7 +420,7 @@ const chartOption = computed(() => {
     data: candles,
     xAxisIndex: 0,
     yAxisIndex: 0,
-    itemStyle: { color: '#ef5350', color0: '#26a69a', borderColor: '#ef5350', borderColor0: '#26a69a' },
+    itemStyle: { color: '#26a69a', color0: '#ef5350', borderColor: '#26a69a', borderColor0: '#ef5350' },
   })
 
   // Overlays
@@ -501,6 +509,51 @@ const chartOption = computed(() => {
   font-size: 14px;
   color: #fff;
   min-width: 50px;
+}
+
+.ticker-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.header-ticker-input {
+  width: 72px;
+  padding: 2px 6px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.header-ticker-input:focus { outline: none; border-color: #8b5cf6; }
+.header-ticker-input::placeholder { color: #555; font-weight: normal; }
+
+.go-btn {
+  padding: 2px 7px;
+  background: rgba(139,92,246,0.15);
+  border: 1px solid rgba(139,92,246,0.4);
+  border-radius: 3px;
+  color: #a78bfa;
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.go-btn:hover { background: rgba(139,92,246,0.25); }
+
+.color-picker {
+  width: 24px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid #444;
+  border-radius: 3px;
+  background: none;
+  cursor: pointer;
+  flex-shrink: 0;
 }
 
 .interval-btns {

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -365,25 +365,25 @@ describe('Ticker source', () => {
     wrapper.unmount()
   })
 
-  test('manual mode: uses settings.ticker, ignores bus', async () => {
-    // Arrange
+  test('bus always updates ticker: bus fires even when ticker was pre-configured', async () => {
+    // Arrange — bus always enabled now; manual ticker set via settings is overridable by bus
     global.fetch = mockFetch({ results: [] })
     const callsBefore = vi.mocked(useScannerLink).mock.calls.length
     const wrapper = mount(CandlestickChart, {
-      props: { ...defaultProps, settings: { tickerSource: 'manual', ticker: 'AAPL' } },
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
     })
     await nextTick()
     await nextTick()
     const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
     const fetchBefore = global.fetch.mock.calls.length
 
-    // Act
+    // Act — bus fires TSLA
     activeTicker.value = 'TSLA'
     await nextTick()
     await nextTick()
 
-    // Assert — bus change does NOT trigger additional fetch in manual mode
-    expect(global.fetch.mock.calls.length).toBe(fetchBefore)
+    // Assert — bus DOES trigger additional fetch (bus always enabled)
+    expect(global.fetch.mock.calls.length).toBeGreaterThan(fetchBefore)
     wrapper.unmount()
   })
 })
@@ -409,7 +409,6 @@ describe('Settings persistence', () => {
     expect(settingsCalls.length).toBeGreaterThan(0)
     const last = settingsCalls[settingsCalls.length - 1]
     expect(last).toHaveProperty('ticker')
-    expect(last).toHaveProperty('tickerSource')
     expect(last).toHaveProperty('interval')
     expect(last).toHaveProperty('autoRefresh')
     expect(last).toHaveProperty('refreshInterval')
@@ -533,30 +532,23 @@ describe('Candle colors (Bug 2)', () => {
 })
 
 describe('Default indicator counts (Tweak 1)', () => {
-  test('default settings include 3 EMA entries', () => {
-    // Arrange + Act
-    const wrapper = mount(CandlestickChart, { props: defaultProps })
-    const option = wrapper.findComponent({ name: 'VChart' }).props('option')
-
-    // Assert — 3 EMA series (even if some disabled)
-    // We check via the settings structure exposed through settings emit
-    wrapper.unmount()
-
-    // Direct DEFAULT_SETTINGS check via component mount with empty settings
-    const wrapper2 = mount(CandlestickChart, {
-      props: { ...defaultProps, settings: {} },
-    })
+  test('default settings include 3 EMA entries', async () => {
+    // Arrange
     const settingsCalls = []
-    // Trigger a settings emit via interval button click
-    wrapper2.find('[data-testid="interval-btn-5m"]').trigger('click')
-    // Check that the component was initialized with 3 EMAs
-    // We check the rendered settings panel for 3 EMA rows
-    wrapper2.find('.col-menu-btn').trigger('click')
-    nextTick().then(() => {
-      const emaRows = wrapper2.findAll('[data-testid^="ema-row-"]')
-      expect(emaRows.length).toBe(3)
+    const wrapper = mount(CandlestickChart, {
+      props: { ...defaultProps, settings: {} },
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
     })
-    wrapper2.unmount()
+    await nextTick()
+
+    // Act — trigger emit
+    await wrapper.find('[data-testid="interval-btn-5m"]').trigger('click')
+    await nextTick()
+
+    // Assert — emitted settings has 3 EMA entries
+    const last = settingsCalls[settingsCalls.length - 1]
+    expect(last.ema.length).toBe(3)
+    wrapper.unmount()
   })
 
   test('default settings include 2 VWMA entries', async () => {

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -515,7 +515,7 @@ describe('Candle colors (Bug 2)', () => {
     // Arrange
     global.fetch = mockFetch({ results: [{ t: 1700000000000, o: 100, h: 105, l: 95, c: 102, v: 1e6, vw: 101 }] })
     const wrapper = mount(CandlestickChart, {
-      props: { ...defaultProps, settings: { tickerSource: 'manual', ticker: 'AAPL' } },
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
     })
     await nextTick()
     await nextTick()

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -471,3 +471,155 @@ describe('DataZoom slider', () => {
     wrapper.unmount()
   })
 })
+
+// ── Bug fixes & tweaks ────────────────────────────────────────────────────────
+
+describe('Connection indicator (Bug 1)', () => {
+  test('exposes isConnected as true (REST widget, never disconnects)', () => {
+    // Arrange + Act
+    const wrapper = mount(CandlestickChart, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.vm.isConnected).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('exposes reconnecting as false', () => {
+    // Arrange + Act
+    const wrapper = mount(CandlestickChart, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.vm.reconnecting).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('exposes lastDataAt as non-null after successful fetch', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [] })
+    const wrapper = mount(CandlestickChart, {
+      props: { ...defaultProps, settings: { tickerSource: 'manual', ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const lastDataAt = wrapper.vm.lastDataAt
+
+    // Assert
+    expect(lastDataAt).not.toBeNull()
+    wrapper.unmount()
+  })
+})
+
+describe('Candle colors (Bug 2)', () => {
+  test('bullish candles (close >= open) use green color', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [{ t: 1700000000000, o: 100, h: 105, l: 95, c: 102, v: 1e6, vw: 101 }] })
+    const wrapper = mount(CandlestickChart, {
+      props: { ...defaultProps, settings: { tickerSource: 'manual', ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const option = wrapper.findComponent({ name: 'VChart' }).props('option')
+    const candleSeries = option.series?.find(s => s.type === 'candlestick')
+
+    // Assert — color (bullish/up candle) should be green, not red
+    expect(candleSeries.itemStyle.color).toBe('#26a69a')
+    expect(candleSeries.itemStyle.color0).toBe('#ef5350')
+    wrapper.unmount()
+  })
+})
+
+describe('Default indicator counts (Tweak 1)', () => {
+  test('default settings include 3 EMA entries', () => {
+    // Arrange + Act
+    const wrapper = mount(CandlestickChart, { props: defaultProps })
+    const option = wrapper.findComponent({ name: 'VChart' }).props('option')
+
+    // Assert — 3 EMA series (even if some disabled)
+    // We check via the settings structure exposed through settings emit
+    wrapper.unmount()
+
+    // Direct DEFAULT_SETTINGS check via component mount with empty settings
+    const wrapper2 = mount(CandlestickChart, {
+      props: { ...defaultProps, settings: {} },
+    })
+    const settingsCalls = []
+    // Trigger a settings emit via interval button click
+    wrapper2.find('[data-testid="interval-btn-5m"]').trigger('click')
+    // Check that the component was initialized with 3 EMAs
+    // We check the rendered settings panel for 3 EMA rows
+    wrapper2.find('.col-menu-btn').trigger('click')
+    nextTick().then(() => {
+      const emaRows = wrapper2.findAll('[data-testid^="ema-row-"]')
+      expect(emaRows.length).toBe(3)
+    })
+    wrapper2.unmount()
+  })
+
+  test('default settings include 2 VWMA entries', async () => {
+    // Arrange
+    const settingsCalls = []
+    const wrapper = mount(CandlestickChart, {
+      props: { ...defaultProps, settings: {} },
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    await nextTick()
+
+    // Act — trigger emit
+    await wrapper.find('[data-testid="interval-btn-5m"]').trigger('click')
+    await nextTick()
+
+    // Assert — emitted settings has 2 VWMA entries
+    const last = settingsCalls[settingsCalls.length - 1]
+    expect(last.vwma.length).toBe(2)
+    wrapper.unmount()
+  })
+})
+
+describe('Header ticker input (Tweak 3)', () => {
+  test('ticker input is always visible in the widget header', () => {
+    // Arrange + Act
+    const wrapper = mount(CandlestickChart, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.find('[data-testid="header-ticker-input"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('pressing Enter in header ticker input triggers fetch with that ticker', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [] })
+    const wrapper = mount(CandlestickChart, { props: defaultProps })
+    await nextTick()
+
+    // Act
+    await wrapper.find('[data-testid="header-ticker-input"]').setValue('TSLA')
+    await wrapper.find('[data-testid="header-ticker-input"]').trigger('keydown.enter')
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.some(c => c[0].includes('TSLA'))).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('bus activeTicker updates the header ticker input', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [] })
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(CandlestickChart, { props: defaultProps })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+    await nextTick()
+
+    // Act
+    activeTicker.value = 'MSFT'
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('[data-testid="header-ticker-input"]').element.value).toBe('MSFT')
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -382,8 +382,8 @@ describe('Ticker source', () => {
     await nextTick()
     await nextTick()
 
-    // Assert — bus DOES trigger additional fetch (bus always enabled)
-    expect(global.fetch.mock.calls.length).toBeGreaterThan(fetchBefore)
+    // Assert — bus DOES trigger exactly one additional fetch (not two — double-fire would be a regression)
+    expect(global.fetch.mock.calls.length).toBe(fetchBefore + 1)
     wrapper.unmount()
   })
 })
@@ -496,7 +496,7 @@ describe('Connection indicator (Bug 1)', () => {
     // Arrange
     global.fetch = mockFetch({ results: [] })
     const wrapper = mount(CandlestickChart, {
-      props: { ...defaultProps, settings: { tickerSource: 'manual', ticker: 'AAPL' } },
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
     })
     await nextTick()
     await nextTick()


### PR DESCRIPTION
## Bugs fixed

1. **Connection indicator flashing** — `CandlestickChart` didn't `defineExpose`, so `WidgetWrapper` saw `lastDataAt = null` and entered the permanent oscillating "connecting" state. Fix: expose `lastDataAt` (set after each successful fetch), `isConnected: true`, `reconnecting: false`.

2. **Candle colors inverted** — ECharts `color` (bullish) was `#ef5350` (red) and `color0` (bearish) was `#26a69a` (green). Swapped.

## Tweaks

3. **3 EMAs, 2 VWMAs** — Added 3rd EMA (period 50) and 2nd VWMA (period 50) to DEFAULT_SETTINGS.

4. **Color pickers for all overlays** — Added `<input type="color">` for each EMA, SMA, VWMA entry and for VWAP in the settings panel.

5. **Header ticker input** — Replaced bus/manual radio + settings-panel text box with an always-visible ticker `<input>` + Go button in the widget header. Bus always enabled (fires → auto-fills the input). Manual entry: type + press Enter or click Go.

TDD arc: red commit `cea0823` → green commit (pending).

refs #234