### PR TITLE
fix: pass migrate/fake_migrate settings to auth.define_tables()

### DIFF
--- a/apps/_default/settings.py
+++ b/apps/_default/settings.py
@@ -37,8 +37,8 @@ APP_NAME = os.path.split(APP_FOLDER)[-1]
 DB_FOLDER = required_folder(APP_FOLDER, "databases")
 DB_URI = PYDAL_URI
 DB_POOL_SIZE = 1
-DB_MIGRATE = True
-DB_FAKE_MIGRATE = False
+DB_MIGRATE = os.environ.get("DB_MIGRATE", "true").lower() == "true"
+DB_FAKE_MIGRATE = os.environ.get("DB_FAKE_MIGRATE", "false").lower() == "true"
 
 # location where static files are stored:
 STATIC_FOLDER = required_folder(APP_FOLDER, "static")


### PR DESCRIPTION
## Problem

`auth.define_tables()` was always called with pydal's default `migrate=True`, regardless of the `DB_MIGRATE` setting that controls the `DAL()` connection. With PostgreSQL + Docker, the `databases/` directory has no `.table` migration state files on container startup, so pydal assumes `auth_user` doesn't exist and tries `CREATE TABLE` — which throws `psycopg2.errors.DuplicateTable` if the table already exists.

## Fix

Pass `DB_MIGRATE` and `DB_FAKE_MIGRATE` from settings through to `auth.define_tables()`, consistent with how `DAL()` is configured on line 43.

To suppress DDL on startup against an existing PostgreSQL DB:
```
DB_MIGRATE=False
```