### PR TITLE
fix: drop Python upper bound — <3.13 blocked 3.14 runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Tom Pounders", email = "git@oldschool.engineer" },
 ]
 readme = "README.md"
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.12"
 license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
GHA bumped its Python runner to 3.14.4. The `<3.13` upper bound in `pyproject.toml` (set in #272) blocked it.

Dropped the upper bound entirely — no actual incompatibility with 3.14.