### PR TITLE
fix(CandlestickChart): remove orphaned tickerSource from DEFAULT_SETTINGS

### DIFF
--- a/client/src/components/widgets/CandlestickChart.vue
+++ b/client/src/components/widgets/CandlestickChart.vue
@@ -176,7 +176,6 @@ const INTERVAL_MS = {
 
 const DEFAULT_SETTINGS = {
   ticker:          null,
-  tickerSource:    'bus',
   interval:        '5m',
   barCount:        1000,
   autoRefresh:     true,


### PR DESCRIPTION
Removes `tickerSource: 'bus'` from `DEFAULT_SETTINGS`. This field was made obsolete in PR #237 when bus/manual mode selection was replaced with the always-enabled bus + header ticker input pattern. The field was silently accepted but never read.


One-line change, 441/441 passing.