### PR TITLE
chore: remove window.__APP_CONFIG__ from app.html

### DIFF
--- a/apps/_default/controllers.py
+++ b/apps/_default/controllers.py
@@ -91,8 +91,6 @@ def index():
 @action.uses("app.html", db, session, auth.user)
 def app():
     return dict(
-        api_key=WDS_API_KEY,
-        ws_endpoint=WDS_ENDPOINT  # ,
         # version_info=version_info,
     )
 

--- a/apps/_default/templates/app.html
+++ b/apps/_default/templates/app.html
@@ -6,12 +6,6 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgiIGhlaWdodD0iNDgiIHZpZXdCb3g9IjAgMCA0OCA0OCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjQgOEMyMCA4IDE3IDExIDE3IDE1QzE3IDE2IDE3IDE3IDE4IDE4TDE0IDM4TDIwIDM2TDIyIDQyTDI0IDQwTDI2IDQyTDI4IDM2TDM0IDM4TDMwIDE4QzMxIDE3IDMxIDE2IDMxIDE1QzMxIDExIDI4IDggMjQgOFoiIGZpbGw9IiMwMDAiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIyIi8+PGNpcmNsZSBjeD0iMjEiIGN5PSIxNCIgcj0iMS41IiBmaWxsPSIjZmZmIi8+PGNpcmNsZSBjeD0iMjciIGN5PSIxNCIgcj0iMS41IiBmaWxsPSIjZmZmIi8+PHBhdGggZD0iTTIwIDhMMTYgNk0yOCA4TDMyIDYiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNMjQgMTZMMjYgMTgiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjwvc3ZnPg==">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Top Stocks</title>
-    <script>
-      window.__APP_CONFIG__ = {
-        apiKey: "[[=api_key]]",
-        wsEndpoint: "[[=ws_endpoint]]"
-      };
-    </script>
     <script type="module" crossorigin src="[[=URL('static/dist/index.js')]]"></script>
     <link rel="stylesheet" crossorigin href="[[=URL('static/dist/index.css')]]">
   </head>

--- a/tests/apps/test_default_controllers.py
+++ b/tests/apps/test_default_controllers.py
@@ -122,8 +122,12 @@ def test_index_with_authenticated_user_expect_personalized_message():
 # app()
 # ---------------------------------------------------------------------------
 
-def test_app_with_authenticated_user_expect_config_returned():
-    """app() returns WDS api_key and ws_endpoint."""
+def test_app_with_authenticated_user_expect_renders_without_credentials():
+    """app() renders without embedding credentials in context.
+
+    api_key and ws_endpoint are served by /api/get_config (auth-gated),
+    not embedded in the app.html page source.
+    """
     controllers = _import_controllers(
         wds_api_key='app-api-key',
         wds_endpoint='ws://app:4202/ws',
@@ -131,9 +135,9 @@ def test_app_with_authenticated_user_expect_config_returned():
 
     result = controllers.app()
 
-    assert result['api_key'] == 'app-api-key'
-    assert result['ws_endpoint'] == 'ws://app:4202/ws'
-
+    assert isinstance(result, dict)
+    assert 'api_key' not in result
+    assert 'ws_endpoint' not in result
 
 def test_app_with_authenticated_user_expect_no_api_key_in_context():
     """app() no longer returns api_key (moved to /api/get_config)."""

--- a/tests/apps/test_default_controllers.py
+++ b/tests/apps/test_default_controllers.py
@@ -122,23 +122,6 @@ def test_index_with_authenticated_user_expect_personalized_message():
 # app()
 # ---------------------------------------------------------------------------
 
-def test_app_with_authenticated_user_expect_renders_without_credentials():
-    """app() renders without embedding credentials in context.
-
-    api_key and ws_endpoint are served by /api/get_config (auth-gated),
-    not embedded in the app.html page source.
-    """
-    controllers = _import_controllers(
-        wds_api_key='app-api-key',
-        wds_endpoint='ws://app:4202/ws',
-    )
-
-    result = controllers.app()
-
-    assert isinstance(result, dict)
-    assert 'api_key' not in result
-    assert 'ws_endpoint' not in result
-
 def test_app_with_authenticated_user_expect_no_api_key_in_context():
     """app() no longer returns api_key (moved to /api/get_config)."""
     controllers = _import_controllers(

--- a/tests/apps/test_default_controllers.py
+++ b/tests/apps/test_default_controllers.py
@@ -135,6 +135,36 @@ def test_app_with_authenticated_user_expect_config_returned():
     assert result['ws_endpoint'] == 'ws://app:4202/ws'
 
 
+def test_app_with_authenticated_user_expect_no_api_key_in_context():
+    """app() no longer returns api_key (moved to /api/get_config)."""
+    controllers = _import_controllers(
+        wds_api_key='app-api-key',
+        wds_endpoint='ws://app:4202/ws',
+    )
+
+    result = controllers.app()
+
+    assert 'api_key' not in result, (
+        "api_key must not be returned by app() -- credentials must not be "
+        "embedded in the HTML response. Use /api/get_config instead."
+    )
+
+
+def test_app_with_authenticated_user_expect_no_ws_endpoint_in_context():
+    """app() no longer returns ws_endpoint (moved to /api/get_config)."""
+    controllers = _import_controllers(
+        wds_api_key='app-api-key',
+        wds_endpoint='ws://app:4202/ws',
+    )
+
+    result = controllers.app()
+
+    assert 'ws_endpoint' not in result, (
+        "ws_endpoint must not be returned by app() -- credentials must not be "
+        "embedded in the HTML response. Use /api/get_config instead."
+    )
+
+
 # ---------------------------------------------------------------------------
 # get_config()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Final cleanup for the `useConfig()` migration. Removes the `window.__APP_CONFIG__` inline script block from `app.html` and strips `api_key`/`ws_endpoint` from the `app()` controller context dict.

All widgets now fetch credentials from `/api/get_config` (auth-gated). Credentials no longer appear in page source.

refs #257