### PR TITLE
docs: revise CLAUDE.md for coding agent effectiveness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,101 +1,151 @@
 # CLAUDE.md — kuhl-haus-mdp-app
 
-## Overview
+## What This Is
 
-Service Control Plane (SCP) and web application for the Kuhl Haus Market Data Platform. Built on [py4web](https://py4web.com/), it provides OAuth-secured access to the market data dashboard and serves the client single-page application (SPA) to authenticated users.
+Service Control Plane (SCP) and dashboard SPA for the Kuhl Haus Market Data Platform. Two stacks in one repo:
 
-**Platform documentation:** https://kuhl-haus-mdp.readthedocs.io
+- **Backend:** Python 3.12 / py4web — OAuth, API proxy, config endpoint
+- **Frontend:** Vue 3 SPA (Vite, `<script setup>`) — real-time market data dashboard
 
-## Platform Context
+The SCP authenticates users, serves the SPA, and proxies enrichment APIs (Massive, Finlight) with Redis caching. The SPA connects directly to the Widget Data Service (WDS) via WebSocket for live data.
 
-**Platform repositories:**
-- **kuhl-haus-mdp** — Core library
-- **kuhl-haus-mdp-servers** — Data plane server entry points and Docker images
-- **kuhl-haus-mdp-app** *(this repo)* — Service Control Plane web application
-- **kuhl-haus-mdp-deployment** — Kubernetes/Ansible deployment automation
+## Running Tests
 
-## Architecture
+**Backend (pytest):**
+```bash
+pip install -e ".[testing]"
+pytest tests/ -v
+```
 
-The SCP is the only platform component with external network access. It:
+**Frontend (Vitest):**
+```bash
+cd client
+npm ci
+npm test            # single run
+npm run coverage    # with V8 coverage report
+```
 
-1. Authenticates users via OAuth
-2. Serves the SPA to authenticated clients
-3. Injects the WDS URL and auth token into the SPA environment for direct Widget Data Service access
-4. (Planned) Provides a runtime control plane API for managing data plane components
+Both suites run in CI on every PR (`test-backend.yml`, `test-frontend.yml`). PRs that break tests will not be merged.
 
-The SCP requires access to the data plane network for API communication with data plane components.
-
-**Implemented features:**
-- Authentication and authorization (OAuth)
-- Static and dynamic content serving via py4web
-- SPA delivery to authenticated clients
-- WDS URL + auth token injection into SPA environment
-
-**Planned features:**
-- Runtime control plane for managing data plane components
-- Programmatic API for service controls and instrumentation
-
-## Code Organization
+## Code Layout
 
 ```
 apps/
-├── _dashboard/           # py4web dashboard application (admin interface)
-└── mdp/                  # MDP control plane application (if present)
-app.Dockerfile            # Container image build
-app-entrypoint.sh         # Container entrypoint script
+├── _default/              # Main py4web app
+│   ├── api/market_data.py # Enrichment proxy endpoints (company, news, short interest, logo)
+│   ├── controllers.py     # Routes: index, app, get_config
+│   ├── common.py          # Auth, db, session fixtures
+│   └── settings.py        # All config via env vars
+├── health/                # GET /health → "OK"
+└── healthz/               # GET /healthz → JSON with version info
+client/
+├── src/
+│   ├── components/
+│   │   ├── DashboardGrid.vue     # Root layout — gates all widgets on config
+│   │   ├── WidgetMenu.vue        # Widget type picker
+│   │   ├── WidgetWrapper.vue     # Per-widget chrome (header, link color, remove)
+│   │   └── widgets/              # Individual widget components
+│   ├── composables/
+│   │   ├── useConfig.js          # Module singleton — fetches /api/get_config
+│   │   ├── useWebSocketClient.js # WDS WebSocket connection + subscription
+│   │   ├── useWidgetBus.js       # Cross-widget ticker linking via color groups
+│   │   └── useScannerLink.js     # Scanner → content widget click binding
+│   └── utils/
+│       ├── chartIndicators.js    # EMA/VWMA/SMA calculation
+│       └── parseShareCount.js    # Human-readable share count parsing
+tests/                     # Backend tests (pytest)
+client/src/**/__tests__/   # Frontend tests (Vitest)
 ```
 
-**Languages:** JavaScript (frontend SPA) + Python (py4web backend)  
-**Backend framework:** [py4web](https://py4web.com/)  
-**Authentication:** OAuth
+## Testing Standards
 
-## Container Image
+### General Principles
 
-The published image at `ghcr.io/kuhl-haus/kuhl-haus-mdp-app-server` is for **local development and demonstration only**. The default password is `changeme` and cannot be changed in the base image (immutable).
+- **Observable behavior only** — assert on outputs and rendered DOM, not implementation details
+- **No test classes in frontend** — standalone `test()` functions grouped by `describe()`
+- **Backend uses both styles** — standalone functions for simple cases, classes for endpoint groups (see `test_market_data.py`)
+- **Target ≥95% branch coverage** — floor, not ceiling
 
-For a production image with a custom password:
+### Test Naming
 
-```bash
-# 1. Generate password hash
-python3 -c "from pydal.validators import CRYPT; open('password.txt','w').write(str(CRYPT()(input('password:'))[0]))"
-
-# 2. Build custom image
-docker build -t my-mdp-app - <<EOF
-ARG BASE_IMAGE=ghcr.io/kuhl-haus/kuhl-haus-mdp-app-server:latest
-FROM \${BASE_IMAGE}
-ARG user=py4web
-USER root
-COPY password.txt /home/\$user/
-RUN chown "\${user}:\${user}" /home/\$user/password.txt
-EXPOSE 8000
-USER \$user
-WORKDIR /home/\$user/
-ENTRYPOINT ["/home/py4web/app-entrypoint.sh"]
-EOF
+**Backend (pytest):** `test_<subject>_with_<scenario>_expect_<outcome>`
+```python
+def test_healthz_index_with_defaults_expect_status_ok(monkeypatch):
 ```
 
-See the [py4web run command documentation](https://py4web.com/_documentation/static/en/chapter-03.html#run-command-option) for `--password-file` details.
+**Frontend (Vitest):** Same pattern inside `test()` or `it()`:
+```javascript
+test('with go button click expect manualTicker set to uppercased input', async () => {
+```
 
-## CI/CD (GitHub Actions)
+### Arrange / Act / Assert
 
-| Workflow | Trigger | Purpose |
-|---|---|---|
-| `build-images.yml` | push/tag on mainline | Build and push Docker images to GHCR |
-| `codeql.yml` | push/PR | CodeQL security analysis |
+Every test follows AAA. Act should be a single logical action:
+```python
+# Arrange
+md = _import_market_data()
+mock_redis = _make_redis_mock(json.dumps(cached_data))
 
-## Branch and Merge Conventions
+# Act
+result = md.short_interest("TSLA")
 
-- **Default branch:** `mainline`
-- **Squash merge only** — org-level enforcement; merge commits and rebase are disabled
-- All PRs target `mainline`; use feature branches for all changes
-- Version tags drive Docker image releases — tag format: `vX.Y.Z`
+# Assert
+assert result["source"] == "cache"
+```
 
+### Backend: py4web Stubbing Pattern
 
-## Bug Workflow — Test First
+py4web requires full module stubbing at import time. Follow the established pattern in `test_market_data.py`:
 
-When a bug is reported, **do not start by fixing it**.
+1. Stub `py4web`, `pydal`, `yatl` in `sys.modules` before importing app code
+2. Make `@action` a passthrough decorator (no-op)
+3. Re-import the module under test on each test to pick up fresh patches
+4. Call action functions directly — no HTTP server needed
 
-1. **Write a failing test** that reproduces the bug first
-2. Confirm the test fails (proving the bug exists)
-3. Then fix the bug and prove it with a passing test
+`test_default_controllers.py` is **frozen** — do not modify it. Use it as a reference only.
 
+When using `unittest.mock.patch` or `monkeypatch`, patch the symbol where it is **looked up**, not where it is **defined**. Patching at the definition site has no effect on already-imported callers.
+
+### Frontend: Component Test Patterns
+
+**Mock composables before import** — Vue SFC `<script setup>` runs at import time:
+```javascript
+vi.mock('@/composables/useWebSocketClient.js', async () => {
+  const { ref } = await import('vue')
+  return {
+    useWebSocketClient: vi.fn((config) => ({
+      lastDataAt:  ref(null),
+      isConnected: ref(true),
+      // ... all refs the component destructures
+    })),
+  }
+})
+```
+
+**Module singleton reset** — `useConfig` is a module singleton. Reset between tests:
+```javascript
+beforeEach(async () => { vi.resetModules() })
+```
+
+**VTU 2.4.x emit capture bug** — `wrapper.emitted('event')` does NOT capture Vue emissions from `<script setup>` components in jsdom. Use the `attrs` listener pattern instead:
+```javascript
+const settingsCalls = []
+const wrapper = mount(MyComponent, {
+  props: { /* ... */ },
+  attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+})
+// Assert on settingsCalls[], not wrapper.emitted()
+```
+
+## Dependencies
+
+- **Backend Python:** dependencies in `pyproject.toml` under `[project.dependencies]`; test deps under `[project.optional-dependencies.testing]`
+- **Frontend:** `client/package.json`; lock file is `client/package-lock.json`
+- **Cross-repo:** `kuhl-haus-mdp` is the core library (pinned as `kuhl-haus-mdp>=0.4.8`). Enum values like `WidgetDataCacheKeys` and `WidgetDataCacheTTL` come from there — keep cache key/TTL usage consistent with the library.
+
+## Architecture Notes for Context
+
+- `DashboardGrid.vue` is the parent component. It calls `useConfig()` and gates widget rendering on `config.value` being non-null. This eliminates the async timing race for `autoConnect` widgets. All child widgets mount with config already available.
+- `useWebSocketClient.js` manages WDS connections. Widgets provide feed name, cache key, and auth — the composable handles connect/disconnect/reconnect/subscribe lifecycle.
+- `useWidgetBus.js` provides cross-widget ticker linking via color groups. Scanner widgets set active tickers; content widgets watch them. State is ephemeral (resets on page reload).
+- Market data proxy endpoints in `api/market_data.py` use Redis caching with TTLs consistent with the MDP data pipeline. Cache keys use `WidgetDataCacheKeys` from the core library.


### PR DESCRIPTION
Rewrites CLAUDE.md to focus on code and test standards for IDE-integrated coding agents.

**Added:**
- How to run both test suites (pytest + Vitest)
- Test naming convention with examples from the codebase
- AAA pattern with concrete examples
- py4web stubbing pattern for backend tests
- VTU 2.4.x emit capture bug and the `attrs` workaround
- Module singleton reset pattern for `useConfig`
- `test_default_controllers.py` frozen status
- Cross-repo dependency context (`kuhl-haus-mdp` library)
- Architecture notes: DashboardGrid config gating, widget bus, WDS composable

**Removed:**
- Container image build instructions
- Production password hash generation
- CI/CD workflow table
- Platform repository listing
- PR/git workflow instructions (not relevant for IDE agents)

refs #271