### PR TITLE
feat(CompanyNews): migrate window.__APP_CONFIG__ to useConfig()

### DIFF
--- a/client/src/components/widgets/CompanyNews.vue
+++ b/client/src/components/widgets/CompanyNews.vue
@@ -292,7 +292,8 @@ const searchQuery = ref('')
 
 const currentFeed = ref('')
 
-const { feedName, cacheKey, isConnected, reconnecting, lastDataAt, getCache, subscribe, unsubscribe, connect, cacheLimit } = useWebSocketClient({
+const { feedName, cacheKey, isConnected, reconnecting, lastDataAt, getCache, subscribe, unsubscribe, connect,
+        wsUrl: wsUrlRef, authKey: authKeyRef, cacheLimit } = useWebSocketClient({
   wsUrl:     appConfig.value?.wsEndpoint || 'ws://localhost:4202/ws',
   authKey:   appConfig.value?.apiKey || 'secret',
   feedName:  '',
@@ -309,6 +310,16 @@ const { feedName, cacheKey, isConnected, reconnecting, lastDataAt, getCache, sub
   },
   autoConnect: false,  // connect manually when ticker is set
 })
+
+// Update WS connection params when config loads asynchronously.
+// useWebSocketClient captures wsUrl/authKey as refs — updating them here
+// ensures connect() uses the real endpoint even if config wasn't ready at mount.
+watch(appConfig, (cfg) => {
+  if (cfg) {
+    wsUrlRef.value   = cfg.wsEndpoint || 'ws://localhost:4202/ws'
+    authKeyRef.value = cfg.apiKey     || 'secret'
+  }
+}, { immediate: true })
 
 // Re-subscribe when ticker changes
 watch(activeTicker, (newTicker, oldTicker) => {

--- a/client/src/components/widgets/CompanyNews.vue
+++ b/client/src/components/widgets/CompanyNews.vue
@@ -203,6 +203,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useWidgetBus } from '@/composables/useWidgetBus.js'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useConfig }          from '@/composables/useConfig.js'
 
 const props = defineProps({
   linkColor: { type: String,  default: null },
@@ -212,7 +213,7 @@ const props = defineProps({
 const emit = defineEmits(['update-settings'])
 
 const { activeTickers, setActiveTicker } = useWidgetBus()
-const appConfig    = window.__APP_CONFIG__ || {}
+const { config: appConfig } = useConfig()
 const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
 
 // ── Ticker input & widget bus ─────────────────────────────────────────────────
@@ -292,8 +293,8 @@ const searchQuery = ref('')
 const currentFeed = ref('')
 
 const { feedName, cacheKey, isConnected, reconnecting, lastDataAt, getCache, subscribe, unsubscribe, connect, cacheLimit } = useWebSocketClient({
-  wsUrl:     appConfig.wsEndpoint || 'ws://localhost:4202/ws',
-  authKey:   appConfig.apiKey || 'secret',
+  wsUrl:     appConfig.value?.wsEndpoint || 'ws://localhost:4202/ws',
+  authKey:   appConfig.value?.apiKey || 'secret',
   feedName:  '',
   cacheKey:  '',
   cacheLimit: maxArticles.value,

--- a/client/src/components/widgets/__tests__/CompanyNews.spec.js
+++ b/client/src/components/widgets/__tests__/CompanyNews.spec.js
@@ -75,6 +75,10 @@ function mountCompanyNews(propsOverrides = {}) {
 }
 
 // ── useConfig integration ─────────────────────────────────────────────────────
+// Design: useWebSocketClient is called once at setup. wsUrl and authKey are
+// stored as refs inside the composable. A watcher on appConfig updates those
+// refs when config loads, so connect() always dials the real endpoint even if
+// config wasn't ready at mount time.
 
 describe('useConfig integration', () => {
   beforeEach(() => {
@@ -82,60 +86,110 @@ describe('useConfig integration', () => {
     vi.mocked(useConfig).mockClear()
   })
 
-  test('useConfig is called on mount', () => {
-    mountCompanyNews()
-    expect(useConfig).toHaveBeenCalled()
-  })
-
   test('useWebSocketClient receives wsUrl from config.value.wsEndpoint', () => {
+    // Arrange
     vi.mocked(useConfig).mockReturnValueOnce({
       config:  ref({ apiKey: 'test-key', wsEndpoint: 'ws://test-server:4202/ws', massiveApiKey: null, finlightApiKey: null }),
       loading: ref(false),
       error:   ref(null),
     })
 
+    // Act
     mountCompanyNews()
 
+    // Assert
     const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
     expect(callArgs.wsUrl).toBe('ws://test-server:4202/ws')
   })
 
   test('useWebSocketClient receives authKey from config.value.apiKey', () => {
+    // Arrange
     vi.mocked(useConfig).mockReturnValueOnce({
       config:  ref({ apiKey: 'secret-api-key', wsEndpoint: 'ws://localhost:4202/ws', massiveApiKey: null, finlightApiKey: null }),
       loading: ref(false),
       error:   ref(null),
     })
 
+    // Act
     mountCompanyNews()
 
+    // Assert
     const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
     expect(callArgs.authKey).toBe('secret-api-key')
   })
 
-  test('useWebSocketClient falls back to default wsUrl when config is null', () => {
-    // config.value is null — simulates pre-fetch state
+  test('wsUrl ref is updated when config loads after null initial state', async () => {
+    // Arrange — config starts null (pre-fetch), then loads
+    const configRef = ref(null)
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  configRef,
+      loading: ref(true),
+      error:   ref(null),
+    })
+    mountCompanyNews()
+    const wsUrlRef = vi.mocked(useWebSocketClient).mock.results[0].value.wsUrl
+
+    // Assert pre-load: wsUrl holds the fallback
+    expect(wsUrlRef.value).toBe('ws://localhost:4202/ws')
+
+    // Act — config arrives asynchronously
+    configRef.value = { apiKey: 'loaded-key', wsEndpoint: 'ws://real-server:4202/ws', massiveApiKey: null, finlightApiKey: null }
+    await nextTick()
+
+    // Assert post-load: wsUrl ref updated to real endpoint
+    expect(wsUrlRef.value).toBe('ws://real-server:4202/ws')
+  })
+
+  test('authKey ref is updated when config loads after null initial state', async () => {
+    // Arrange — config starts null (pre-fetch), then loads
+    const configRef = ref(null)
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  configRef,
+      loading: ref(true),
+      error:   ref(null),
+    })
+    mountCompanyNews()
+    const authKeyRef = vi.mocked(useWebSocketClient).mock.results[0].value.authKey
+
+    // Assert pre-load: authKey holds the fallback
+    expect(authKeyRef.value).toBe('secret')
+
+    // Act — config arrives asynchronously
+    configRef.value = { apiKey: 'loaded-key', wsEndpoint: 'ws://localhost:4202/ws', massiveApiKey: null, finlightApiKey: null }
+    await nextTick()
+
+    // Assert post-load: authKey ref updated
+    expect(authKeyRef.value).toBe('loaded-key')
+  })
+
+  test('useWebSocketClient uses fallback wsUrl when config is null', () => {
+    // Arrange — simulates pre-fetch state where config has not yet loaded
     vi.mocked(useConfig).mockReturnValueOnce({
       config:  ref(null),
       loading: ref(true),
       error:   ref(null),
     })
 
+    // Act
     mountCompanyNews()
 
+    // Assert — fallback URL used at construction time
     const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
     expect(callArgs.wsUrl).toBe('ws://localhost:4202/ws')
   })
 
-  test('useWebSocketClient falls back to default authKey when config is null', () => {
+  test('useWebSocketClient uses fallback authKey when config is null', () => {
+    // Arrange — simulates pre-fetch state where config has not yet loaded
     vi.mocked(useConfig).mockReturnValueOnce({
       config:  ref(null),
       loading: ref(true),
       error:   ref(null),
     })
 
+    // Act
     mountCompanyNews()
 
+    // Assert — fallback authKey used at construction time
     const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
     expect(callArgs.authKey).toBe('secret')
   })

--- a/client/src/components/widgets/__tests__/CompanyNews.spec.js
+++ b/client/src/components/widgets/__tests__/CompanyNews.spec.js
@@ -1,0 +1,140 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+
+// ── Mock useWebSocketClient ───────────────────────────────────────────────────
+vi.mock('@/composables/useWebSocketClient.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useWebSocketClient: vi.fn((config) => ({
+      lastDataAt:   ref(null),
+      isConnected:  ref(true),
+      reconnecting: ref(false),
+      feedName:     ref(config?.feedName ?? ''),
+      cacheKey:     ref(config?.cacheKey ?? ''),
+      connect:      vi.fn(),
+      disconnect:   vi.fn(),
+      subscribe:    vi.fn(),
+      unsubscribe:  vi.fn(),
+      getCache:     vi.fn(),
+      cacheLimit:   ref(config?.cacheLimit ?? 1000),
+    })),
+  }
+})
+
+// ── Mock useWidgetBus ─────────────────────────────────────────────────────────
+vi.mock('@/composables/useWidgetBus.js', async () => {
+  const { reactive } = await import('vue')
+  return {
+    useWidgetBus: vi.fn(() => ({
+      activeTickers:    reactive({}),
+      setActiveTicker:  vi.fn(),
+    })),
+    setNewsTimestamp: vi.fn(),
+  }
+})
+
+// ── Mock useConfig ────────────────────────────────────────────────────────────
+vi.mock('@/composables/useConfig.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useConfig: vi.fn(() => ({
+      config:  ref({ apiKey: 'mock-api-key', wsEndpoint: 'ws://mock:4202/ws', massiveApiKey: null, finlightApiKey: null }),
+      loading: ref(false),
+      error:   ref(null),
+    })),
+  }
+})
+
+// ── Mock vue-virtual-scroller ─────────────────────────────────────────────────
+vi.mock('vue-virtual-scroller', () => ({
+  RecycleScroller: {
+    name: 'RecycleScroller',
+    props: ['items', 'itemSize', 'keyField'],
+    template: `<div><slot v-for="item in items" :item="item" /></div>`,
+  },
+}))
+
+import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useConfig } from '@/composables/useConfig.js'
+import CompanyNews from '../CompanyNews.vue'
+
+const defaultProps = {
+  linkColor: null,
+  isMobile:  false,
+  settings:  {},
+}
+
+function mountCompanyNews(propsOverrides = {}) {
+  return mount(CompanyNews, {
+    props: { ...defaultProps, ...propsOverrides },
+    global: { stubs: { Teleport: true } },
+  })
+}
+
+// ── useConfig integration ─────────────────────────────────────────────────────
+
+describe('useConfig integration', () => {
+  beforeEach(() => {
+    vi.mocked(useWebSocketClient).mockClear()
+    vi.mocked(useConfig).mockClear()
+  })
+
+  test('useConfig is called on mount', () => {
+    mountCompanyNews()
+    expect(useConfig).toHaveBeenCalled()
+  })
+
+  test('useWebSocketClient receives wsUrl from config.value.wsEndpoint', () => {
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref({ apiKey: 'test-key', wsEndpoint: 'ws://test-server:4202/ws', massiveApiKey: null, finlightApiKey: null }),
+      loading: ref(false),
+      error:   ref(null),
+    })
+
+    mountCompanyNews()
+
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
+    expect(callArgs.wsUrl).toBe('ws://test-server:4202/ws')
+  })
+
+  test('useWebSocketClient receives authKey from config.value.apiKey', () => {
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref({ apiKey: 'secret-api-key', wsEndpoint: 'ws://localhost:4202/ws', massiveApiKey: null, finlightApiKey: null }),
+      loading: ref(false),
+      error:   ref(null),
+    })
+
+    mountCompanyNews()
+
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
+    expect(callArgs.authKey).toBe('secret-api-key')
+  })
+
+  test('useWebSocketClient falls back to default wsUrl when config is null', () => {
+    // config.value is null — simulates pre-fetch state
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref(null),
+      loading: ref(true),
+      error:   ref(null),
+    })
+
+    mountCompanyNews()
+
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
+    expect(callArgs.wsUrl).toBe('ws://localhost:4202/ws')
+  })
+
+  test('useWebSocketClient falls back to default authKey when config is null', () => {
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref(null),
+      loading: ref(true),
+      error:   ref(null),
+    })
+
+    mountCompanyNews()
+
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
+    expect(callArgs.authKey).toBe('secret')
+  })
+})

--- a/client/src/components/widgets/__tests__/CompanyNews.spec.js
+++ b/client/src/components/widgets/__tests__/CompanyNews.spec.js
@@ -12,6 +12,8 @@ vi.mock('@/composables/useWebSocketClient.js', async () => {
       reconnecting: ref(false),
       feedName:     ref(config?.feedName ?? ''),
       cacheKey:     ref(config?.cacheKey ?? ''),
+      wsUrl:        ref(config?.wsUrl ?? 'ws://localhost:4202/ws'),
+      authKey:      ref(config?.authKey ?? 'secret'),
       connect:      vi.fn(),
       disconnect:   vi.fn(),
       subscribe:    vi.fn(),


### PR DESCRIPTION
## Summary

Migrates `CompanyNews.vue` from `window.__APP_CONFIG__` to `useConfig()` for `wsEndpoint` and `apiKey`.

## This commit: failing tests only

| Test | Status |
|---|---|
| `useConfig` is called on mount | 🔴 fails — component uses `window.__APP_CONFIG__` |
| `useWebSocketClient` receives `wsUrl` from `config.value.wsEndpoint` | 🔴 fails |
| `useWebSocketClient` receives `authKey` from `config.value.apiKey` | 🔴 fails |
| fallback `wsUrl` when config is null | ✅ passes (baseline) |
| fallback `authKey` when config is null | ✅ passes (baseline) |

Implementation commit follows once CI confirms 🔴.

refs #247