### PR TITLE
fix(DashboardGrid): gate GridLayout on appConfig — prevent premature widget mount

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -233,6 +233,7 @@
 
   <div class="dashboard">
     <!-- Mobile: simple vertical stack (< 640px) -->
+    <div v-if="appConfig">
     <div v-if="isMobile" class="mobile-stack">
       <div
           v-for="item in layout"
@@ -299,6 +300,7 @@
         />
       </GridItem>
     </GridLayout>
+    </div><!-- /v-if="appConfig" -->
   </div>
 </template>
 

--- a/client/src/components/__tests__/DashboardGridUseConfig.spec.js
+++ b/client/src/components/__tests__/DashboardGridUseConfig.spec.js
@@ -162,6 +162,41 @@ describe('DashboardGrid useConfig integration', () => {
     wrapper.unmount()
   })
 
+  test('grid layout is not rendered when config is null — widgets cannot mount prematurely', async () => {
+    // Arrange — config not yet loaded
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref(null),
+      loading: ref(true),
+      error:   ref(null),
+    })
+
+    // Act
+    const wrapper = mountGrid()
+    await nextTick()
+
+    // Assert — no grid layout rendered (no widget mount opportunity while config is null)
+    expect(wrapper.find('.mock-grid-layout').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('grid layout renders when config is loaded', async () => {
+    // Arrange — config available
+    vi.mocked(useConfig).mockReturnValueOnce({
+      config:  ref({ apiKey: 'test-key', wsEndpoint: 'ws://test:4202/ws', massiveApiKey: null, finlightApiKey: null }),
+      loading: ref(false),
+      error:   ref(null),
+    })
+
+    // Act
+    const wrapper = mountGrid()
+    await nextTick()
+
+    // Assert — grid layout present (widgets can mount with config available)
+    // Note: mock-grid-layout comes from the vue3-grid-layout-next mock
+    expect(wrapper.find('.mock-grid-layout').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
   test('auth-required message not shown after successful auth (error clears with config)', async () => {
     // Arrange — error present initially, then config loads (re-auth or retry)
     const configRef = ref(null)


### PR DESCRIPTION
## Bug

`GridLayout` (and all widgets inside it) had no `v-if` guard on `appConfig`. Only the header controls were gated. Widgets were mounting immediately regardless of config state, so `autoConnect` widgets attempted `ws://localhost:4202/ws` before the `useConfig()` fetch resolved.

## Fix

Wrap both `v-if="isMobile"` mobile-stack and `v-else` `GridLayout` in `v-if="appConfig"`. Widgets only mount once `config.value` is non-null — real WDS endpoint guaranteed.

## New tests

- Grid layout absent when config is null
- Grid layout present when config is loaded

refs #254