### PR TITLE
feat(TVLiteChart): new TV Lite Chart widget using TradingView Lightweight Charts v5

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@polygon.io/client-js": "^8.2.0",
         "echarts": "^6.0.0",
+        "lightweight-charts": "^5.2.0",
         "vue": "^3.5.18",
         "vue-echarts": "^8.0.1",
         "vue-virtual-scroller": "^2.0.0-beta.10",
@@ -2948,6 +2949,12 @@
         "type": "^2.7.2"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3534,6 +3541,15 @@
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.2.0.tgz",
+      "integrity": "sha512-ey3Vas8UhV06ni+LT9TA1nEe4y8So4Mi6CL/oarNHFMyTktz/xy8e8+oh04Q//eO3t6etvFXgayz2fClyFQb5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@polygon.io/client-js": "^8.2.0",
     "echarts": "^6.0.0",
+    "lightweight-charts": "^5.2.0",
     "vue": "^3.5.18",
     "vue-echarts": "^8.0.1",
     "vue-virtual-scroller": "^2.0.0-beta.10",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       echarts:
         specifier: ^6.0.0
         version: 6.0.0
+      lightweight-charts:
+        specifier: ^5.2.0
+        version: 5.2.0
       vue:
         specifier: ^3.5.18
         version: 3.5.32
@@ -1014,6 +1017,9 @@ packages:
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1183,6 +1189,9 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  lightweight-charts@5.2.0:
+    resolution: {integrity: sha512-ey3Vas8UhV06ni+LT9TA1nEe4y8So4Mi6CL/oarNHFMyTktz/xy8e8+oh04Q//eO3t6etvFXgayz2fClyFQb5w==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2635,6 +2644,8 @@ snapshots:
     dependencies:
       type: 2.7.3
 
+  fancy-canvas@2.1.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2802,6 +2813,10 @@ snapshots:
   json5@2.2.3: {}
 
   kolorist@1.8.0: {}
+
+  lightweight-charts@5.2.0:
+    dependencies:
+      fancy-canvas: 2.1.0
 
   lru-cache@10.4.3: {}
 

--- a/client/src/components/WidgetMenu.vue
+++ b/client/src/components/WidgetMenu.vue
@@ -38,6 +38,7 @@ const availableWidgets = [
   { type: 'enhanced-quote-v4', label: 'Enhanced Quote', icon: '💎' },
   { type: 'range-alerts',      label: 'Range Alerts',      icon: '🔔' },
   { type: 'candlestick-chart', label: 'Candlestick Chart',  icon: '📈' },
+  { type: 'tv-lite-chart',     label: 'TV Lite Chart',       icon: '📊' },
 ]
 
 const selectWidget = (widget) => {

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -74,6 +74,7 @@ import EnhancedQuoteV3 from './widgets/EnhancedQuoteV3.vue'
 import EnhancedQuoteV4 from './widgets/EnhancedQuoteV4.vue'
 import DailyRangeAlerts from './widgets/DailyRangeAlerts.vue'
 import CandlestickChart from './widgets/CandlestickChart.vue'
+import TVLiteChart     from './widgets/TVLiteChart.vue'
 import { LINK_COLORS, LINK_COLOR_MAP } from '@/composables/useWidgetBus.js'
 
 const props = defineProps({
@@ -99,6 +100,7 @@ const widgetComponents = {
   'enhanced-quote-v4': EnhancedQuoteV4,
   'range-alerts':      DailyRangeAlerts,
   'candlestick-chart': CandlestickChart,
+  'tv-lite-chart':     TVLiteChart,
 }
 
 const widgetComponent = computed(() => widgetComponents[props.widgetType])

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -166,7 +166,7 @@ const DEFAULT_SETTINGS = {
   ],
   vwap:  { enabled: true,  color: '#ff7400' },
   volume: { enabled: true },
-  macd:  { enabled: false, fast: 12, slow: 26, signal: 9 },
+  macd:  { enabled: true, fast: 12, slow: 26, signal: 9 },
 }
 
 const config = computed(() => ({ ...DEFAULT_SETTINGS, ...props.settings }))

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -77,6 +77,12 @@
         <input type="checkbox" v-model="volumeLocal.enabled" @change="emitSettings" />
         <span class="settings-label">Volume</span>
       </div>
+      <div class="settings-row" v-if="volumeLocal.enabled">
+        <input type="checkbox" v-model="avgVolumeLocal.enabled" @change="emitSettings" />
+        <span class="settings-label">Avg Vol</span>
+        <input type="number" v-model.number="avgVolumeLocal.period" @change="emitSettings" min="1" class="narrow-input" />
+        <input type="color" v-model="avgVolumeLocal.color" @change="emitSettings" class="color-picker" />
+      </div>
       <div class="settings-row">
         <input type="checkbox" v-model="macdLocal.enabled" @change="emitSettings" />
         <span class="settings-label">MACD</span>
@@ -115,7 +121,7 @@ import {
 import { useScannerLink } from '@/composables/useScannerLink.js'
 import { useConfig }      from '@/composables/useConfig.js'
 import {
-  calcEMA, calcSMA, calcVWMA, calcVWAP, calcMACD,
+  calcEMA, calcSMA, calcVWMA, calcVWAP, calcMACD, calcVolumeAvg,
 } from '@/utils/chartIndicators.js'
 
 // ── Props / emits ─────────────────────────────────────────────────────────────
@@ -166,6 +172,7 @@ const DEFAULT_SETTINGS = {
   ],
   vwap:  { enabled: true,  color: '#ff7400' },
   volume: { enabled: true },
+  avgVolume: { enabled: true, period: 20, color: '#0257ff' },
   macd:  { enabled: true, fast: 12, slow: 26, signal: 9 },
 }
 
@@ -198,6 +205,7 @@ const smaLocal            = ref(config.value.sma.map(e => ({ ...e })))
 const vwmaLocal           = ref(config.value.vwma.map(e => ({ ...e })))
 const vwapLocal           = ref({ ...config.value.vwap })
 const volumeLocal         = ref({ ...config.value.volume })
+const avgVolumeLocal      = ref({ ...config.value.avgVolume })
 const macdLocal           = ref({ ...config.value.macd })
 const showSettings        = ref(false)
 
@@ -262,12 +270,13 @@ watch(() => props.settings, (s) => {
   vwmaLocal.value            = m.vwma.map(e => ({ ...e }))
   vwapLocal.value            = { ...m.vwap }
   volumeLocal.value          = { ...m.volume }
+  avgVolumeLocal.value       = { ...m.avgVolume }
   macdLocal.value            = { ...m.macd }
 })
 
 // Re-render chart when any indicator/pane setting changes (no refetch needed)
 watch(
-  [emaLocal, smaLocal, vwmaLocal, vwapLocal, volumeLocal, macdLocal],
+  [emaLocal, smaLocal, vwmaLocal, vwapLocal, volumeLocal, avgVolumeLocal, macdLocal],
   () => { updateChart() },
   { deep: true }
 )
@@ -305,6 +314,7 @@ function emitSettings() {
     vwma:            vwmaLocal.value.map(e => ({ ...e })),
     vwap:            { ...vwapLocal.value },
     volume:          { ...volumeLocal.value },
+    avgVolume:       { ...avgVolumeLocal.value },
     macd:            { ...macdLocal.value },
   })
 }
@@ -316,6 +326,7 @@ const chartContainer = ref(null)
 let chart          = null
 let candleSeries   = null
 let volumeSeriesRef = null
+let avgVolumeSeriesRef = null
 let overlaySeries  = []
 let macdSeriesRef  = { line: null, signal: null, histogram: null }
 let resizeObserver = null
@@ -361,6 +372,16 @@ onMounted(() => {
     visible: volumeLocal.value.enabled,
   }, PANE_VOLUME)
   chart.priceScale('volume').applyOptions({ scaleMargins: { top: 0.7, bottom: 0 } })
+
+  // Avg Volume line on volume pane — always created, visibility controlled in updateChart
+  avgVolumeSeriesRef = chart.addSeries(LineSeries, {
+    color:              avgVolumeLocal.value.color ?? '#0257ff',
+    lineWidth:          1,
+    priceLineVisible:   false,
+    lastValueVisible:   false,
+    visible:            volumeLocal.value.enabled && avgVolumeLocal.value.enabled,
+    priceScaleId:       'volume',
+  }, PANE_VOLUME)
 
   // MACD (pane 2) — always created; visibility controlled in updateChart
   macdSeriesRef.line      = chart.addSeries(LineSeries,      { color: '#3b82f6', lineWidth: 1, visible: macdLocal.value.enabled }, PANE_MACD)
@@ -412,6 +433,16 @@ function updateChart() {
         value: b.v,
         color: b.c >= b.o ? 'rgba(38,166,154,0.5)' : 'rgba(239,83,80,0.5)',
       })))
+    }
+  }
+
+  // Avg Volume line — visibility tied to both volume pane AND avgVolume toggle
+  if (avgVolumeSeriesRef) {
+    const showAvgVol = volumeLocal.value.enabled && avgVolumeLocal.value.enabled
+    avgVolumeSeriesRef.applyOptions({ visible: showAvgVol, color: avgVolumeLocal.value.color ?? '#0257ff' })
+    if (showAvgVol) {
+      const vals = calcVolumeAvg(bars.value, avgVolumeLocal.value.period ?? 20)
+      avgVolumeSeriesRef.setData(vals.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
     }
   }
 

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -114,7 +114,7 @@ import {
 import { useScannerLink } from '@/composables/useScannerLink.js'
 import { useConfig }      from '@/composables/useConfig.js'
 import {
-  calcEMA, calcSMA, calcVWMA, calcVWAP, calcMACD, calcVolumeAvg,
+  calcEMA, calcSMA, calcVWMA, calcVWAP, calcMACD,
 } from '@/utils/chartIndicators.js'
 
 // ── Props / emits ─────────────────────────────────────────────────────────────
@@ -264,6 +264,13 @@ watch(() => props.settings, (s) => {
   macdLocal.value            = { ...m.macd }
 })
 
+// Re-render chart when any indicator/pane setting changes (no refetch needed)
+watch(
+  [emaLocal, smaLocal, vwmaLocal, vwapLocal, volumeLocal, macdLocal],
+  () => { updateChart() },
+  { deep: true }
+)
+
 // ── Auto-refresh ──────────────────────────────────────────────────────────────
 let refreshTimer = null
 
@@ -346,21 +353,18 @@ onMounted(() => {
     wickDownColor:    '#ef5350',
   }, PANE_MAIN)
 
-  // Volume (pane 1)
-  if (volumeLocal.value.enabled) {
-    volumeSeriesRef = chart.addSeries(HistogramSeries, {
-      priceFormat:  { type: 'volume' },
-      priceScaleId: 'volume',
-    }, PANE_VOLUME)
-    chart.priceScale('volume').applyOptions({ scaleMargins: { top: 0.7, bottom: 0 } })
-  }
+  // Volume (pane 1) — always created; visibility controlled in updateChart
+  volumeSeriesRef = chart.addSeries(HistogramSeries, {
+    priceFormat:  { type: 'volume' },
+    priceScaleId: 'volume',
+    visible: volumeLocal.value.enabled,
+  }, PANE_VOLUME)
+  chart.priceScale('volume').applyOptions({ scaleMargins: { top: 0.7, bottom: 0 } })
 
-  // MACD (pane 2)
-  if (macdLocal.value.enabled) {
-    macdSeriesRef.line      = chart.addSeries(LineSeries,      { color: '#3b82f6', lineWidth: 1 }, PANE_MACD)
-    macdSeriesRef.signal    = chart.addSeries(LineSeries,      { color: '#f59e0b', lineWidth: 1 }, PANE_MACD)
-    macdSeriesRef.histogram = chart.addSeries(HistogramSeries, {}, PANE_MACD)
-  }
+  // MACD (pane 2) — always created; visibility controlled in updateChart
+  macdSeriesRef.line      = chart.addSeries(LineSeries,      { color: '#3b82f6', lineWidth: 1, visible: macdLocal.value.enabled }, PANE_MACD)
+  macdSeriesRef.signal    = chart.addSeries(LineSeries,      { color: '#f59e0b', lineWidth: 1, visible: macdLocal.value.enabled }, PANE_MACD)
+  macdSeriesRef.histogram = chart.addSeries(HistogramSeries, { visible: macdLocal.value.enabled }, PANE_MACD)
 
   // Autoresize
   resizeObserver = new ResizeObserver(() => {
@@ -397,13 +401,17 @@ function updateChart() {
   }))
   candleSeries.setData(mapped)
 
-  // Volume
+  // Volume — update visibility and data
   if (volumeSeriesRef) {
-    volumeSeriesRef.setData(bars.value.map(b => ({
-      time:      b.t / 1000,
-      value:     b.v,
-      color:     b.c >= b.o ? 'rgba(38,166,154,0.5)' : 'rgba(239,83,80,0.5)',
-    })))
+    const showVol = volumeLocal.value.enabled
+    volumeSeriesRef.applyOptions({ visible: showVol })
+    if (showVol) {
+      volumeSeriesRef.setData(bars.value.map(b => ({
+        time:  b.t / 1000,
+        value: b.v,
+        color: b.c >= b.o ? 'rgba(38,166,154,0.5)' : 'rgba(239,83,80,0.5)',
+      })))
+    }
   }
 
   // Overlays — remove stale series then rebuild
@@ -434,16 +442,22 @@ function updateChart() {
   if (vwapLocal.value.enabled) {
     const s = chart.addSeries(LineSeries, { color: vwapLocal.value.color, lineWidth: 1, priceLineVisible: false, lastValueVisible: false }, PANE_MAIN)
     const vals = calcVWAP(bars.value, isIntraday.value)
-    s.setData(vals.map((v, i) => ({ time: bars.value[i].t / 1000, value: v })))
+    s.setData(vals.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
     overlaySeries.push(s)
   }
 
-  // MACD
+  // MACD — update visibility and data
   if (macdSeriesRef.line) {
-    const { macdLine, signalLine, histogram } = calcMACD(bars.value, macdLocal.value.fast, macdLocal.value.slow, macdLocal.value.signal)
-    macdSeriesRef.line.setData(macdLine.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
-    macdSeriesRef.signal.setData(signalLine.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
-    macdSeriesRef.histogram.setData(histogram.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v, color: v >= 0 ? '#26a69a' : '#ef5350' }).filter(Boolean))
+    const showMACD = macdLocal.value.enabled
+    macdSeriesRef.line.applyOptions({ visible: showMACD })
+    macdSeriesRef.signal.applyOptions({ visible: showMACD })
+    macdSeriesRef.histogram.applyOptions({ visible: showMACD })
+    if (showMACD) {
+      const { macdLine, signalLine, histogram } = calcMACD(bars.value, macdLocal.value.fast, macdLocal.value.slow, macdLocal.value.signal)
+      macdSeriesRef.line.setData(macdLine.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
+      macdSeriesRef.signal.setData(signalLine.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
+      macdSeriesRef.histogram.setData(histogram.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v, color: v >= 0 ? '#26a69a' : '#ef5350' }).filter(Boolean))
+    }
   }
 }
 

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -1,0 +1,8 @@
+<template>
+  <!-- TVLiteChart stub — implementation pending -->
+  <div class="tv-lite-chart-widget"></div>
+</template>
+
+<script setup>
+// Stub: no implementation yet — tests will fail with assertion errors
+</script>

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -1,8 +1,591 @@
 <template>
-  <!-- TVLiteChart stub — implementation pending -->
-  <div class="tv-lite-chart-widget"></div>
+  <div class="tv-lite-chart-widget">
+    <!-- Header: ticker input + interval buttons + gear -->
+    <div class="chart-header">
+      <div class="ticker-input-wrap">
+        <input
+          type="text"
+          class="header-ticker-input"
+          :value="headerTickerInput"
+          @input="headerTickerInput = $event.target.value.toUpperCase()"
+          @keydown.enter="onGoTicker"
+          placeholder="Ticker…"
+          data-testid="header-ticker-input"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <button class="go-btn" @click="onGoTicker" title="Go">Go</button>
+      </div>
+      <div class="interval-btns">
+        <button
+          v-for="iv in INTERVALS"
+          :key="iv"
+          :class="['interval-btn', intervalLocal === iv ? 'interval-btn--active' : '']"
+          :data-testid="`interval-btn-${iv}`"
+          @click="selectInterval(iv)"
+        >{{ iv }}</button>
+      </div>
+      <button class="col-menu-btn" @click="showSettings = !showSettings" title="Settings">⚙️</button>
+    </div>
+
+    <!-- Settings panel -->
+    <div v-if="showSettings" class="settings-panel">
+      <!-- Bar count -->
+      <div class="settings-row">
+        <span class="settings-label">Bars</span>
+        <input type="number" v-model.number="barCountLocal" @change="emitSettings" min="1" max="50000" class="narrow-input" data-testid="bar-count-input" />
+      </div>
+
+      <!-- Auto-refresh -->
+      <div class="settings-row">
+        <span class="settings-label">Auto-refresh</span>
+        <input type="checkbox" v-model="autoRefreshLocal" @change="onAutoRefreshChange" data-testid="auto-refresh-toggle" />
+        <select v-if="autoRefreshLocal" v-model="refreshIntervalLocal" @change="onRefreshIntervalChange" class="interval-select">
+          <option v-for="iv in INTERVALS" :key="iv" :value="iv">{{ iv }}</option>
+        </select>
+      </div>
+
+      <!-- Overlays -->
+      <div class="settings-section-title">Overlays</div>
+      <div class="settings-row" v-for="(cfg, idx) in emaLocal" :key="`ema-${idx}`">
+        <input type="checkbox" v-model="cfg.enabled" @change="emitSettings" />
+        <span class="settings-label">EMA</span>
+        <input type="number" v-model.number="cfg.period" @change="emitSettings" min="1" class="narrow-input" />
+        <input type="color" v-model="cfg.color" @change="emitSettings" class="color-picker" />
+      </div>
+      <div class="settings-row" v-for="(cfg, idx) in smaLocal" :key="`sma-${idx}`">
+        <input type="checkbox" v-model="cfg.enabled" @change="emitSettings" />
+        <span class="settings-label">SMA</span>
+        <input type="number" v-model.number="cfg.period" @change="emitSettings" min="1" class="narrow-input" />
+        <input type="color" v-model="cfg.color" @change="emitSettings" class="color-picker" />
+      </div>
+      <div class="settings-row" v-for="(cfg, idx) in vwmaLocal" :key="`vwma-${idx}`">
+        <input type="checkbox" v-model="cfg.enabled" @change="emitSettings" />
+        <span class="settings-label">VWMA</span>
+        <input type="number" v-model.number="cfg.period" @change="emitSettings" min="1" class="narrow-input" />
+        <input type="color" v-model="cfg.color" @change="emitSettings" class="color-picker" />
+      </div>
+      <div class="settings-row">
+        <input type="checkbox" v-model="vwapLocal.enabled" @change="emitSettings" />
+        <span class="settings-label">VWAP</span>
+        <input type="color" v-model="vwapLocal.color" @change="emitSettings" class="color-picker" />
+      </div>
+
+      <!-- Panes -->
+      <div class="settings-section-title">Panes</div>
+      <div class="settings-row">
+        <input type="checkbox" v-model="volumeLocal.enabled" @change="emitSettings" />
+        <span class="settings-label">Volume</span>
+      </div>
+      <div class="settings-row">
+        <input type="checkbox" v-model="macdLocal.enabled" @change="emitSettings" />
+        <span class="settings-label">MACD</span>
+        <template v-if="macdLocal.enabled">
+          <input type="number" v-model.number="macdLocal.fast"   @change="emitSettings" min="1" class="narrow-input" title="Fast" />
+          <input type="number" v-model.number="macdLocal.slow"   @change="emitSettings" min="1" class="narrow-input" title="Slow" />
+          <input type="number" v-model.number="macdLocal.signal" @change="emitSettings" min="1" class="narrow-input" title="Signal" />
+        </template>
+      </div>
+    </div>
+
+    <!-- Chart container — always in DOM so onMounted can init the chart -->
+    <div ref="chartContainer" class="chart-container" data-testid="chart-container"></div>
+
+    <!-- Overlay states rendered on top of chart container -->
+    <div v-if="!tickerLocal" class="overlay" data-testid="no-ticker">
+      <span>No ticker selected. Click a row in a linked scanner or enter a ticker above.</span>
+    </div>
+    <div v-else-if="error" class="overlay" data-testid="error-state">
+      <span>⚠ {{ error }}</span>
+      <button class="retry-btn" data-testid="retry-btn" @click="fetchBars">↻ Retry</button>
+    </div>
+    <div v-else-if="loading && !bars.length" class="overlay" data-testid="loading-state">
+      <span>Loading…</span>
+    </div>
+  </div>
 </template>
 
 <script setup>
-// Stub: no implementation yet — tests will fail with assertion errors
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import {
+  createChart, ColorType, CrosshairMode,
+  CandlestickSeries, LineSeries, HistogramSeries,
+} from 'lightweight-charts'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+import { useConfig }      from '@/composables/useConfig.js'
+import {
+  calcEMA, calcSMA, calcVWMA, calcVWAP, calcMACD, calcVolumeAvg,
+} from '@/utils/chartIndicators.js'
+
+// ── Props / emits ─────────────────────────────────────────────────────────────
+const props = defineProps({
+  isLocked:  { type: Boolean, default: true },
+  linkColor: { type: String,  default: null },
+  isMobile:  { type: Boolean, default: false },
+  settings:  { type: Object,  default: () => ({}) },
+})
+const emit = defineEmits(['update-settings'])
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const INTERVALS = ['1m', '5m', '15m', '1h', '4h', '1d', '1w']
+
+const INTERVAL_CONFIG = {
+  '1m':  { multiplier: 1,  timespan: 'minute', lookbackDays: 5    },
+  '5m':  { multiplier: 5,  timespan: 'minute', lookbackDays: 10   },
+  '15m': { multiplier: 15, timespan: 'minute', lookbackDays: 30   },
+  '1h':  { multiplier: 1,  timespan: 'hour',   lookbackDays: 90   },
+  '4h':  { multiplier: 4,  timespan: 'hour',   lookbackDays: 180  },
+  '1d':  { multiplier: 1,  timespan: 'day',    lookbackDays: 730  },
+  '1w':  { multiplier: 1,  timespan: 'week',   lookbackDays: 1825 },
+}
+
+const INTERVAL_MS = {
+  '1m': 60_000, '5m': 300_000, '15m': 900_000,
+  '1h': 3_600_000, '4h': 14_400_000, '1d': 86_400_000, '1w': 604_800_000,
+}
+
+const DEFAULT_SETTINGS = {
+  ticker:          null,
+  interval:        '5m',
+  barCount:        1000,
+  autoRefresh:     true,
+  refreshInterval: '1m',
+  ema:   [
+    { period: 9,   enabled: true,  color: '#9c9c9c' },
+    { period: 21,  enabled: true,  color: '#27a158' },
+    { period: 200, enabled: true,  color: '#7a00a3' },
+  ],
+  sma:   [
+    { period: 50,  enabled: false, color: '#8bc476' },
+    { period: 200, enabled: true,  color: '#4f7fff' },
+  ],
+  vwma:  [
+    { period: 9,  enabled: false, color: '#b0b0b0' },
+    { period: 50, enabled: true,  color: '#02e7fd' },
+  ],
+  vwap:  { enabled: true,  color: '#ff7400' },
+  volume: { enabled: true },
+  macd:  { enabled: false, fast: 12, slow: 26, signal: 9 },
+}
+
+const config = computed(() => ({ ...DEFAULT_SETTINGS, ...props.settings }))
+
+// ── Config (massiveApiKey) ────────────────────────────────────────────────────
+const { config: appConfig } = useConfig()
+
+// ── Scanner bus ───────────────────────────────────────────────────────────────
+// TVLiteChart is read-only from the bus — no onRowClick needed
+const { activeTicker } = useScannerLink(computed(() => props.linkColor))
+
+// ── Local state ───────────────────────────────────────────────────────────────
+const bars    = ref([])
+const loading = ref(false)
+const error   = ref(null)
+
+// Exposed for WidgetWrapper freshness indicator
+const lastDataAt   = ref(null)
+const isConnected  = ref(true)   // REST widget — always connected
+const reconnecting = ref(false)  // REST widget — never reconnecting
+
+const headerTickerInput   = ref(config.value.ticker?.trim().toUpperCase() ?? '')
+const intervalLocal       = ref(config.value.interval)
+const barCountLocal       = ref(config.value.barCount)
+const autoRefreshLocal    = ref(config.value.autoRefresh)
+const refreshIntervalLocal = ref(config.value.refreshInterval)
+const emaLocal            = ref(config.value.ema.map(e => ({ ...e })))
+const smaLocal            = ref(config.value.sma.map(e => ({ ...e })))
+const vwmaLocal           = ref(config.value.vwma.map(e => ({ ...e })))
+const vwapLocal           = ref({ ...config.value.vwap })
+const volumeLocal         = ref({ ...config.value.volume })
+const macdLocal           = ref({ ...config.value.macd })
+const showSettings        = ref(false)
+
+// ── Ticker ────────────────────────────────────────────────────────────────────
+const tickerLocal = computed(() => headerTickerInput.value?.trim().toUpperCase() || null)
+
+// Bus auto-fills the header input
+watch(activeTicker, (t) => { if (t) headerTickerInput.value = t })
+
+const onGoTicker = () => {
+  headerTickerInput.value = headerTickerInput.value.trim().toUpperCase()
+  emitSettings()
+}
+
+// ── Date range ────────────────────────────────────────────────────────────────
+function buildDateRange(interval) {
+  const cfg = INTERVAL_CONFIG[interval] || INTERVAL_CONFIG['1d']
+  const to   = new Date()
+  const from = new Date(to - cfg.lookbackDays * 86_400_000)
+  const fmt  = (d) => d.toISOString().split('T')[0]
+  return { from: fmt(from), to: fmt(to), ...cfg }
+}
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+async function fetchBars() {
+  if (!tickerLocal.value) return
+  const key = appConfig.value?.massiveApiKey
+  const { multiplier, timespan, from, to } = buildDateRange(intervalLocal.value)
+  const limit = barCountLocal.value
+  const url = `https://api.massive.com/v2/aggs/ticker/${tickerLocal.value}/range/${multiplier}/${timespan}/${from}/${to}?adjusted=true&sort=asc&limit=${limit}&apiKey=${key}`
+
+  loading.value = true
+  error.value   = null
+  try {
+    const resp = await fetch(url)
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const json = await resp.json()
+    bars.value       = json.results ?? []
+    lastDataAt.value = Date.now()
+    updateChart()
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+// ── Watchers ──────────────────────────────────────────────────────────────────
+watch(tickerLocal, (t) => { if (t) fetchBars() }, { immediate: true })
+watch(intervalLocal, () => { fetchBars(); scheduleRefresh() })
+
+// Sync local state when settings prop changes
+watch(() => props.settings, (s) => {
+  const m = { ...DEFAULT_SETTINGS, ...s }
+  headerTickerInput.value    = m.ticker?.trim().toUpperCase() ?? ''
+  intervalLocal.value        = m.interval
+  barCountLocal.value        = m.barCount
+  autoRefreshLocal.value     = m.autoRefresh
+  refreshIntervalLocal.value = m.refreshInterval
+  emaLocal.value             = m.ema.map(e => ({ ...e }))
+  smaLocal.value             = m.sma.map(e => ({ ...e }))
+  vwmaLocal.value            = m.vwma.map(e => ({ ...e }))
+  vwapLocal.value            = { ...m.vwap }
+  volumeLocal.value          = { ...m.volume }
+  macdLocal.value            = { ...m.macd }
+})
+
+// ── Auto-refresh ──────────────────────────────────────────────────────────────
+let refreshTimer = null
+
+function scheduleRefresh() {
+  clearRefresh()
+  if (!autoRefreshLocal.value) return
+  const ms = INTERVAL_MS[refreshIntervalLocal.value] ?? 60_000
+  refreshTimer = setInterval(fetchBars, ms)
+}
+
+function clearRefresh() {
+  if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null }
+}
+
+scheduleRefresh()
+
+function onAutoRefreshChange()    { scheduleRefresh(); emitSettings() }
+function onRefreshIntervalChange() { scheduleRefresh(); emitSettings() }
+function selectInterval(iv)       { intervalLocal.value = iv; emitSettings() }
+
+// ── Settings emit ─────────────────────────────────────────────────────────────
+function emitSettings() {
+  emit('update-settings', {
+    ticker:          headerTickerInput.value?.trim().toUpperCase() || null,
+    interval:        intervalLocal.value,
+    barCount:        barCountLocal.value,
+    autoRefresh:     autoRefreshLocal.value,
+    refreshInterval: refreshIntervalLocal.value,
+    ema:             emaLocal.value.map(e => ({ ...e })),
+    sma:             smaLocal.value.map(e => ({ ...e })),
+    vwma:            vwmaLocal.value.map(e => ({ ...e })),
+    vwap:            { ...vwapLocal.value },
+    volume:          { ...volumeLocal.value },
+    macd:            { ...macdLocal.value },
+  })
+}
+
+// ── Chart (plain JS vars — NOT Vue refs per TW docs) ─────────────────────────
+const chartContainer = ref(null)
+
+// eslint-disable-next-line no-unused-vars
+let chart          = null
+let candleSeries   = null
+let volumeSeriesRef = null
+let overlaySeries  = []
+let macdSeriesRef  = { line: null, signal: null, histogram: null }
+let resizeObserver = null
+
+// Pane indices
+const PANE_MAIN   = 0
+const PANE_VOLUME = 1
+const PANE_MACD   = 2
+
+const isIntraday = computed(() => ['1m', '5m', '15m', '1h'].includes(intervalLocal.value))
+
+onMounted(() => {
+  chart = createChart(chartContainer.value, {
+    layout: {
+      background: { type: ColorType.Solid, color: '#0f0f0f' },
+      textColor:  '#9ca3af',
+    },
+    grid: {
+      vertLines: { color: '#1a1a1a' },
+      horzLines: { color: '#1a1a1a' },
+    },
+    crosshair:       { mode: CrosshairMode.Magnet },
+    rightPriceScale: { borderColor: '#333' },
+    timeScale:       { borderColor: '#333', timeVisible: true, secondsVisible: false },
+    width:  chartContainer.value.clientWidth,
+    height: chartContainer.value.clientHeight,
+  })
+
+  // Candlestick (main pane)
+  candleSeries = chart.addSeries(CandlestickSeries, {
+    upColor:          '#26a69a',
+    downColor:        '#ef5350',
+    borderUpColor:    '#26a69a',
+    borderDownColor:  '#ef5350',
+    wickUpColor:      '#26a69a',
+    wickDownColor:    '#ef5350',
+  }, PANE_MAIN)
+
+  // Volume (pane 1)
+  if (volumeLocal.value.enabled) {
+    volumeSeriesRef = chart.addSeries(HistogramSeries, {
+      priceFormat:  { type: 'volume' },
+      priceScaleId: 'volume',
+    }, PANE_VOLUME)
+    chart.priceScale('volume').applyOptions({ scaleMargins: { top: 0.7, bottom: 0 } })
+  }
+
+  // MACD (pane 2)
+  if (macdLocal.value.enabled) {
+    macdSeriesRef.line      = chart.addSeries(LineSeries,      { color: '#3b82f6', lineWidth: 1 }, PANE_MACD)
+    macdSeriesRef.signal    = chart.addSeries(LineSeries,      { color: '#f59e0b', lineWidth: 1 }, PANE_MACD)
+    macdSeriesRef.histogram = chart.addSeries(HistogramSeries, {}, PANE_MACD)
+  }
+
+  // Autoresize
+  resizeObserver = new ResizeObserver(() => {
+    if (chart && chartContainer.value) {
+      chart.applyOptions({
+        width:  chartContainer.value.clientWidth,
+        height: chartContainer.value.clientHeight,
+      })
+    }
+  })
+  resizeObserver.observe(chartContainer.value)
+
+  // Render any bars already loaded before mount
+  if (bars.value.length) updateChart()
+})
+
+onUnmounted(() => {
+  clearRefresh()
+  resizeObserver?.disconnect()
+  if (chart) { chart.remove(); chart = null }
+})
+
+// ── Chart update ──────────────────────────────────────────────────────────────
+function updateChart() {
+  if (!chart || !candleSeries || !bars.value.length) return
+
+  // Map Massive API (ms) → lightweight-charts (seconds)
+  const mapped = bars.value.map(b => ({
+    time:  b.t / 1000,
+    open:  b.o,
+    high:  b.h,
+    low:   b.l,
+    close: b.c,
+  }))
+  candleSeries.setData(mapped)
+
+  // Volume
+  if (volumeSeriesRef) {
+    volumeSeriesRef.setData(bars.value.map(b => ({
+      time:      b.t / 1000,
+      value:     b.v,
+      color:     b.c >= b.o ? 'rgba(38,166,154,0.5)' : 'rgba(239,83,80,0.5)',
+    })))
+  }
+
+  // Overlays — remove stale series then rebuild
+  overlaySeries.forEach(s => { try { chart.removeSeries(s) } catch (_) {} })
+  overlaySeries = []
+
+  for (const cfg of emaLocal.value) {
+    if (!cfg.enabled) continue
+    const s = chart.addSeries(LineSeries, { color: cfg.color, lineWidth: 1, priceLineVisible: false, lastValueVisible: false }, PANE_MAIN)
+    const vals = calcEMA(bars.value, cfg.period)
+    s.setData(vals.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
+    overlaySeries.push(s)
+  }
+  for (const cfg of smaLocal.value) {
+    if (!cfg.enabled) continue
+    const s = chart.addSeries(LineSeries, { color: cfg.color, lineWidth: 1, priceLineVisible: false, lastValueVisible: false }, PANE_MAIN)
+    const vals = calcSMA(bars.value, cfg.period)
+    s.setData(vals.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
+    overlaySeries.push(s)
+  }
+  for (const cfg of vwmaLocal.value) {
+    if (!cfg.enabled) continue
+    const s = chart.addSeries(LineSeries, { color: cfg.color, lineWidth: 1, priceLineVisible: false, lastValueVisible: false }, PANE_MAIN)
+    const vals = calcVWMA(bars.value, cfg.period)
+    s.setData(vals.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
+    overlaySeries.push(s)
+  }
+  if (vwapLocal.value.enabled) {
+    const s = chart.addSeries(LineSeries, { color: vwapLocal.value.color, lineWidth: 1, priceLineVisible: false, lastValueVisible: false }, PANE_MAIN)
+    const vals = calcVWAP(bars.value, isIntraday.value)
+    s.setData(vals.map((v, i) => ({ time: bars.value[i].t / 1000, value: v })))
+    overlaySeries.push(s)
+  }
+
+  // MACD
+  if (macdSeriesRef.line) {
+    const { macdLine, signalLine, histogram } = calcMACD(bars.value, macdLocal.value.fast, macdLocal.value.slow, macdLocal.value.signal)
+    macdSeriesRef.line.setData(macdLine.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
+    macdSeriesRef.signal.setData(signalLine.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v }).filter(Boolean))
+    macdSeriesRef.histogram.setData(histogram.map((v, i) => v === null ? null : { time: bars.value[i].t / 1000, value: v, color: v >= 0 ? '#26a69a' : '#ef5350' }).filter(Boolean))
+  }
+}
+
+defineExpose({ lastDataAt, isConnected, reconnecting })
 </script>
+
+<style scoped>
+.tv-lite-chart-widget {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #0f0f0f;
+  color: #e0e0e0;
+  font-size: 13px;
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  background: #1a1a1a;
+  border-bottom: 1px solid #333;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ticker-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.header-ticker-input {
+  width: 72px;
+  padding: 2px 6px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.header-ticker-input:focus { outline: none; border-color: #8b5cf6; }
+.header-ticker-input::placeholder { color: #555; font-weight: normal; }
+
+.go-btn {
+  padding: 2px 7px;
+  background: rgba(139,92,246,0.15);
+  border: 1px solid rgba(139,92,246,0.4);
+  border-radius: 3px;
+  color: #a78bfa;
+  font-size: 11px;
+  cursor: pointer;
+}
+.go-btn:hover { background: rgba(139,92,246,0.25); }
+
+.interval-btns { display: flex; gap: 2px; flex: 1; }
+
+.interval-btn {
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 3px;
+  color: #888;
+  font-size: 11px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+.interval-btn--active {
+  background: rgba(139,92,246,0.15);
+  border-color: rgba(139,92,246,0.5);
+  color: #a78bfa;
+}
+
+.col-menu-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  padding: 2px 4px;
+}
+
+.settings-panel {
+  padding: 8px 12px;
+  background: #111;
+  border-bottom: 1px solid #333;
+  flex-shrink: 0;
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 0;
+  font-size: 12px;
+}
+
+.settings-label { color: #999; min-width: 40px; }
+.settings-section-title {
+  font-size: 11px; color: #555; text-transform: uppercase;
+  letter-spacing: 0.05em; padding: 5px 0 2px;
+  border-top: 1px solid #1f1f1f; margin-top: 3px;
+}
+
+.narrow-input {
+  width: 55px; padding: 2px 4px; background: #1a1a1a;
+  border: 1px solid #333; border-radius: 3px; color: #e0e0e0; font-size: 12px;
+}
+
+.interval-select {
+  padding: 2px 4px; background: #1a1a1a; border: 1px solid #333;
+  border-radius: 3px; color: #e0e0e0; font-size: 12px;
+}
+
+.color-picker {
+  width: 24px; height: 20px; padding: 0;
+  border: 1px solid #444; border-radius: 3px;
+  background: none; cursor: pointer; flex-shrink: 0;
+}
+
+.chart-container { flex: 1; min-height: 0; position: relative; }
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: #555;
+  font-size: 13px;
+  padding: 24px;
+  text-align: center;
+  background: #0f0f0f;
+  z-index: 10;
+}
+
+.retry-btn {
+  background: #1a1a1a; border: 1px solid #444; border-radius: 3px;
+  color: #ccc; padding: 4px 12px; cursor: pointer; font-size: 12px;
+}
+</style>

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -88,19 +88,20 @@
       </div>
     </div>
 
-    <!-- Chart container — always in DOM so onMounted can init the chart -->
-    <div ref="chartContainer" class="chart-container" data-testid="chart-container"></div>
-
-    <!-- Overlay states rendered on top of chart container -->
-    <div v-if="!tickerLocal" class="overlay" data-testid="no-ticker">
-      <span>No ticker selected. Click a row in a linked scanner or enter a ticker above.</span>
-    </div>
-    <div v-else-if="error" class="overlay" data-testid="error-state">
-      <span>⚠ {{ error }}</span>
-      <button class="retry-btn" data-testid="retry-btn" @click="fetchBars">↻ Retry</button>
-    </div>
-    <div v-else-if="loading && !bars.length" class="overlay" data-testid="loading-state">
-      <span>Loading…</span>
+    <!-- Chart container — always in DOM so onMounted can init the chart.
+         Overlay states live inside so position:absolute is scoped here,
+         not to WidgetWrapper (which would cover its title bar). -->
+    <div ref="chartContainer" class="chart-container" data-testid="chart-container">
+      <div v-if="!tickerLocal" class="overlay" data-testid="no-ticker">
+        <span>No ticker selected. Click a row in a linked scanner or enter a ticker above.</span>
+      </div>
+      <div v-else-if="error" class="overlay" data-testid="error-state">
+        <span>⚠ {{ error }}</span>
+        <button class="retry-btn" data-testid="retry-btn" @click="fetchBars">↻ Retry</button>
+      </div>
+      <div v-else-if="loading && !bars.length" class="overlay" data-testid="loading-state">
+        <span>Loading…</span>
+      </div>
     </div>
   </div>
 </template>

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -454,6 +454,7 @@ describe('Settings persistence', () => {
     expect(last).toHaveProperty('autoRefresh')
     expect(last).toHaveProperty('refreshInterval')
     expect(last).toHaveProperty('ema')
+    expect(last).toHaveProperty('avgVolume')
     wrapper.unmount()
   })
 })

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -295,6 +295,40 @@ describe('Data fetching', () => {
   })
 })
 
+// ── Average volume ────────────────────────────────────────────────────────────
+// addSeries call order in onMounted: [0]=candle, [1]=volume, [2]=avgVolume, [3]=macdLine, [4]=signal, [5]=histogram
+
+describe('Average volume', () => {
+  test('avgVolume setData called after successful fetch', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL', volume: { enabled: true }, avgVolume: { enabled: true, period: 20 } } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act — avgVolume is the 3rd series created in onMounted (index 2)
+    const avgVolSeriesMock = vi.mocked(createChart).mock.results[0]?.value?.addSeries.mock.results[2]?.value
+
+    // Assert
+    expect(avgVolSeriesMock.setData).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  test('avgVolume series created with visible: false when volume pane is disabled', () => {
+    // Arrange + Act
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { volume: { enabled: false }, avgVolume: { enabled: true, period: 20 } } },
+    })
+
+    // Assert — addSeries call [2] options should have visible: false (vol disabled AND avgVol enabled = false)
+    const avgVolAddOptions = vi.mocked(createChart).mock.results[0]?.value?.addSeries.mock.calls[2]?.[1]
+    expect(avgVolAddOptions?.visible).toBe(false)
+    wrapper.unmount()
+  })
+})
+
 // ── Ticker source (bus + header input) ────────────────────────────────────────
 
 describe('Ticker source', () => {

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -117,11 +117,11 @@ describe('Rendering', () => {
 
   test('createChart called on mount', () => {
     // Arrange + Act
-    mount(TVLiteChart, { props: defaultProps })
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
 
     // Assert
     expect(createChart).toHaveBeenCalled()
-    wrapper?.unmount()
+    wrapper.unmount()
   })
 
   test('no ticker → placeholder shown', () => {
@@ -248,7 +248,7 @@ describe('Data fetching', () => {
     await nextTick()
 
     // Assert
-    expect(global.fetch.mock.calls.length).toBeGreaterThan(before)
+    expect(global.fetch.mock.calls.length).toBe(before + 1)
     expect(global.fetch.mock.calls[global.fetch.mock.calls.length - 1][0]).toContain('TSLA')
     wrapper.unmount()
   })
@@ -269,7 +269,7 @@ describe('Data fetching', () => {
     await nextTick()
 
     // Assert
-    expect(global.fetch.mock.calls.length).toBeGreaterThan(before)
+    expect(global.fetch.mock.calls.length).toBe(before + 1)
     wrapper.unmount()
   })
 

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -354,7 +354,7 @@ describe('Auto-refresh', () => {
     await nextTick()
 
     // Assert
-    expect(global.fetch.mock.calls.length).toBeGreaterThan(before)
+    expect(global.fetch.mock.calls.length).toBe(before + 1)
     wrapper.unmount()
     vi.useRealTimers()
   })

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -1,0 +1,458 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+// ── Mock lightweight-charts (v5 API) ─────────────────────────────────────────
+// chart/series instances must NOT be wrapped in Vue ref() — plain JS vars only.
+// v5 series API: chart.addSeries(CandlestickSeries, opts) rather than addCandlestickSeries.
+vi.mock('lightweight-charts', () => {
+  const makeSeriesMock = () => ({ setData: vi.fn(), applyOptions: vi.fn() })
+  const paneSeriesMock  = makeSeriesMock()
+  const paneMock = { addSeries: vi.fn(() => paneSeriesMock) }
+
+  const chartMock = {
+    addSeries:    vi.fn(() => makeSeriesMock()),
+    addPane:      vi.fn(() => paneMock),
+    panes:        vi.fn(() => []),
+    remove:       vi.fn(),
+    applyOptions: vi.fn(),
+    timeScale:    vi.fn(() => ({ fitContent: vi.fn(), setOptions: vi.fn() })),
+    priceScale:   vi.fn(() => ({ applyOptions: vi.fn() })),
+  }
+
+  return {
+    createChart:       vi.fn(() => chartMock),
+    CandlestickSeries: { seriesType: 'Candlestick' },
+    LineSeries:        { seriesType: 'Line' },
+    HistogramSeries:   { seriesType: 'Histogram' },
+    ColorType:         { Solid: 'solid' },
+    CrosshairMode:     { Magnet: 1 },
+    // Export chart mock for direct assertion in tests
+    __chartMock:       chartMock,
+    __paneMock:        paneMock,
+  }
+})
+
+// ── Mock useConfig ────────────────────────────────────────────────────────────
+vi.mock('@/composables/useConfig.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useConfig: vi.fn(() => ({
+      config:  ref({ massiveApiKey: 'test-key' }),
+      loading: ref(false),
+      error:   ref(null),
+    })),
+  }
+})
+
+// ── Mock useScannerLink ───────────────────────────────────────────────────────
+vi.mock('@/composables/useScannerLink.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useScannerLink: vi.fn(() => ({
+      activeTicker: ref(null),
+      onRowClick:   vi.fn(),
+    })),
+  }
+})
+
+// ── Mock chartIndicators ──────────────────────────────────────────────────────
+vi.mock('@/utils/chartIndicators.js', () => ({
+  calcEMA:       vi.fn(() => []),
+  calcSMA:       vi.fn(() => []),
+  calcVWMA:      vi.fn(() => []),
+  calcVWAP:      vi.fn(() => []),
+  calcMACD:      vi.fn(() => ({ macdLine: [], signalLine: [], histogram: [] })),
+  calcVolumeAvg: vi.fn(() => []),
+}))
+
+// ── ResizeObserver mock (not in jsdom) ────────────────────────────────────────
+const resizeObserverMock = { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() }
+vi.stubGlobal('ResizeObserver', vi.fn(() => resizeObserverMock))
+
+import { createChart } from 'lightweight-charts'
+import { useScannerLink } from '@/composables/useScannerLink.js'
+import TVLiteChart from '../TVLiteChart.vue'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const defaultProps = {
+  isLocked:  true,
+  linkColor: 'blue',
+  isMobile:  false,
+  settings:  {},
+}
+
+function mockFetch(results = [], ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue({ results, status: 'OK' }),
+  })
+}
+
+function makeBar(i = 0) {
+  return { t: (1_700_000_000 + i * 60) * 1000, o: 100, h: 105, l: 95, c: 102, v: 1e6, vw: 101 }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.stubGlobal('ResizeObserver', vi.fn(() => resizeObserverMock))
+})
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('Rendering', () => {
+  test('chart container div renders', () => {
+    // Arrange + Act
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.find('[data-testid="chart-container"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('createChart called on mount', () => {
+    // Arrange + Act
+    mount(TVLiteChart, { props: defaultProps })
+
+    // Assert
+    expect(createChart).toHaveBeenCalled()
+    wrapper?.unmount()
+  })
+
+  test('no ticker → placeholder shown', () => {
+    // Arrange + Act
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.find('[data-testid="no-ticker"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('header ticker input always visible', () => {
+    // Arrange + Act
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+
+    // Assert
+    expect(wrapper.find('[data-testid="header-ticker-input"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})
+
+// ── Data fetching ─────────────────────────────────────────────────────────────
+
+describe('Data fetching', () => {
+  test('fetch called on mount with ticker', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const url = global.fetch.mock.calls[0]?.[0] ?? ''
+
+    // Assert
+    expect(url).toContain('AAPL')
+    expect(url).toContain('test-key')
+    expect(url).toContain('sort=asc')
+    wrapper.unmount()
+  })
+
+  test('fetch NOT called when no ticker', async () => {
+    // Arrange
+    global.fetch = mockFetch()
+
+    // Act
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+    await nextTick()
+
+    // Assert
+    expect(global.fetch).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  test('loading state shown during fetch', async () => {
+    // Arrange
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
+
+    // Act
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
+    })
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('[data-testid="loading-state"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('error state shown on HTTP error + retry button present', async () => {
+    // Arrange
+    global.fetch = mockFetch([], false)
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    const errorState = wrapper.find('[data-testid="error-state"]')
+    const retryBtn   = wrapper.find('[data-testid="retry-btn"]')
+
+    // Assert
+    expect(errorState.exists()).toBe(true)
+    expect(retryBtn.exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('retry button triggers another fetch', async () => {
+    // Arrange
+    global.fetch = mockFetch([], false)
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+    const before = global.fetch.mock.calls.length
+
+    // Act
+    await wrapper.find('[data-testid="retry-btn"]').trigger('click')
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.length).toBe(before + 1)
+    wrapper.unmount()
+  })
+
+  test('ticker change triggers new fetch', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+    const before = global.fetch.mock.calls.length
+
+    // Act
+    await wrapper.setProps({ settings: { ticker: 'TSLA' } })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.length).toBeGreaterThan(before)
+    expect(global.fetch.mock.calls[global.fetch.mock.calls.length - 1][0]).toContain('TSLA')
+    wrapper.unmount()
+  })
+
+  test('interval change triggers new fetch', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL', interval: '1d' } },
+    })
+    await nextTick()
+    await nextTick()
+    const before = global.fetch.mock.calls.length
+
+    // Act
+    await wrapper.setProps({ settings: { ticker: 'AAPL', interval: '1h' } })
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.length).toBeGreaterThan(before)
+    wrapper.unmount()
+  })
+
+  test('bars mapped to seconds: setData called with time = t/1000', async () => {
+    // Arrange
+    const bar = makeBar()
+    global.fetch = mockFetch([bar])
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act — get the series mock from the first addSeries call on the chart
+    const candleSeriesMock = vi.mocked(createChart).mock.results[0]?.value?.addSeries.mock.results[0]?.value
+
+    // Assert — setData was called and time was converted from ms to seconds
+    expect(candleSeriesMock.setData).toHaveBeenCalled()
+    const calledData = candleSeriesMock.setData.mock.calls[0][0]
+    expect(calledData[0].time).toBe(bar.t / 1000)
+    wrapper.unmount()
+  })
+})
+
+// ── Ticker source (bus + header input) ────────────────────────────────────────
+
+describe('Ticker source', () => {
+  test('bus activeTicker updates header input and triggers exactly one fetch', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+    const fetchBefore = global.fetch.mock.calls.length
+
+    // Act
+    activeTicker.value = 'MSFT'
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('[data-testid="header-ticker-input"]').element.value).toBe('MSFT')
+    expect(global.fetch.mock.calls.length).toBe(fetchBefore + 1)
+    wrapper.unmount()
+  })
+
+  test('pressing Enter in header input triggers fetch with that ticker', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+    await nextTick()
+
+    // Act
+    await wrapper.find('[data-testid="header-ticker-input"]').setValue('NVDA')
+    await wrapper.find('[data-testid="header-ticker-input"]').trigger('keydown.enter')
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.some(c => c[0].includes('NVDA'))).toBe(true)
+    wrapper.unmount()
+  })
+})
+
+// ── Auto-refresh ──────────────────────────────────────────────────────────────
+
+describe('Auto-refresh', () => {
+  test('advancing time by refreshInterval triggers additional fetch', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL', autoRefresh: true, refreshInterval: '1m' } },
+    })
+    await nextTick()
+    await nextTick()
+    const before = global.fetch.mock.calls.length
+
+    // Act
+    vi.advanceTimersByTime(60_000)
+    await nextTick()
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.length).toBeGreaterThan(before)
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  test('autoRefresh false: no extra fetch after time advances', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL', autoRefresh: false } },
+    })
+    await nextTick()
+    await nextTick()
+    const before = global.fetch.mock.calls.length
+
+    // Act
+    vi.advanceTimersByTime(120_000)
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.length).toBe(before)
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  test('auto-refresh stops after unmount', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL', autoRefresh: true, refreshInterval: '1m' } },
+    })
+    await nextTick()
+    await nextTick()
+
+    // Act
+    wrapper.unmount()
+    const countAfterUnmount = global.fetch.mock.calls.length
+    vi.advanceTimersByTime(120_000)
+    await nextTick()
+
+    // Assert
+    expect(global.fetch.mock.calls.length).toBe(countAfterUnmount)
+    vi.useRealTimers()
+  })
+})
+
+// ── Lifecycle cleanup ─────────────────────────────────────────────────────────
+
+describe('Lifecycle cleanup', () => {
+  test('chart.remove() called on unmount', () => {
+    // Arrange
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+
+    // Act
+    wrapper.unmount()
+
+    // Assert — the chart returned from createChart should have had remove() called
+    expect(vi.mocked(createChart).mock.results[0]?.value?.remove).toHaveBeenCalled()
+  })
+
+  test('ResizeObserver.disconnect() called on unmount', () => {
+    // Arrange
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+
+    // Act
+    wrapper.unmount()
+
+    // Assert
+    expect(resizeObserverMock.disconnect).toHaveBeenCalled()
+  })
+})
+
+// ── Settings persistence ──────────────────────────────────────────────────────
+
+describe('Settings persistence', () => {
+  test('emitted settings include required keys', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const settingsCalls = []
+    const wrapper = mount(TVLiteChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
+      attrs: { 'onUpdate-settings': s => settingsCalls.push(s) },
+    })
+    await nextTick()
+
+    // Act — trigger emit via interval button
+    await wrapper.find('[data-testid="interval-btn-5m"]').trigger('click')
+    await nextTick()
+
+    // Assert
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    const last = settingsCalls[settingsCalls.length - 1]
+    expect(last).toHaveProperty('ticker')
+    expect(last).toHaveProperty('interval')
+    expect(last).toHaveProperty('autoRefresh')
+    expect(last).toHaveProperty('refreshInterval')
+    expect(last).toHaveProperty('ema')
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -68,7 +68,8 @@ vi.mock('@/utils/chartIndicators.js', () => ({
 
 // ── ResizeObserver mock (not in jsdom) ────────────────────────────────────────
 const resizeObserverMock = { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() }
-vi.stubGlobal('ResizeObserver', vi.fn(() => resizeObserverMock))
+// Regular function (not arrow) so it works as a constructor with `new`
+vi.stubGlobal('ResizeObserver', function ResizeObserverMock() { return resizeObserverMock })
 
 import { createChart } from 'lightweight-charts'
 import { useScannerLink } from '@/composables/useScannerLink.js'
@@ -100,7 +101,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
-  vi.stubGlobal('ResizeObserver', vi.fn(() => resizeObserverMock))
+  vi.stubGlobal('ResizeObserver', function ResizeObserverMock() { return resizeObserverMock })
 })
 
 // ── Rendering ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #239

## Summary

New `tv-lite-chart` widget backed by TradingView Lightweight Charts v5 (Apache 2.0, ~45 KB). Complements the existing ECharts `CandlestickChart` — same data source, same indicators, cleaner trading-native aesthetics.

**New dependency:** `lightweight-charts` v5

**Reuses without modification:** `chartIndicators.js`, Massive REST API endpoint, same header ticker input + bus pattern as `CandlestickChart`.

## TDD arc

Red commit `e965958` (tests only — `TVLiteChart.vue` absent → `Failed to resolve import`) → green commit (pending).

refs #239