### PR TITLE
fix(charts): display ET (America/New_York) time instead of UTC

### DIFF
--- a/client/src/components/widgets/CandlestickChart.vue
+++ b/client/src/components/widgets/CandlestickChart.vue
@@ -355,7 +355,9 @@ const isIntraday = computed(() => ['1m', '5m', '15m', '1h'].includes(intervalLoc
 const chartOption = computed(() => {
   if (!bars.value.length) return {}
 
-  const times    = bars.value.map(b => new Date(b.t).toISOString())
+  const times    = bars.value.map(b =>
+    new Date(b.t).toLocaleString('sv-SE', { timeZone: 'America/New_York' }).replace('T', ' ')
+  )
   const candles  = bars.value.map(b => [b.o, b.c, b.l, b.h])
   const volumes  = bars.value.map((b, i) => ({
     value: b.v,

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -361,7 +361,20 @@ onMounted(() => {
           hour12:   false,
         }),
     },
-    timeScale:       { borderColor: '#333', timeVisible: true, secondsVisible: false },
+    timeScale: {
+      borderColor:       '#333',
+      timeVisible:       true,
+      secondsVisible:    false,
+      tickMarkFormatter: (timestamp, markType) => {
+        const d    = new Date(timestamp * 1000)
+        const opts = { timeZone: 'America/New_York' }
+        // markType: 0=Year, 1=Month, 2=DayOfMonth, 3=Time, 4=TimeWithSeconds
+        if (markType >= 3) return d.toLocaleString('en-US', { ...opts, hour: '2-digit', minute: '2-digit', hour12: false })
+        if (markType === 2) return d.toLocaleString('en-US', { ...opts, month: '2-digit', day: '2-digit' })
+        if (markType === 1) return d.toLocaleString('en-US', { ...opts, month: 'short' })
+        return d.toLocaleString('en-US', { ...opts, year: 'numeric' })
+      },
+    },
     width:  chartContainer.value.clientWidth,
     height: chartContainer.value.clientHeight,
   })

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -350,6 +350,17 @@ onMounted(() => {
     },
     crosshair:       { mode: CrosshairMode.Magnet },
     rightPriceScale: { borderColor: '#333' },
+    localization: {
+      timeFormatter: (timestamp) =>
+        new Date(timestamp * 1000).toLocaleString('en-US', {
+          timeZone: 'America/New_York',
+          month:    '2-digit',
+          day:      '2-digit',
+          hour:     '2-digit',
+          minute:   '2-digit',
+          hour12:   false,
+        }),
+    },
     timeScale:       { borderColor: '#333', timeVisible: true, secondsVisible: false },
     width:  chartContainer.value.clientWidth,
     height: chartContainer.value.clientHeight,

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -618,42 +618,63 @@ describe('Header ticker input (Tweak 3)', () => {
 
 // ── ET timezone on x-axis labels ──────────────────────────────────────────────
 // Bug: times array uses toISOString() which produces UTC strings (e.g. "14:30Z")
-// instead of ET (e.g. "09:30" for EST / "10:30" for EDT).
-// Fixture: 2024-01-15T14:30:00Z = 09:30 EST (UTC-5, winter — no DST)
+// instead of ET (America/New_York) which handles both EST (UTC-5) and EDT (UTC-4).
+//
+// Winter fixture: 2024-01-15T14:30:00Z = 09:30 EST (UTC-5)
+// Summer fixture: 2024-07-15T13:30:00Z = 09:30 EDT (UTC-4)
+// A naive UTC-5 offset passes winter but returns 08:30 for the summer fixture.
 
 describe('ET timezone on x-axis time labels', () => {
-  const UTC_TS   = new Date('2024-01-15T14:30:00Z').getTime()  // 14:30 UTC = 09:30 ET
-  const ET_HOUR  = '09'  // expected hour in ET for this fixture
-  const UTC_HOUR = '14'  // current broken hour (UTC)
+  // Winter (EST, UTC-5)
+  const WINTER_UTC_TS   = new Date('2024-01-15T14:30:00Z').getTime()
+  const WINTER_UTC_HOUR = '14'
+  // Summer (EDT, UTC-4)
+  const SUMMER_UTC_TS   = new Date('2024-07-15T13:30:00Z').getTime()
+  const SUMMER_UTC_HOUR = '13'
 
-  function mountWithBar() {
+  function mountWithBar(t) {
     global.fetch = mockFetch({
-      results: [{ t: UTC_TS, o: 150, h: 155, l: 148, c: 152, v: 1_000_000, vw: 151 }],
+      results: [{ t, o: 150, h: 155, l: 148, c: 152, v: 1_000_000, vw: 151 }],
     })
-    const wrapper = mount(CandlestickChart, {
+    return mount(CandlestickChart, {
       props: { ...defaultProps, settings: { ticker: 'AAPL' } },
     })
-    return wrapper
   }
 
-  test('x-axis time label shows ET hour, not UTC hour', async () => {
+  test('winter (EST): x-axis label shows 09:30, not UTC 14:30', async () => {
     // Arrange + Act
-    const wrapper = mountWithBar()
+    const wrapper = mountWithBar(WINTER_UTC_TS)
     await nextTick()
     await nextTick()
 
     const option = wrapper.findComponent({ name: 'VChart' }).props('option')
-    const timeLabel = option.xAxis[0].data[0]  // first (only) bar label
+    const timeLabel = option.xAxis[0].data[0]
 
-    // Assert — label contains ET hour (09) not UTC hour (14)
-    expect(timeLabel).toContain(ET_HOUR)
-    expect(timeLabel).not.toContain(UTC_HOUR)
+    // Assert — 09:30 ET; not UTC 14:xx
+    expect(timeLabel).toMatch(/09:30/)
+    expect(timeLabel).not.toContain(WINTER_UTC_HOUR)
+    wrapper.unmount()
+  })
+
+  test('summer (EDT): x-axis label shows 09:30, not UTC 13:30', async () => {
+    // Arrange + Act
+    // A naive UTC-5 fix would produce 08:30 here — wrong for EDT (UTC-4)
+    const wrapper = mountWithBar(SUMMER_UTC_TS)
+    await nextTick()
+    await nextTick()
+
+    const option = wrapper.findComponent({ name: 'VChart' }).props('option')
+    const timeLabel = option.xAxis[0].data[0]
+
+    // Assert — 09:30 ET; not UTC 13:xx
+    expect(timeLabel).toMatch(/09:30/)
+    expect(timeLabel).not.toContain(SUMMER_UTC_HOUR)
     wrapper.unmount()
   })
 
   test('x-axis time label does not end with Z (not a UTC ISO string)', async () => {
     // Arrange + Act
-    const wrapper = mountWithBar()
+    const wrapper = mountWithBar(WINTER_UTC_TS)
     await nextTick()
     await nextTick()
 

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -615,3 +615,53 @@ describe('Header ticker input (Tweak 3)', () => {
     wrapper.unmount()
   })
 })
+
+// ── ET timezone on x-axis labels ──────────────────────────────────────────────
+// Bug: times array uses toISOString() which produces UTC strings (e.g. "14:30Z")
+// instead of ET (e.g. "09:30" for EST / "10:30" for EDT).
+// Fixture: 2024-01-15T14:30:00Z = 09:30 EST (UTC-5, winter — no DST)
+
+describe('ET timezone on x-axis time labels', () => {
+  const UTC_TS   = new Date('2024-01-15T14:30:00Z').getTime()  // 14:30 UTC = 09:30 ET
+  const ET_HOUR  = '09'  // expected hour in ET for this fixture
+  const UTC_HOUR = '14'  // current broken hour (UTC)
+
+  function mountWithBar() {
+    global.fetch = mockFetch({
+      results: [{ t: UTC_TS, o: 150, h: 155, l: 148, c: 152, v: 1_000_000, vw: 151 }],
+    })
+    const wrapper = mount(CandlestickChart, {
+      props: { ...defaultProps, settings: { ticker: 'AAPL' } },
+    })
+    return wrapper
+  }
+
+  test('x-axis time label shows ET hour, not UTC hour', async () => {
+    // Arrange + Act
+    const wrapper = mountWithBar()
+    await nextTick()
+    await nextTick()
+
+    const option = wrapper.findComponent({ name: 'VChart' }).props('option')
+    const timeLabel = option.xAxis[0].data[0]  // first (only) bar label
+
+    // Assert — label contains ET hour (09) not UTC hour (14)
+    expect(timeLabel).toContain(ET_HOUR)
+    expect(timeLabel).not.toContain(UTC_HOUR)
+    wrapper.unmount()
+  })
+
+  test('x-axis time label does not end with Z (not a UTC ISO string)', async () => {
+    // Arrange + Act
+    const wrapper = mountWithBar()
+    await nextTick()
+    await nextTick()
+
+    const option = wrapper.findComponent({ name: 'VChart' }).props('option')
+    const timeLabel = option.xAxis[0].data[0]
+
+    // Assert — toISOString() always ends with "Z"; ET strings don't
+    expect(timeLabel).not.toMatch(/Z$/)
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -547,4 +547,28 @@ describe('ET timezone in chart localization', () => {
     expect(result).not.toContain(SUMMER_UTC_HOUR)
     wrapper.unmount()
   })
+
+  test('timeScale.tickMarkFormatter renders ET time for intraday ticks (markType 3)', () => {
+    // markType 3 = Time tick (intraday). Winter: 1705329000 = 09:30 EST.
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+    const timeScale = vi.mocked(createChart).mock.calls[0]?.[1]?.timeScale
+
+    expect(typeof timeScale?.tickMarkFormatter).toBe('function')
+    const result = timeScale.tickMarkFormatter(1705329000, 3)
+
+    expect(result).toMatch(/09:30/)
+    expect(result).not.toContain('14')  // not UTC hour
+    wrapper.unmount()
+  })
+
+  test('timeScale.tickMarkFormatter renders ET time for summer EDT ticks (markType 3)', () => {
+    // Summer: 1721050200 = 09:30 EDT (UTC-4). Naive UTC-5 would give 08:30.
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+    const timeScale = vi.mocked(createChart).mock.calls[0]?.[1]?.timeScale
+
+    const result = timeScale.tickMarkFormatter(1721050200, 3)
+    expect(result).toMatch(/09:30/)
+    expect(result).not.toContain('13')  // not UTC hour
+    wrapper.unmount()
+  })
 })

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -492,3 +492,41 @@ describe('Settings persistence', () => {
     wrapper.unmount()
   })
 })
+
+// ── ET timezone in chart localization ─────────────────────────────────────────
+// Bug: createChart is called without a localization.timeFormatter, so
+// lightweight-charts displays timestamps in UTC instead of ET.
+// Fixture: 2024-01-15T14:30:00Z (Unix: 1705329000) = 09:30 EST (UTC-5, winter)
+
+describe('ET timezone in chart localization', () => {
+  const UTC_UNIX  = 1705329000          // 2024-01-15T14:30:00Z
+  const ET_HOUR   = '09'                // expected hour in ET for this fixture
+  const UTC_HOUR  = '14'               // broken: what UTC would show
+
+  test('createChart options include localization.timeFormatter', () => {
+    // Arrange + Act
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+
+    const callOpts = vi.mocked(createChart).mock.calls[0]?.[1]
+
+    // Assert — localization block with timeFormatter must be present
+    expect(callOpts).toHaveProperty('localization')
+    expect(typeof callOpts.localization.timeFormatter).toBe('function')
+    wrapper.unmount()
+  })
+
+  test('timeFormatter converts UTC unix timestamp to ET hour', () => {
+    // Arrange + Act
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+
+    const callOpts = vi.mocked(createChart).mock.calls[0]?.[1]
+    const formatter = callOpts?.localization?.timeFormatter
+
+    // Assert — formatter must exist and return ET time string
+    expect(typeof formatter).toBe('function')
+    const result = formatter(UTC_UNIX)
+    expect(result).toContain(ET_HOUR)
+    expect(result).not.toContain(UTC_HOUR)
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -493,15 +493,19 @@ describe('Settings persistence', () => {
   })
 })
 
-// ── ET timezone in chart localization ─────────────────────────────────────────
+// ── ET timezone in chart localization ───────────────────────────────────────────────────
 // Bug: createChart is called without a localization.timeFormatter, so
-// lightweight-charts displays timestamps in UTC instead of ET.
-// Fixture: 2024-01-15T14:30:00Z (Unix: 1705329000) = 09:30 EST (UTC-5, winter)
+// lightweight-charts displays timestamps in UTC instead of ET (America/New_York).
+//
+// Winter fixture: 1705329000 = 2024-01-15T14:30:00Z = 09:30 EST (UTC-5)
+// Summer fixture: 1721050200 = 2024-07-15T13:30:00Z = 09:30 EDT (UTC-4)
+// A naive UTC-5 offset passes winter but returns 08:30 for the summer fixture.
 
 describe('ET timezone in chart localization', () => {
-  const UTC_UNIX  = 1705329000          // 2024-01-15T14:30:00Z
-  const ET_HOUR   = '09'                // expected hour in ET for this fixture
-  const UTC_HOUR  = '14'               // broken: what UTC would show
+  const WINTER_UTC_UNIX = 1705329000   // 2024-01-15T14:30:00Z = 09:30 EST
+  const WINTER_UTC_HOUR = '14'
+  const SUMMER_UTC_UNIX = 1721050200   // 2024-07-15T13:30:00Z = 09:30 EDT
+  const SUMMER_UTC_HOUR = '13'
 
   test('createChart options include localization.timeFormatter', () => {
     // Arrange + Act
@@ -515,18 +519,32 @@ describe('ET timezone in chart localization', () => {
     wrapper.unmount()
   })
 
-  test('timeFormatter converts UTC unix timestamp to ET hour', () => {
+  test('winter (EST): timeFormatter returns 09:30, not UTC 14:30', () => {
     // Arrange + Act
     const wrapper = mount(TVLiteChart, { props: defaultProps })
+    const formatter = vi.mocked(createChart).mock.calls[0]?.[1]?.localization?.timeFormatter
 
-    const callOpts = vi.mocked(createChart).mock.calls[0]?.[1]
-    const formatter = callOpts?.localization?.timeFormatter
-
-    // Assert — formatter must exist and return ET time string
     expect(typeof formatter).toBe('function')
-    const result = formatter(UTC_UNIX)
-    expect(result).toContain(ET_HOUR)
-    expect(result).not.toContain(UTC_HOUR)
+    const result = formatter(WINTER_UTC_UNIX)
+
+    // Assert — 09:30 ET; not UTC 14:xx
+    expect(result).toMatch(/09:30/)
+    expect(result).not.toContain(WINTER_UTC_HOUR)
+    wrapper.unmount()
+  })
+
+  test('summer (EDT): timeFormatter returns 09:30, not UTC 13:30', () => {
+    // Arrange + Act
+    // A naive UTC-5 fix would produce 08:30 here — wrong for EDT (UTC-4)
+    const wrapper = mount(TVLiteChart, { props: defaultProps })
+    const formatter = vi.mocked(createChart).mock.calls[0]?.[1]?.localization?.timeFormatter
+
+    expect(typeof formatter).toBe('function')
+    const result = formatter(SUMMER_UTC_UNIX)
+
+    // Assert — 09:30 ET; not UTC 13:xx
+    expect(result).toMatch(/09:30/)
+    expect(result).not.toContain(SUMMER_UTC_HOUR)
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Bug

Both `CandlestickChart` and `TVLiteChart` display timestamps in UTC instead of ET (America/New_York).

**CandlestickChart:** `times` array is built with `new Date(b.t).toISOString()`, which always returns UTC (e.g. `2024-01-15T14:30:00.000Z`). Market open at 09:30 ET shows as 14:30 UTC.

**TVLiteChart:** `createChart` is called without `localization.timeFormatter`, so lightweight-charts renders all axis/crosshair timestamps in UTC by default.

## Failing Tests (this commit)

Fixture: `2024-01-15T14:30:00Z` = `09:30 EST` (UTC-5, January — no DST)

- `CandlestickChart`: x-axis label contains UTC hour `14`, not ET hour `09`; label ends with `Z`
- `TVLiteChart`: `createChart` options have no `localization.timeFormatter`

Implementation to follow in a subsequent commit once CI confirms 🔴.

refs #243