### PR TITLE
feat(NewsFeed): add ticker select/filter mode toggle

### DIFF
--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -3,6 +3,14 @@
 
     <!-- Controls -->
     <div class="news-controls">
+      <!-- Ticker click mode toggle -->
+      <button
+        :class="['filter-btn', tickerClickMode === 'filter' ? 'filter-btn--active' : '']"
+        :title="tickerClickMode === 'filter' ? 'Ticker click: filter feed — click to switch to select mode' : 'Ticker click: select ticker only — click to switch to filter mode'"
+        @click="toggleTickerClickMode"
+        data-testid="ticker-mode-toggle"
+      >{{ tickerClickMode === 'filter' ? 'filter' : 'select' }}</button>
+
       <!-- R1: has-tickers toggle -->
       <button
         :class="['filter-btn', hasTickersOnly ? 'filter-btn--active' : '']"
@@ -200,6 +208,14 @@ const emit = defineEmits(['ticker-click', 'update-col-widths', 'update-settings'
 
 const { setActiveTicker, activeTickers } = useWidgetBus()
 
+// ── Ticker click mode ─────────────────────────────────────────────────────────
+const tickerClickMode = ref(props.settings.tickerClickMode ?? 'filter')
+
+const toggleTickerClickMode = () => {
+  tickerClickMode.value = tickerClickMode.value === 'filter' ? 'select' : 'filter'
+  emit('update-settings', { ...props.settings, tickerClickMode: tickerClickMode.value })
+}
+
 const appConfig   = window.__APP_CONFIG__ || {}
 const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
 const LS_HAS_TICKERS_KEY = 'newsfeed:hasTickersOnly'
@@ -249,10 +265,11 @@ watch(hasTickersOnly, (val) => {
 })
 
 // Receive ticker from bus when another linked widget broadcasts
+// Only update local filter in filter mode; in select mode, feed stays unchanged
 watch(
   () => props.linkColor ? activeTickers[props.linkColor] : undefined,
   (incoming) => {
-    if (props.linkColor && incoming !== undefined) {
+    if (props.linkColor && incoming !== undefined && tickerClickMode.value === 'filter') {
       activeTicker.value = incoming
     }
   }
@@ -352,8 +369,11 @@ const openDetail = (item) => { selected.value = item }
 
 const toggleTickerFilter = (ticker) => {
   const next = activeTicker.value === ticker ? null : ticker
-  activeTicker.value = next
-  // Broadcast to linked widgets if this widget has a link color
+  if (tickerClickMode.value === 'filter') {
+    // Filter mode: update local feed filter AND broadcast
+    activeTicker.value = next
+  }
+  // Select mode: broadcast only — local feed unchanged
   if (props.linkColor) {
     setActiveTicker(props.linkColor, next)
   }

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -367,15 +367,27 @@ const formatDateTime = (ts) => {
 
 const openDetail = (item) => { selected.value = item }
 
+// Tracks the last ticker broadcast in select mode so double-click can clear
+// linked widgets (deselect). Cannot reuse activeTicker for this because
+// activeTicker drives the feed filter pill and must stay null in select mode.
+const lastBroadcastTicker = ref(null)
+
+// Reset bookkeeping ref when mode changes
+watch(tickerClickMode, () => { lastBroadcastTicker.value = null })
+
 const toggleTickerFilter = (ticker) => {
-  const next = activeTicker.value === ticker ? null : ticker
   if (tickerClickMode.value === 'filter') {
-    // Filter mode: update local feed filter AND broadcast
+    // Filter mode: toggle local feed filter AND broadcast
+    const next = activeTicker.value === ticker ? null : ticker
     activeTicker.value = next
-  }
-  // Select mode: broadcast only — local feed unchanged
-  if (props.linkColor) {
-    setActiveTicker(props.linkColor, next)
+    if (props.linkColor) setActiveTicker(props.linkColor, next)
+  } else {
+    // Select mode: broadcast only — feed unchanged.
+    // Use lastBroadcastTicker for toggle bookkeeping so double-clicking the
+    // same ticker sends null and clears linked widgets (Option B).
+    const next = lastBroadcastTicker.value === ticker ? null : ticker
+    lastBroadcastTicker.value = next
+    if (props.linkColor) setActiveTicker(props.linkColor, next)
   }
 }
 

--- a/client/src/components/widgets/__tests__/NewsFeed.spec.js
+++ b/client/src/components/widgets/__tests__/NewsFeed.spec.js
@@ -1,0 +1,268 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+
+// ── Mock useWebSocketClient ───────────────────────────────────────────────────
+vi.mock('@/composables/useWebSocketClient.js', async () => {
+  const { ref } = await import('vue')
+  let _onData = null
+  const mock = vi.fn((config) => {
+    _onData = config.onData
+    return {
+      lastDataAt:   ref(null),
+      isConnected:  ref(true),
+      reconnecting: ref(false),
+      getCache:     vi.fn(),
+      cacheLimit:   ref(config.cacheLimit ?? 1000),
+    }
+  })
+  mock.__trigger = (data) => _onData && _onData(data)
+  return { useWebSocketClient: mock }
+})
+
+// ── Mock useWidgetBus ─────────────────────────────────────────────────────────
+vi.mock('@/composables/useWidgetBus.js', async () => {
+  const { reactive, ref } = await import('vue')
+  const activeTickers = reactive({})
+  return {
+    useWidgetBus:       vi.fn(() => ({ setActiveTicker: vi.fn(), activeTickers })),
+    setNewsTimestamp:   vi.fn(),
+    activeTickers,
+    setActiveTicker:    vi.fn(),
+  }
+})
+
+// ── Mock vue-virtual-scroller ─────────────────────────────────────────────────
+vi.mock('vue-virtual-scroller', () => ({
+  RecycleScroller: {
+    name: 'RecycleScroller',
+    props: ['items', 'itemSize', 'keyField'],
+    template: `<div><slot v-for="item in items" :item="item" /></div>`,
+  },
+}))
+
+import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useWidgetBus, setActiveTicker } from '@/composables/useWidgetBus.js'
+import NewsFeed from '../NewsFeed.vue'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const defaultProps = {
+  feedName:  'news:feed:latest',
+  cacheKey:  'news:feed:latest',
+  colWidths: {},
+  linkColor: null,
+  isMobile:  false,
+  settings:  {},
+}
+
+function makeArticle(overrides = {}) {
+  return {
+    title:       'Test headline',
+    link:        'https://example.com/test',
+    publishDate: new Date().toISOString(),
+    source:      'example.com',
+    sentiment:   'neutral',
+    summary:     'Test summary',
+    companies:   [{ ticker: 'AAPL', name: 'Apple Inc.', primaryListing: { exchangeCode: 'XNAS' } }],
+    images:      [],
+    ...overrides,
+  }
+}
+
+function mountFeed(propsOverrides = {}) {
+  return mount(NewsFeed, {
+    props: { ...defaultProps, ...propsOverrides },
+    global: { stubs: { Teleport: true } },
+  })
+}
+
+// ── Ticker mode toggle — rendering ────────────────────────────────────────────
+
+describe('Ticker mode toggle', () => {
+  test('mode toggle button renders in the controls bar', () => {
+    const wrapper = mountFeed()
+    expect(wrapper.find('[data-testid="ticker-mode-toggle"]').exists()).toBe(true)
+  })
+
+  test('default mode is filter when no saved setting', () => {
+    const wrapper = mountFeed()
+    expect(wrapper.find('[data-testid="ticker-mode-toggle"]').text()).toBe('filter')
+  })
+
+  test('renders select label when settings.tickerClickMode is select', () => {
+    const wrapper = mountFeed({ settings: { tickerClickMode: 'select' } })
+    expect(wrapper.find('[data-testid="ticker-mode-toggle"]').text()).toBe('select')
+  })
+
+  test('clicking toggle switches from filter to select', async () => {
+    const wrapper = mountFeed()
+    await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
+    expect(wrapper.find('[data-testid="ticker-mode-toggle"]').text()).toBe('select')
+  })
+
+  test('clicking toggle twice returns to filter', async () => {
+    const wrapper = mountFeed()
+    await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
+    await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
+    expect(wrapper.find('[data-testid="ticker-mode-toggle"]').text()).toBe('filter')
+  })
+
+  test('toggle button has active class in filter mode', () => {
+    const wrapper = mountFeed()
+    expect(wrapper.find('[data-testid="ticker-mode-toggle"]').classes()).toContain('filter-btn--active')
+  })
+
+  test('toggle button does not have active class in select mode', async () => {
+    const wrapper = mountFeed({ settings: { tickerClickMode: 'select' } })
+    expect(wrapper.find('[data-testid="ticker-mode-toggle"]').classes()).not.toContain('filter-btn--active')
+  })
+})
+
+// ── Ticker mode toggle — settings persistence ─────────────────────────────────
+
+describe('Ticker mode toggle — settings persistence', () => {
+  test('toggling emits update-settings with tickerClickMode select', async () => {
+    const wrapper = mountFeed()
+    await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
+    const emitted = wrapper.emitted('update-settings')
+    expect(emitted).toBeTruthy()
+    const last = emitted[emitted.length - 1][0]
+    expect(last.tickerClickMode).toBe('select')
+  })
+
+  test('toggling back emits update-settings with tickerClickMode filter', async () => {
+    const wrapper = mountFeed({ settings: { tickerClickMode: 'select' } })
+    await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
+    const emitted = wrapper.emitted('update-settings')
+    const last = emitted[emitted.length - 1][0]
+    expect(last.tickerClickMode).toBe('filter')
+  })
+})
+
+// ── Filter mode (default) ─────────────────────────────────────────────────────
+
+describe('Filter mode — ticker tag click', () => {
+  beforeEach(() => vi.mocked(useWebSocketClient).mockClear())
+
+  test('clicking a ticker tag filters the feed to that ticker', async () => {
+    const callsBefore = vi.mocked(useWebSocketClient).mock.calls.length
+    const wrapper = mountFeed({ linkColor: 'blue' })
+    const wsInstance = vi.mocked(useWebSocketClient).mock.results[callsBefore].value
+    wsInstance.getCache = vi.fn()
+    // Inject an article
+    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
+    wsMock.__trigger([makeArticle()])
+    await nextTick()
+
+    const tagsBefore = wrapper.findAll('.ticker-tag')
+    expect(tagsBefore.length).toBeGreaterThan(0)
+    await tagsBefore[0].trigger('click')
+    await nextTick()
+
+    // active-ticker-pill should appear
+    expect(wrapper.find('.active-ticker-pill').exists()).toBe(true)
+    expect(wrapper.find('.active-ticker-pill').text()).toContain('AAPL')
+  })
+
+  test('filter mode: ticker tag click also broadcasts via setActiveTicker', async () => {
+    const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
+    const mockSet = vi.fn()
+    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
+
+    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
+    const wrapper = mountFeed({ linkColor: 'blue' })
+    wsMock.__trigger([makeArticle()])
+    await nextTick()
+
+    const tags = wrapper.findAll('.ticker-tag')
+    await tags[0].trigger('click')
+    await nextTick()
+
+    expect(mockSet).toHaveBeenCalledWith('blue', 'AAPL')
+  })
+})
+
+// ── Select mode ───────────────────────────────────────────────────────────────
+
+describe('Select mode — ticker tag click', () => {
+  test('clicking a ticker tag broadcasts to linked widgets', async () => {
+    const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
+    const mockSet = vi.fn()
+    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
+
+    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
+    const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
+    wsMock.__trigger([makeArticle()])
+    await nextTick()
+
+    const tags = wrapper.findAll('.ticker-tag')
+    await tags[0].trigger('click')
+    await nextTick()
+
+    expect(mockSet).toHaveBeenCalledWith('blue', 'AAPL')
+  })
+
+  test('select mode: ticker tag click does not filter the feed (no active-ticker-pill)', async () => {
+    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
+    const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
+    wsMock.__trigger([makeArticle()])
+    await nextTick()
+
+    const tags = wrapper.findAll('.ticker-tag')
+    await tags[0].trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('.active-ticker-pill').exists()).toBe(false)
+  })
+
+  test('select mode: all articles remain visible after ticker tag click', async () => {
+    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
+    const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
+    wsMock.__trigger([
+      makeArticle({ link: 'https://example.com/a1' }),
+      makeArticle({ link: 'https://example.com/a2', companies: [{ ticker: 'MSFT', name: 'Microsoft', primaryListing: { exchangeCode: 'XNAS' } }] }),
+    ])
+    await nextTick()
+
+    const tags = wrapper.findAll('.ticker-tag')
+    await tags[0].trigger('click')
+    await nextTick()
+
+    // Both rows still visible — feed unfiltered
+    expect(wrapper.findAll('.vs-row').length).toBe(2)
+  })
+})
+
+// ── Bus sync ──────────────────────────────────────────────────────────────────
+
+describe('Bus sync', () => {
+  test('filter mode: external activeTicker change filters the feed', async () => {
+    const { useWidgetBus: busMock, activeTickers } = await import('@/composables/useWidgetBus.js')
+    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: vi.fn(), activeTickers })
+
+    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
+    const wrapper = mountFeed({ linkColor: 'blue' })
+    wsMock.__trigger([makeArticle()])
+    await nextTick()
+
+    activeTickers['blue'] = 'AAPL'
+    await nextTick()
+
+    expect(wrapper.find('.active-ticker-pill').exists()).toBe(true)
+  })
+
+  test('select mode: external activeTicker change does not filter the feed', async () => {
+    const { useWidgetBus: busMock, activeTickers } = await import('@/composables/useWidgetBus.js')
+    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: vi.fn(), activeTickers })
+
+    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
+    const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
+    wsMock.__trigger([makeArticle()])
+    await nextTick()
+
+    activeTickers['blue'] = 'AAPL'
+    await nextTick()
+
+    expect(wrapper.find('.active-ticker-pill').exists()).toBe(false)
+  })
+})

--- a/client/src/components/widgets/__tests__/NewsFeed.spec.js
+++ b/client/src/components/widgets/__tests__/NewsFeed.spec.js
@@ -48,6 +48,11 @@ const triggerData = (data) => {
   lastCall[0].onData(data)
 }
 
+// Reset shared activeTickers reactive object between tests to prevent state leakage
+beforeEach(() => {
+  Object.keys(activeTickers).forEach(k => delete activeTickers[k])
+})
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const defaultProps = {
   feedName:  'news:feed:latest',
@@ -124,7 +129,8 @@ describe('Ticker mode toggle', () => {
 // ── Ticker mode toggle — settings persistence ─────────────────────────────────
 
 // Note: VTU 2.4.x + <script setup> emit bug — wrapper.emitted() doesn't capture
-// Vue emissions. Use attrs: { 'onUpdate-settings': handler } pattern instead.
+// Vue emissions from defineEmits. Use attrs: { 'onUpdate-settings': handler } instead.
+// TODO: revisit after @vue/test-utils > 2.4.6 (upstream: github.com/vuejs/test-utils/issues/2014)
 describe('Ticker mode toggle — settings persistence', () => {
   test('toggling to select emits update-settings with tickerClickMode select', async () => {
     const calls = []
@@ -148,6 +154,20 @@ describe('Ticker mode toggle — settings persistence', () => {
     await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
     expect(calls.length).toBeGreaterThan(0)
     expect(calls[calls.length - 1].tickerClickMode).toBe('filter')
+  })
+
+  test('toggling preserves other existing settings', async () => {
+    const calls = []
+    const wrapper = mount(NewsFeed, {
+      props: { ...defaultProps, settings: { hasTickersOnly: true, tickerClickMode: 'filter' } },
+      attrs: { 'onUpdate-settings': (s) => calls.push(s) },
+      global: { stubs: { Teleport: true } },
+    })
+    await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
+    expect(calls.length).toBeGreaterThan(0)
+    const last = calls[calls.length - 1]
+    expect(last.tickerClickMode).toBe('select')
+    expect(last.hasTickersOnly).toBe(true)
   })
 })
 
@@ -225,6 +245,39 @@ describe('Select mode — ticker tag click', () => {
     await nextTick()
 
     expect(wrapper.findAll('.vs-row').length).toBe(2)
+  })
+
+  test('select mode: clicking same ticker twice broadcasts null to clear linked widgets', async () => {
+    const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
+    const mockSet = vi.fn()
+    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
+
+    const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
+    triggerData([makeArticle()])
+    await nextTick()
+
+    const tag = wrapper.findAll('.ticker-tag')[0]
+    await tag.trigger('click')  // first click → broadcasts 'AAPL'
+    await tag.trigger('click')  // second click → broadcasts null (deselect)
+    await nextTick()
+
+    expect(mockSet).toHaveBeenLastCalledWith('blue', null)
+  })
+
+  test('select mode: no linkColor — ticker tag click has no observable effect', async () => {
+    const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
+    const mockSet = vi.fn()
+    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
+
+    const wrapper = mountFeed({ linkColor: null, settings: { tickerClickMode: 'select' } })
+    triggerData([makeArticle()])
+    await nextTick()
+
+    await wrapper.findAll('.ticker-tag')[0].trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('.active-ticker-pill').exists()).toBe(false)
+    expect(mockSet).not.toHaveBeenCalled()
   })
 })
 

--- a/client/src/components/widgets/__tests__/NewsFeed.spec.js
+++ b/client/src/components/widgets/__tests__/NewsFeed.spec.js
@@ -5,19 +5,15 @@ import { nextTick, ref } from 'vue'
 // ── Mock useWebSocketClient ───────────────────────────────────────────────────
 vi.mock('@/composables/useWebSocketClient.js', async () => {
   const { ref } = await import('vue')
-  let _onData = null
-  const mock = vi.fn((config) => {
-    _onData = config.onData
-    return {
+  return {
+    useWebSocketClient: vi.fn((config) => ({
       lastDataAt:   ref(null),
       isConnected:  ref(true),
       reconnecting: ref(false),
       getCache:     vi.fn(),
-      cacheLimit:   ref(config.cacheLimit ?? 1000),
-    }
-  })
-  mock.__trigger = (data) => _onData && _onData(data)
-  return { useWebSocketClient: mock }
+      cacheLimit:   ref(config?.cacheLimit ?? 1000),
+    })),
+  }
 })
 
 // ── Mock useWidgetBus ─────────────────────────────────────────────────────────
@@ -42,8 +38,15 @@ vi.mock('vue-virtual-scroller', () => ({
 }))
 
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
-import { useWidgetBus, setActiveTicker } from '@/composables/useWidgetBus.js'
+import { useWidgetBus, setActiveTicker, activeTickers } from '@/composables/useWidgetBus.js'
 import NewsFeed from '../NewsFeed.vue'
+
+// Helper: call onData from the most recent useWebSocketClient mount
+const triggerData = (data) => {
+  const calls = vi.mocked(useWebSocketClient).mock.calls
+  const lastCall = calls[calls.length - 1]
+  lastCall[0].onData(data)
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const defaultProps = {
@@ -120,62 +123,61 @@ describe('Ticker mode toggle', () => {
 
 // ── Ticker mode toggle — settings persistence ─────────────────────────────────
 
+// Note: VTU 2.4.x + <script setup> emit bug — wrapper.emitted() doesn't capture
+// Vue emissions. Use attrs: { 'onUpdate-settings': handler } pattern instead.
 describe('Ticker mode toggle — settings persistence', () => {
-  test('toggling emits update-settings with tickerClickMode select', async () => {
-    const wrapper = mountFeed()
+  test('toggling to select emits update-settings with tickerClickMode select', async () => {
+    const calls = []
+    const wrapper = mount(NewsFeed, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': (s) => calls.push(s) },
+      global: { stubs: { Teleport: true } },
+    })
     await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
-    const emitted = wrapper.emitted('update-settings')
-    expect(emitted).toBeTruthy()
-    const last = emitted[emitted.length - 1][0]
-    expect(last.tickerClickMode).toBe('select')
+    expect(calls.length).toBeGreaterThan(0)
+    expect(calls[calls.length - 1].tickerClickMode).toBe('select')
   })
 
-  test('toggling back emits update-settings with tickerClickMode filter', async () => {
-    const wrapper = mountFeed({ settings: { tickerClickMode: 'select' } })
+  test('toggling to filter emits update-settings with tickerClickMode filter', async () => {
+    const calls = []
+    const wrapper = mount(NewsFeed, {
+      props: { ...defaultProps, settings: { tickerClickMode: 'select' } },
+      attrs: { 'onUpdate-settings': (s) => calls.push(s) },
+      global: { stubs: { Teleport: true } },
+    })
     await wrapper.find('[data-testid="ticker-mode-toggle"]').trigger('click')
-    const emitted = wrapper.emitted('update-settings')
-    const last = emitted[emitted.length - 1][0]
-    expect(last.tickerClickMode).toBe('filter')
+    expect(calls.length).toBeGreaterThan(0)
+    expect(calls[calls.length - 1].tickerClickMode).toBe('filter')
   })
 })
 
 // ── Filter mode (default) ─────────────────────────────────────────────────────
 
 describe('Filter mode — ticker tag click', () => {
-  beforeEach(() => vi.mocked(useWebSocketClient).mockClear())
-
-  test('clicking a ticker tag filters the feed to that ticker', async () => {
-    const callsBefore = vi.mocked(useWebSocketClient).mock.calls.length
+  test('clicking a ticker tag filters the feed and shows active-ticker-pill', async () => {
     const wrapper = mountFeed({ linkColor: 'blue' })
-    const wsInstance = vi.mocked(useWebSocketClient).mock.results[callsBefore].value
-    wsInstance.getCache = vi.fn()
-    // Inject an article
-    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
-    wsMock.__trigger([makeArticle()])
+    triggerData([makeArticle()])
     await nextTick()
 
-    const tagsBefore = wrapper.findAll('.ticker-tag')
-    expect(tagsBefore.length).toBeGreaterThan(0)
-    await tagsBefore[0].trigger('click')
+    const tags = wrapper.findAll('.ticker-tag')
+    expect(tags.length).toBeGreaterThan(0)
+    await tags[0].trigger('click')
     await nextTick()
 
-    // active-ticker-pill should appear
     expect(wrapper.find('.active-ticker-pill').exists()).toBe(true)
     expect(wrapper.find('.active-ticker-pill').text()).toContain('AAPL')
   })
 
-  test('filter mode: ticker tag click also broadcasts via setActiveTicker', async () => {
+  test('filter mode: ticker tag click broadcasts via setActiveTicker', async () => {
     const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
     const mockSet = vi.fn()
     vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
 
-    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
     const wrapper = mountFeed({ linkColor: 'blue' })
-    wsMock.__trigger([makeArticle()])
+    triggerData([makeArticle()])
     await nextTick()
 
-    const tags = wrapper.findAll('.ticker-tag')
-    await tags[0].trigger('click')
+    await wrapper.findAll('.ticker-tag')[0].trigger('click')
     await nextTick()
 
     expect(mockSet).toHaveBeenCalledWith('blue', 'AAPL')
@@ -190,45 +192,38 @@ describe('Select mode — ticker tag click', () => {
     const mockSet = vi.fn()
     vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
 
-    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
     const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
-    wsMock.__trigger([makeArticle()])
+    triggerData([makeArticle()])
     await nextTick()
 
-    const tags = wrapper.findAll('.ticker-tag')
-    await tags[0].trigger('click')
+    await wrapper.findAll('.ticker-tag')[0].trigger('click')
     await nextTick()
 
     expect(mockSet).toHaveBeenCalledWith('blue', 'AAPL')
   })
 
-  test('select mode: ticker tag click does not filter the feed (no active-ticker-pill)', async () => {
-    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
+  test('select mode: ticker tag click does not set active-ticker-pill', async () => {
     const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
-    wsMock.__trigger([makeArticle()])
+    triggerData([makeArticle()])
     await nextTick()
 
-    const tags = wrapper.findAll('.ticker-tag')
-    await tags[0].trigger('click')
+    await wrapper.findAll('.ticker-tag')[0].trigger('click')
     await nextTick()
 
     expect(wrapper.find('.active-ticker-pill').exists()).toBe(false)
   })
 
   test('select mode: all articles remain visible after ticker tag click', async () => {
-    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
     const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
-    wsMock.__trigger([
+    triggerData([
       makeArticle({ link: 'https://example.com/a1' }),
       makeArticle({ link: 'https://example.com/a2', companies: [{ ticker: 'MSFT', name: 'Microsoft', primaryListing: { exchangeCode: 'XNAS' } }] }),
     ])
     await nextTick()
 
-    const tags = wrapper.findAll('.ticker-tag')
-    await tags[0].trigger('click')
+    await wrapper.findAll('.ticker-tag')[0].trigger('click')
     await nextTick()
 
-    // Both rows still visible — feed unfiltered
     expect(wrapper.findAll('.vs-row').length).toBe(2)
   })
 })
@@ -236,13 +231,12 @@ describe('Select mode — ticker tag click', () => {
 // ── Bus sync ──────────────────────────────────────────────────────────────────
 
 describe('Bus sync', () => {
-  test('filter mode: external activeTicker change filters the feed', async () => {
+  test('filter mode: external activeTicker change shows active-ticker-pill', async () => {
     const { useWidgetBus: busMock, activeTickers } = await import('@/composables/useWidgetBus.js')
     vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: vi.fn(), activeTickers })
 
-    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
     const wrapper = mountFeed({ linkColor: 'blue' })
-    wsMock.__trigger([makeArticle()])
+    triggerData([makeArticle()])
     await nextTick()
 
     activeTickers['blue'] = 'AAPL'
@@ -251,13 +245,12 @@ describe('Bus sync', () => {
     expect(wrapper.find('.active-ticker-pill').exists()).toBe(true)
   })
 
-  test('select mode: external activeTicker change does not filter the feed', async () => {
+  test('select mode: external activeTicker change does not show active-ticker-pill', async () => {
     const { useWidgetBus: busMock, activeTickers } = await import('@/composables/useWidgetBus.js')
     vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: vi.fn(), activeTickers })
 
-    const { useWebSocketClient: wsMock } = await import('@/composables/useWebSocketClient.js')
     const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
-    wsMock.__trigger([makeArticle()])
+    triggerData([makeArticle()])
     await nextTick()
 
     activeTickers['blue'] = 'AAPL'


### PR DESCRIPTION
## Summary

Adds a select/filter mode toggle to the NewsFeed widget, controlling what happens when a ticker tag is clicked.

**Filter mode (default):** clicking a ticker tag filters the local feed to that ticker AND broadcasts to linked widgets — preserving current behavior.

**Select mode:** clicking a ticker tag broadcasts to linked widgets only; the news feed view is unchanged. Useful when the feed should stay unfiltered while driving quote/chart widgets from news.

Toggle preference is persisted via `update-settings` → `tickerClickMode`.

## Changes

- `NewsFeed.vue` — `tickerClickMode` ref read from settings; toggle button with `data-testid="ticker-mode-toggle"`; `toggleTickerFilter` branches on mode; bus sync watcher respects mode
- `NewsFeed.spec.js` — new spec file; 16 tests covering toggle rendering, settings persistence, filter/select behavior, and bus sync

refs #242