### PR TITLE
feat(ci): add Codecov coverage badges for frontend and backend

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -25,5 +25,19 @@ jobs:
       - name: Install dependencies
         run: pip install --no-cache-dir -e ".[testing]"
 
-      - name: Run tests
+      - name: Run tests (pull request — no coverage)
+        if: github.event_name == 'pull_request'
+        run: pytest tests/ -v
+
+      - name: Run tests with coverage (mainline push)
+        if: github.event_name == 'push'
         run: pytest --cov=apps --cov-report=xml tests/ -v
+
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'push'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: backend
+          fail_ci_if_error: true

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -28,6 +28,21 @@ jobs:
         run: npm ci
         working-directory: client
 
-      - name: Run tests
+      - name: Run tests (pull request — no coverage)
+        if: github.event_name == 'pull_request'
         run: npm test
         working-directory: client
+
+      - name: Run tests with coverage (mainline push)
+        if: github.event_name == 'push'
+        run: npm run coverage
+        working-directory: client
+
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'push'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./client/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![CodeQL Advanced](https://github.com/kuhl-haus/kuhl-haus-mdp-app/actions/workflows/codeql.yml/badge.svg)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/actions/workflows/codeql.yml)
 [![GitHub issues](https://img.shields.io/github/issues/kuhl-haus/kuhl-haus-mdp-app)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/kuhl-haus/kuhl-haus-mdp-app)](https://github.com/kuhl-haus/kuhl-haus-mdp-app/pulls)
+[![Frontend Coverage](https://codecov.io/gh/kuhl-haus/kuhl-haus-mdp-app/branch/mainline/graph/badge.svg?flag=frontend)](https://codecov.io/gh/kuhl-haus/kuhl-haus-mdp-app)
+[![Backend Coverage](https://codecov.io/gh/kuhl-haus/kuhl-haus-mdp-app/branch/mainline/graph/badge.svg?flag=backend)](https://codecov.io/gh/kuhl-haus/kuhl-haus-mdp-app)
 
 # kuhl-haus-mdp-app
 


### PR DESCRIPTION
refs #152

## Changes

### CI workflows

Both `test-backend.yml` and `test-frontend.yml` now use conditional steps:
- **Pull requests:** tests only (no coverage overhead)
- **Mainline push:** tests with coverage + upload to Codecov

### Backend (`test-backend.yml`)
- PR: `pytest tests/ -v`
- Mainline: `pytest --cov=apps --cov-report=xml tests/ -v` + `codecov/codecov-action@v5` with `flag: backend`

The existing `--cov=apps --cov-report=xml` command was already in the workflow — moved to the mainline-only step.

### Frontend (`test-frontend.yml`)
- PR: `npm test`
- Mainline: `npm run coverage` (existing script: `vitest run --coverage`) + `codecov/codecov-action@v5` with `flag: frontend`

Vitest config already outputs `coverage/lcov.info` (reporter: `['text', 'lcov']`).

### README.md

Two Codecov badge lines added using `?flag=frontend` and `?flag=backend` to display separate coverage percentages.

### Pattern

Follows `kuhl-haus-mdp` exactly: `codecov/codecov-action@v5`, `CODECOV_TOKEN` (org secret), `fail_ci_if_error: true`.