### PR TITLE
feat(DailyRangeAlerts): migrate window.__APP_CONFIG__ to useConfig()

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -233,6 +233,7 @@
 
   <div class="dashboard">
     <!-- Mobile: simple vertical stack (< 640px) -->
+    <div v-if="appConfig">
     <div v-if="isMobile" class="mobile-stack">
       <div
           v-for="item in layout"
@@ -299,6 +300,7 @@
         />
       </GridItem>
     </GridLayout>
+    </div><!-- /v-if="appConfig" -->
   </div>
 </template>
 

--- a/client/src/components/__tests__/DashboardGridUseConfig.spec.js
+++ b/client/src/components/__tests__/DashboardGridUseConfig.spec.js
@@ -162,6 +162,41 @@ describe('DashboardGrid useConfig integration', () => {
     wrapper.unmount()
   })
 
+  test('grid layout is not rendered when config is null — widgets cannot mount prematurely', async () => {
+    // Arrange — config not yet loaded
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref(null),
+      loading: ref(true),
+      error:   ref(null),
+    })
+
+    // Act
+    const wrapper = mountGrid()
+    await nextTick()
+
+    // Assert — no grid layout rendered (no widget mount opportunity while config is null)
+    expect(wrapper.find('.mock-grid-layout').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('grid layout renders when config is loaded', async () => {
+    // Arrange — config available
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref({ apiKey: 'test-key', wsEndpoint: 'ws://test:4202/ws', massiveApiKey: null, finlightApiKey: null }),
+      loading: ref(false),
+      error:   ref(null),
+    })
+
+    // Act
+    const wrapper = mountGrid()
+    await nextTick()
+
+    // Assert — grid layout present (widgets can mount with config available)
+    // Note: mock-grid-layout comes from the vue3-grid-layout-next mock
+    expect(wrapper.find('.mock-grid-layout').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
   test('auth-required message not shown after successful auth (error clears with config)', async () => {
     // Arrange — error present initially, then config loads (re-auth or retry)
     const configRef = ref(null)

--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -162,6 +162,7 @@
 <script setup>
 import { ref, computed, watch, onUnmounted } from 'vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
+import { useConfig }          from '@/composables/useConfig.js'
 import { useScannerLink } from '@/composables/useScannerLink.js'
 import { parseShareCount } from '@/utils/parseShareCount.js'
 import { getFlameVariant, getFlameTooltip, newsTimestamps } from '@/composables/useWidgetBus.js'
@@ -176,7 +177,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update-settings', 'update-col-widths'])
 
-const appConfig = window.__APP_CONFIG__ || {}
+const { config: appConfig } = useConfig()
 
 const DEFAULT_SETTINGS = {
   feed:               'hod',
@@ -243,8 +244,8 @@ const initFeed = FEED_MAP[config.value.feed] || FEED_MAP.hod
 
 const { lastDataAt, isConnected, reconnecting, feedName, cacheKey, connect, disconnect } =
   useWebSocketClient({
-    wsUrl:    appConfig.wsEndpoint || 'ws://localhost:4202/ws',
-    authKey:  appConfig.apiKey     || 'secret',
+    wsUrl:    appConfig.value?.wsEndpoint || 'ws://localhost:4202/ws',
+    authKey:  appConfig.value?.apiKey     || 'secret',
     feedName: initFeed.feedName,
     cacheKey: initFeed.cacheKey,
     onData: (data) => {

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 
 // ── Mock useWebSocketClient ───────────────────────────────────────────────────
 vi.mock('@/composables/useWebSocketClient.js', async () => {

--- a/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlerts.spec.js
@@ -12,6 +12,8 @@ vi.mock('@/composables/useWebSocketClient.js', async () => {
       reconnecting: ref(false),
       feedName:    ref(config.feedName || ''),
       cacheKey:    ref(config.cacheKey || ''),
+      wsUrl:       ref(config.wsUrl   || 'ws://localhost:4202/ws'),
+      authKey:     ref(config.authKey || 'secret'),
       connect:     vi.fn(),
       disconnect:  vi.fn(),
     })),
@@ -41,9 +43,22 @@ vi.mock('@/composables/useWidgetBus.js', async () => {
   }
 })
 
+// ── Mock useConfig ───────────────────────────────────────────────────────────
+vi.mock('@/composables/useConfig.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useConfig: vi.fn(() => ({
+      config:  ref({ apiKey: 'mock-api-key', wsEndpoint: 'ws://mock:4202/ws', massiveApiKey: null, finlightApiKey: null }),
+      loading: ref(false),
+      error:   ref(null),
+    })),
+  }
+})
+
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useScannerLink } from '@/composables/useScannerLink.js'
 import { getFlameVariant } from '@/composables/useWidgetBus.js'
+import { useConfig } from '@/composables/useConfig.js'
 import DailyRangeAlerts from '../DailyRangeAlerts.vue'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -1728,6 +1743,70 @@ describe('RAF batching of live events', () => {
     // Assert — available without flushing RAF (synchronous)
     expect(countDataRows(wrapper)).toBe(2)
 
+    wrapper.unmount()
+  })
+})
+
+
+// ── useConfig integration ─────────────────────────────────────────────────────
+// DashboardGrid now gates widget rendering on config being ready (PR #254).
+// DailyRangeAlerts mounts with config.value guaranteed non-null, so autoConnect:
+// true fires immediately with the real WDS endpoint — no race, no watch needed.
+
+describe('useConfig integration', () => {
+  beforeEach(() => {
+    vi.mocked(useWebSocketClient).mockClear()
+    vi.mocked(useConfig).mockClear()
+  })
+
+  test('useWebSocketClient receives wsUrl from config.value.wsEndpoint', () => {
+    // Arrange
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref({ apiKey: 'test-key', wsEndpoint: 'ws://test-server:4202/ws', massiveApiKey: null, finlightApiKey: null }),
+      loading: ref(false),
+      error:   ref(null),
+    })
+
+    // Act
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+
+    // Assert
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
+    expect(callArgs.wsUrl).toBe('ws://test-server:4202/ws')
+    wrapper.unmount()
+  })
+
+  test('useWebSocketClient receives authKey from config.value.apiKey', () => {
+    // Arrange
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref({ apiKey: 'real-api-key', wsEndpoint: 'ws://localhost:4202/ws', massiveApiKey: null, finlightApiKey: null }),
+      loading: ref(false),
+      error:   ref(null),
+    })
+
+    // Act
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+
+    // Assert
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
+    expect(callArgs.authKey).toBe('real-api-key')
+    wrapper.unmount()
+  })
+
+  test('useWebSocketClient falls back to default wsUrl when config is null', () => {
+    // Arrange — defensive baseline; should not occur in prod with DashboardGrid gating
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref(null),
+      loading: ref(true),
+      error:   ref(null),
+    })
+
+    // Act
+    const wrapper = mount(DailyRangeAlerts, { props: defaultProps })
+
+    // Assert
+    const callArgs = vi.mocked(useWebSocketClient).mock.calls[0][0]
+    expect(callArgs.wsUrl).toBe('ws://localhost:4202/ws')
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary

Two fixes in one PR:

**1. `DashboardGrid` — gate `GridLayout` on `appConfig`**
The `GridLayout` (and all widgets inside it) had no `v-if` guard on `appConfig`. Only the header controls were gated. Widgets were mounting immediately before the `useConfig()` fetch resolved, so `autoConnect` widgets dialed `ws://localhost:4202/ws`.

Fix: wrap both mobile-stack and `GridLayout v-else` in `v-if="appConfig"`. Widgets only mount once `config.value` is non-null.

**2. `DailyRangeAlerts` — migrate `window.__APP_CONFIG__` to `useConfig()`**
Now that `DashboardGrid` correctly gates widget rendering, `DailyRangeAlerts` mounts with `config.value` guaranteed non-null. `autoConnect: true` fires immediately with the correct WDS endpoint — no race, no watch.

refs #248 refs #254