### PR TITLE
perf(DailyRangeAlerts): Rec 3 — RAF batching of live WebSocket events

### DIFF
--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -208,6 +208,29 @@ const config = computed(() => ({ ...DEFAULT_SETTINGS, ...props.settings }))
 let _seq = 0
 const events = ref([])
 
+// ── RAF batch buffer (Rec 3 — Option A) ──────────────────────────────────────
+// Live events accumulate in a plain non-reactive array. requestAnimationFrame
+// fires once at the frame boundary and does a single events.value assignment:
+// one reactive cycle, one VDOM diff, one paint — regardless of burst size.
+//
+// Background tab: RAF pauses when the tab is hidden; the buffer accumulates
+// and flushes in one shot on focus. This is accepted behavior.
+//
+// Cache hydration (Array payload) remains synchronous — one-time load, no batching.
+let _rafPending = []    // plain array — non-reactive, no Vue tracking overhead
+let _rafId = null
+
+const flushLiveEvents = () => {
+  if (_rafPending.length === 0) { _rafId = null; return }
+  const maxEv = config.value.maxEvents
+  const incoming = _rafPending.map(e => ({ ...e, _seq: _seq++ }))
+  _rafPending = []
+  _rafId = null
+  // Single reactive assignment: prepend batch to existing events, then cap
+  const next = [...incoming.reverse(), ...events.value]
+  events.value = maxEv > 0 ? next.slice(0, maxEv) : next
+}
+
 const enforceMaxEvents = () => {
   const maxEv = config.value.maxEvents
   if (maxEv > 0 && events.value.length > maxEv) {
@@ -226,14 +249,15 @@ const { lastDataAt, isConnected, reconnecting, feedName, cacheKey, connect, disc
     cacheKey: initFeed.cacheKey,
     onData: (data) => {
       if (Array.isArray(data)) {
-        // Cache hydration — sort timestamp DESC, then assign _seq
+        // Cache hydration — synchronous, one-time load, no RAF batching
         const sorted = [...data].sort((a, b) => b.timestamp - a.timestamp)
         events.value = sorted.map(e => ({ ...e, _seq: _seq++ }))
+        enforceMaxEvents()
       } else {
-        // Live event — prepend
-        events.value.unshift({ ...data, _seq: _seq++ })
+        // Live event — buffer and schedule RAF flush
+        _rafPending.push(data)
+        if (!_rafId) _rafId = requestAnimationFrame(flushLiveEvents)
       }
-      enforceMaxEvents()
     },
     autoConnect: true,
   })

--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -470,7 +470,14 @@ const startResize = (e, colKey) => {
   document.addEventListener('mousemove', onMove)
   document.addEventListener('mouseup', onUp)
 }
-onUnmounted(() => { resizeState = null })
+onUnmounted(() => {
+  // Cancel any pending RAF flush to avoid writing to dead reactive state
+  if (_rafId) {
+    cancelAnimationFrame(_rafId)
+    _rafId = null
+  }
+  resizeState = null
+})
 
 // ── Rel Vol class (matches GenericScannerTable) ─────────────────────────────
 const getRelVolClass = (relVol) => {

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -1553,3 +1553,167 @@ describe('Bus sync in filter mode', () => {
     wrapper.unmount()
   })
 })
+
+// ── Rec 3 — RAF batching (Option A: batching in widget, not in useWebSocketClient) ──
+// Bug: each live WebSocket message immediately mutates events.value, triggering
+// a reactive cycle, VDOM diff, and paint per message. A burst of 50 alerts in
+// 2 seconds = 50 reactive updates. The fix is to buffer incoming live events in
+// a non-reactive array and assign them to events.value in one RAF callback.
+//
+// Cache hydration (Array payload) must remain synchronous — it is a one-time
+// load and does not need batching.
+
+describe('RAF batching of live events', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('live event is not immediately added to events — remains buffered until RAF fires', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await nextTick()
+    const onData = getOnData()
+
+    // Act — send a live event (non-array = single live alert)
+    onData(makeEvent({ symbol: 'AAPL', price: 10 }))
+    await nextTick()
+
+    // Assert — event is still buffered; events.value not yet updated
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(0)
+
+    wrapper.unmount()
+  })
+
+  test('RAF flush delivers all buffered events in one reactive update', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await nextTick()
+    const onData = getOnData()
+
+    // Act — send 3 rapid live events without advancing timers
+    onData(makeEvent({ symbol: 'AAPL', price: 10 }))
+    onData(makeEvent({ symbol: 'TSLA', price: 20 }))
+    onData(makeEvent({ symbol: 'NVDA', price: 30 }))
+    await nextTick()
+
+    // Assert — still buffered; no rows visible before RAF fires
+    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(0)
+
+    // Advance into next animation frame
+    vi.advanceTimersByTime(20)
+    await nextTick()
+
+    // Assert — all 3 events delivered in one flush
+    const rows = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state'))
+    expect(rows.length).toBe(3)
+
+    wrapper.unmount()
+  })
+
+  test('burst order is preserved after RAF flush (newest first)', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await nextTick()
+    const onData = getOnData()
+
+    // Act — simulate 3 live events in arrival order
+    onData(makeEvent({ symbol: 'FIRST',  price: 1, timestamp: 1000 }))
+    onData(makeEvent({ symbol: 'SECOND', price: 2, timestamp: 2000 }))
+    onData(makeEvent({ symbol: 'THIRD',  price: 3, timestamp: 3000 }))
+
+    // Assert — still buffered before RAF fires
+    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(0)
+
+    vi.advanceTimersByTime(20)
+    await nextTick()
+
+    // Assert — DailyRangeAlerts prepends new events; newest (THIRD) should be first row
+    const rows = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state'))
+    expect(rows.length).toBe(3)
+    expect(rows[0].text()).toContain('THIRD')
+
+    wrapper.unmount()
+  })
+
+  test('maxEvents limit is enforced at RAF flush, not per-event', async () => {
+    // Arrange — maxEvents: 2
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { maxEvents: 2 } },
+    })
+    await nextTick()
+    const onData = getOnData()
+
+    // Act — send 4 events in one burst
+    onData(makeEvent({ symbol: 'A', price: 1, timestamp: 1000 }))
+    onData(makeEvent({ symbol: 'B', price: 2, timestamp: 2000 }))
+    onData(makeEvent({ symbol: 'C', price: 3, timestamp: 3000 }))
+    onData(makeEvent({ symbol: 'D', price: 4, timestamp: 4000 }))
+
+    // Assert — still buffered before RAF fires
+    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(0)
+
+    vi.advanceTimersByTime(20)
+    await nextTick()
+
+    // Assert — only 2 rows (maxEvents applied at flush)
+    const rows = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state'))
+    expect(rows.length).toBe(2)
+
+    wrapper.unmount()
+  })
+
+  test('second burst after first flush is also batched', async () => {
+    // Arrange
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await nextTick()
+    const onData = getOnData()
+
+    // First burst + flush
+    onData(makeEvent({ symbol: 'AAPL', price: 10 }))
+    vi.advanceTimersByTime(20)
+    await nextTick()
+
+    const countAfterFirst = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length
+    expect(countAfterFirst).toBe(1)
+
+    // Second burst — must remain buffered until RAF fires again
+    onData(makeEvent({ symbol: 'TSLA', price: 20 }))
+    onData(makeEvent({ symbol: 'NVDA', price: 30 }))
+    await nextTick()
+
+    // Still only 1 row (second burst buffered)
+    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(1)
+
+    // Flush second burst
+    vi.advanceTimersByTime(20)
+    await nextTick()
+
+    // Now 3 rows total
+    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(3)
+
+    wrapper.unmount()
+  })
+
+  test('cache hydration (Array payload) remains synchronous — not affected by RAF', async () => {
+    // Cache hydration is a one-time load; it must appear immediately without RAF
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+    await nextTick()
+    const onData = getOnData()
+
+    // Act — hydrate with array (cache load path)
+    onData([makeEvent({ symbol: 'AAPL' }), makeEvent({ symbol: 'TSLA' })])
+    await nextTick()
+
+    // Assert — available without advancing timers (synchronous)
+    const rows = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state'))
+    expect(rows.length).toBe(2)
+
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -350,22 +350,25 @@ describe('Data flow', () => {
     wrapper.unmount()
   })
 
-  test('live event prepend: new event appears at index 0', async () => {
+  test('live event prepend: new event appears at index 0 after RAF flush', async () => {
+    vi.useFakeTimers()
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
     const onData = getOnData()
 
-    // Hydrate with one event
+    // Hydrate with one event (synchronous — array payload)
     onData([makeEvent({ symbol: 'OLD', timestamp: 1000 })])
     await nextTick()
 
-    // Live event arrives
+    // Live event arrives — buffered until RAF fires
     onData(makeEvent({ symbol: 'NEW', timestamp: 2000 }))
+    vi.advanceTimersByTime(20)
     await nextTick()
 
     const rows = wrapper.findAll('tbody tr')
     expect(rows[0].text()).toContain('NEW')
     expect(rows[1].text()).toContain('OLD')
     wrapper.unmount()
+    vi.useRealTimers()
   })
 
   test('maxEvents cap value 3: when 4th event arrives oldest is dropped', async () => {
@@ -383,8 +386,10 @@ describe('Data flow', () => {
     await nextTick()
     expect(countDataRows(wrapper)).toBe(3)
 
-    // 4th live event arrives — oldest (E1) should be dropped
+    // 4th live event arrives — buffered until RAF fires
+    vi.useFakeTimers()
     onData(makeEvent({ symbol: 'E4', timestamp: 4000 }))
+    vi.advanceTimersByTime(20)
     await nextTick()
 
     expect(countDataRows(wrapper)).toBe(3)
@@ -393,6 +398,7 @@ describe('Data flow', () => {
     expect(wrapper.text()).toContain('E2')
     expect(wrapper.text()).not.toContain('E1')
     wrapper.unmount()
+    vi.useRealTimers()
   })
 
   test('maxEvents === 0 is unlimited: events accumulate without cap', async () => {
@@ -1564,13 +1570,30 @@ describe('Bus sync in filter mode', () => {
 // load and does not need batching.
 
 describe('RAF batching of live events', () => {
+  // Use vi.stubGlobal to guarantee RAF control independent of fake-timer interop
+  // with jsdom's native requestAnimationFrame implementation.
+  let pendingRafCallbacks = []
+
+  const flushRaf = async () => {
+    const cbs = [...pendingRafCallbacks]
+    pendingRafCallbacks = []
+    cbs.forEach(cb => cb(performance.now()))
+    await nextTick()
+  }
+
   beforeEach(() => {
-    vi.useFakeTimers()
+    pendingRafCallbacks = []
+    vi.stubGlobal('requestAnimationFrame', (cb) => {
+      pendingRafCallbacks.push(cb)
+      return pendingRafCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    vi.mocked(useWebSocketClient).mockClear()  // reset call tracking so getOnData(0) = THIS mount
     global.fetch = vi.fn()
   })
 
   afterEach(() => {
-    vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   test('live event is not immediately added to events — remains buffered until RAF fires', async () => {
@@ -1584,8 +1607,7 @@ describe('RAF batching of live events', () => {
     await nextTick()
 
     // Assert — event is still buffered; events.value not yet updated
-    const rows = wrapper.findAll('tbody tr')
-    expect(rows.length).toBe(0)
+    expect(countDataRows(wrapper)).toBe(0)
 
     wrapper.unmount()
   })
@@ -1596,22 +1618,20 @@ describe('RAF batching of live events', () => {
     await nextTick()
     const onData = getOnData()
 
-    // Act — send 3 rapid live events without advancing timers
+    // Act — send 3 rapid live events without flushing RAF
     onData(makeEvent({ symbol: 'AAPL', price: 10 }))
     onData(makeEvent({ symbol: 'TSLA', price: 20 }))
     onData(makeEvent({ symbol: 'NVDA', price: 30 }))
     await nextTick()
 
     // Assert — still buffered; no rows visible before RAF fires
-    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(0)
+    expect(countDataRows(wrapper)).toBe(0)
 
-    // Advance into next animation frame
-    vi.advanceTimersByTime(20)
-    await nextTick()
+    // Flush RAF — one reactive assignment for all 3
+    await flushRaf()
 
     // Assert — all 3 events delivered in one flush
-    const rows = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state'))
-    expect(rows.length).toBe(3)
+    expect(countDataRows(wrapper)).toBe(3)
 
     wrapper.unmount()
   })
@@ -1628,15 +1648,14 @@ describe('RAF batching of live events', () => {
     onData(makeEvent({ symbol: 'THIRD',  price: 3, timestamp: 3000 }))
 
     // Assert — still buffered before RAF fires
-    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(0)
+    expect(countDataRows(wrapper)).toBe(0)
 
-    vi.advanceTimersByTime(20)
-    await nextTick()
+    await flushRaf()
 
-    // Assert — DailyRangeAlerts prepends new events; newest (THIRD) should be first row
-    const rows = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state'))
-    expect(rows.length).toBe(3)
-    expect(rows[0].text()).toContain('THIRD')
+    // Assert — DailyRangeAlerts prepends new events; newest (THIRD) should be first row.
+    // v-if empty-state tr is not rendered when filteredEvents has items, so [0] = first data row.
+    expect(countDataRows(wrapper)).toBe(3)
+    expect(wrapper.findAll('tbody tr')[0].text()).toContain('THIRD')
 
     wrapper.unmount()
   })
@@ -1656,14 +1675,12 @@ describe('RAF batching of live events', () => {
     onData(makeEvent({ symbol: 'D', price: 4, timestamp: 4000 }))
 
     // Assert — still buffered before RAF fires
-    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(0)
+    expect(countDataRows(wrapper)).toBe(0)
 
-    vi.advanceTimersByTime(20)
-    await nextTick()
+    await flushRaf()
 
     // Assert — only 2 rows (maxEvents applied at flush)
-    const rows = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state'))
-    expect(rows.length).toBe(2)
+    expect(countDataRows(wrapper)).toBe(2)
 
     wrapper.unmount()
   })
@@ -1676,10 +1693,9 @@ describe('RAF batching of live events', () => {
 
     // First burst + flush
     onData(makeEvent({ symbol: 'AAPL', price: 10 }))
-    vi.advanceTimersByTime(20)
-    await nextTick()
+    await flushRaf()
 
-    const countAfterFirst = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length
+    const countAfterFirst = countDataRows(wrapper)
     expect(countAfterFirst).toBe(1)
 
     // Second burst — must remain buffered until RAF fires again
@@ -1688,20 +1704,19 @@ describe('RAF batching of live events', () => {
     await nextTick()
 
     // Still only 1 row (second burst buffered)
-    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(1)
+    expect(countDataRows(wrapper)).toBe(1)
 
     // Flush second burst
-    vi.advanceTimersByTime(20)
-    await nextTick()
+    await flushRaf()
 
     // Now 3 rows total
-    expect(wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state')).length).toBe(3)
+    expect(countDataRows(wrapper)).toBe(3)
 
     wrapper.unmount()
   })
 
   test('cache hydration (Array payload) remains synchronous — not affected by RAF', async () => {
-    // Cache hydration is a one-time load; it must appear immediately without RAF
+    // Cache hydration is a one-time load; it must appear immediately without RAF flush
     const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
     await nextTick()
     const onData = getOnData()
@@ -1710,9 +1725,8 @@ describe('RAF batching of live events', () => {
     onData([makeEvent({ symbol: 'AAPL' }), makeEvent({ symbol: 'TSLA' })])
     await nextTick()
 
-    // Assert — available without advancing timers (synchronous)
-    const rows = wrapper.findAll('tbody tr').filter(r => !r.classes('empty-state'))
-    expect(rows.length).toBe(2)
+    // Assert — available without flushing RAF (synchronous)
+    expect(countDataRows(wrapper)).toBe(2)
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Problem

Each live WebSocket message immediately mutates `events.value`, triggering a full reactive cycle, VDOM diff, and paint per message. A burst of 50 alerts in 2 seconds = 50 reactive updates. The main thread is blocked throughout, producing the 392ms INP measurement.

## Solution (Option A — batching in widget, not in `useWebSocketClient.js`)

Buffer incoming live events in a plain non-reactive array. A `requestAnimationFrame` callback fires once at the frame boundary and does a single `events.value = [...]` assignment — one reactive cycle, one VDOM diff, one paint, regardless of burst size.

Cache hydration (Array payload) remains synchronous — it is a one-time load.

## This commit: failing tests only

5 failing tests, 1 passing baseline:

| Test | Expected behavior |
|---|---|
| live event not immediately added | events buffered pre-RAF |
| RAF flush delivers all buffered events | one update for N messages |
| burst order preserved | newest first after flush |
| maxEvents enforced at flush | not per-event |
| second burst also batched | RAF re-arms after flush |
| cache hydration synchronous (passing) | array payload unaffected |

All failing tests assert `events.value` is empty before `vi.advanceTimersByTime(20)` — they will only pass with a real RAF buffer.

Implementation commit to follow once CI confirms 🔴.

refs #244