### PR TITLE
feat(pinia): migrate active ticker consumers to useDashboardStore

### DIFF
--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -75,7 +75,7 @@ import EnhancedQuoteV4 from './widgets/EnhancedQuoteV4.vue'
 import DailyRangeAlerts from './widgets/DailyRangeAlerts.vue'
 import CandlestickChart from './widgets/CandlestickChart.vue'
 import TVLiteChart     from './widgets/TVLiteChart.vue'
-import { LINK_COLORS, LINK_COLOR_MAP } from '@/composables/useWidgetBus.js'
+import { LINK_COLORS, LINK_COLOR_MAP } from '@/constants/linkColors.js'
 
 const props = defineProps({
   widgetId:   { type: String,  required: true },

--- a/client/src/components/widgets/CompanyNews.vue
+++ b/client/src/components/widgets/CompanyNews.vue
@@ -200,7 +200,7 @@
  * @emits update-settings    - Settings changed, payload: updated settings object
  */
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-import { useWidgetBus } from '@/composables/useWidgetBus.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useConfig }          from '@/composables/useConfig.js'
@@ -212,7 +212,7 @@ const props = defineProps({
 })
 const emit = defineEmits(['update-settings'])
 
-const { activeTickers, setActiveTicker } = useWidgetBus()
+const store = useDashboardStore()
 const { config: appConfig } = useConfig()
 const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
 
@@ -222,7 +222,7 @@ const inputTicker  = ref('')
 const manualTicker = ref('')
 
 const busTicker = computed(() =>
-  props.linkColor ? (activeTickers[props.linkColor] || null) : null
+  props.linkColor ? (store.activeTickers[props.linkColor] || null) : null
 )
 const activeTicker = computed(() => busTicker.value || manualTicker.value || null)
 
@@ -231,7 +231,7 @@ const applyInput = () => {
   if (!t) return
   manualTicker.value = t
   inputTicker.value  = ''
-  if (props.linkColor) setActiveTicker(props.linkColor, t)
+  if (props.linkColor) store.setActiveTicker(props.linkColor, t)
 }
 
 // When bus fires, clear manual override
@@ -376,7 +376,7 @@ const usCompanies = (item) => item.companies?.filter(isUsTicker) ?? []
 
 const switchTicker = (ticker) => {
   manualTicker.value = ticker
-  if (props.linkColor) setActiveTicker(props.linkColor, ticker)
+  if (props.linkColor) store.setActiveTicker(props.linkColor, ticker)
 }
 
 const shortSource = (src) => src ? src.replace(/^www\./, '').replace(/\.[^.]+$/, '') : ''

--- a/client/src/components/widgets/EnhancedQuoteV3.vue
+++ b/client/src/components/widgets/EnhancedQuoteV3.vue
@@ -577,7 +577,8 @@
 <script setup>
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import draggable from 'vuedraggable'
-import { useWidgetBus, getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useConfig } from '@/composables/useConfig.js'
 import EQV3CompanyCard from './EQV3CompanyCard.vue'
@@ -607,7 +608,7 @@ const props = defineProps({
 const emit = defineEmits(['update-settings'])
 
 const { config } = useConfig()
-const { activeTickers, setActiveTicker } = useWidgetBus()
+const store = useDashboardStore()
 
 // ── Layout mode ──
 const widgetEl = ref(null)
@@ -753,7 +754,7 @@ const quoteFlame = computed(() => {
 const inputTicker = ref('')
 
 const busTicker = computed(() =>
-  props.linkColor ? (activeTickers[props.linkColor] || null) : null
+  props.linkColor ? (store.activeTickers[props.linkColor] || null) : null
 )
 const manualTicker = ref('')
 const activeTicker = computed(() => busTicker.value || manualTicker.value || null)
@@ -764,7 +765,7 @@ const applyInput = () => {
   manualTicker.value = t
   inputTicker.value = ''
   if (props.linkColor) {
-    setActiveTicker(props.linkColor, t)
+    store.setActiveTicker(props.linkColor, t)
   }
 }
 

--- a/client/src/components/widgets/EnhancedQuoteV4.vue
+++ b/client/src/components/widgets/EnhancedQuoteV4.vue
@@ -133,7 +133,8 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { GridLayout, GridItem } from 'vue3-grid-layout-next'
-import { useWidgetBus, getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useConfig } from '@/composables/useConfig.js'
 import EQV4HeroCard    from './EQV4HeroCard.vue'
@@ -190,7 +191,7 @@ const emit = defineEmits(['update-settings'])
 const { config } = useConfig()
 
 // ── Widget bus ───────────────────────────────────────────────────────────────
-const { activeTickers, setActiveTicker } = useWidgetBus()
+const store = useDashboardStore()
 
 // ── Settings helpers ─────────────────────────────────────────────────────────
 const gridCols = computed(() => props.settings?.gridCols ?? 6)
@@ -367,7 +368,7 @@ const onGridRowHeightChange = (e) => {
 const inputTicker = ref('')
 const manualTicker = ref('')
 const busTicker = computed(() =>
-  props.linkColor ? (activeTickers[props.linkColor] || null) : null
+  props.linkColor ? (store.activeTickers[props.linkColor] || null) : null
 )
 const activeTicker = computed(() => busTicker.value || manualTicker.value || null)
 
@@ -377,7 +378,7 @@ const applyInput = () => {
   manualTicker.value = t
   inputTicker.value = ''
   if (props.linkColor) {
-    setActiveTicker(props.linkColor, t)
+    store.setActiveTicker(props.linkColor, t)
   }
 }
 

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -192,7 +192,8 @@
  * @emits update-col-widths   - Column widths changed, payload: { time, title, source, tickers }
  */
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-import { useWidgetBus, setNewsTimestamp } from '@/composables/useWidgetBus.js'
+import { setNewsTimestamp } from '@/composables/useWidgetBus.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useConfig }          from '@/composables/useConfig.js'
@@ -207,7 +208,7 @@ const props = defineProps({
 })
 const emit = defineEmits(['ticker-click', 'update-col-widths', 'update-settings'])
 
-const { setActiveTicker, activeTickers } = useWidgetBus()
+const store = useDashboardStore()
 
 // ── Ticker click mode ─────────────────────────────────────────────────────────
 const tickerClickMode = ref(props.settings.tickerClickMode ?? 'filter')
@@ -268,7 +269,7 @@ watch(hasTickersOnly, (val) => {
 // Receive ticker from bus when another linked widget broadcasts
 // Only update local filter in filter mode; in select mode, feed stays unchanged
 watch(
-  () => props.linkColor ? activeTickers[props.linkColor] : undefined,
+  () => props.linkColor ? store.activeTickers[props.linkColor] : undefined,
   (incoming) => {
     if (props.linkColor && incoming !== undefined && tickerClickMode.value === 'filter') {
       activeTicker.value = incoming
@@ -381,14 +382,14 @@ const toggleTickerFilter = (ticker) => {
     // Filter mode: toggle local feed filter AND broadcast
     const next = activeTicker.value === ticker ? null : ticker
     activeTicker.value = next
-    if (props.linkColor) setActiveTicker(props.linkColor, next)
+    if (props.linkColor) store.setActiveTicker(props.linkColor, next)
   } else {
     // Select mode: broadcast only — feed unchanged.
     // Use lastBroadcastTicker for toggle bookkeeping so double-clicking the
     // same ticker sends null and clears linked widgets (Option B).
     const next = lastBroadcastTicker.value === ticker ? null : ticker
     lastBroadcastTicker.value = next
-    if (props.linkColor) setActiveTicker(props.linkColor, next)
+    if (props.linkColor) store.setActiveTicker(props.linkColor, next)
   }
 }
 

--- a/client/src/components/widgets/Quote.vue
+++ b/client/src/components/widgets/Quote.vue
@@ -94,7 +94,8 @@
 
 <script setup>
 import { ref, computed, watch, onUnmounted } from 'vue'
-import { useWidgetBus, getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useConfig }          from '@/composables/useConfig.js'
 
@@ -108,7 +109,7 @@ const props = defineProps({
 defineEmits(['update-settings'])
 
 const { config: appConfig } = useConfig()
-const { activeTickers, setActiveTicker } = useWidgetBus()
+const store = useDashboardStore()
 
 // ── Flame freshness icon ──────────────────────────────────────────────────────
 const FLAME_SRCS = {
@@ -132,7 +133,7 @@ const inputTicker = ref('')
 // Active ticker: widget bus takes precedence when linked; manual entry otherwise
 // Widget bus updates reset manual input; manual entry overrides bus for that ticker
 const busTicker = computed(() =>
-  props.linkColor ? (activeTickers[props.linkColor] || null) : null
+  props.linkColor ? (store.activeTickers[props.linkColor] || null) : null
 )
 const manualTicker = ref('')
 const activeTicker = computed(() => busTicker.value || manualTicker.value || null)
@@ -144,7 +145,7 @@ const applyInput = () => {
   inputTicker.value = ''
   // Broadcast to widget bus so linked widgets (news feed, etc.) also update
   if (props.linkColor) {
-    setActiveTicker(props.linkColor, t)
+    store.setActiveTicker(props.linkColor, t)
   }
 }
 

--- a/client/src/components/widgets/__tests__/CompanyNews.spec.js
+++ b/client/src/components/widgets/__tests__/CompanyNews.spec.js
@@ -2,6 +2,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 
 // ── Mock useWebSocketClient ───────────────────────────────────────────────────
 vi.mock('@/composables/useWebSocketClient.js', async () => {
@@ -27,12 +28,7 @@ vi.mock('@/composables/useWebSocketClient.js', async () => {
 
 // ── Mock useWidgetBus ─────────────────────────────────────────────────────────
 vi.mock('@/composables/useWidgetBus.js', async () => {
-  const { reactive } = await import('vue')
   return {
-    useWidgetBus: vi.fn(() => ({
-      activeTickers:    reactive({}),
-      setActiveTicker:  vi.fn(),
-    })),
     setNewsTimestamp: vi.fn(),
   }
 })
@@ -251,19 +247,14 @@ describe('applyInput', () => {
 
   test('with input and linkColor expect setActiveTicker called', async () => {
     // Arrange
-    const { useWidgetBus: mockWidgetBus } = await import('@/composables/useWidgetBus.js')
-    const setActiveTickerMock = vi.fn()
-    vi.mocked(mockWidgetBus).mockReturnValue({
-      activeTickers: {},
-      setActiveTicker: setActiveTickerMock,
-    })
+    const store = useDashboardStore()
     const wrapper = mountCompanyNews({ linkColor: 'blue' })
     // Act
     await wrapper.find('.cn-input').setValue('AAPL')
     await wrapper.find('.cn-go-btn').trigger('click')
     await wrapper.vm.$nextTick()
     // Assert
-    expect(setActiveTickerMock).toHaveBeenCalledWith('blue', 'AAPL')
+    expect(store.activeTickers['blue']).toBe('AAPL')
     wrapper.unmount()
   })
 

--- a/client/src/components/widgets/__tests__/CompanyNewsCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/CompanyNewsCoverage.spec.js
@@ -19,8 +19,9 @@
  */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import { nextTick, ref, reactive } from 'vue'
+import { nextTick, ref } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 
 // ── Mocks (same setup as existing spec) ──────────────────────────────────────
 vi.mock('@/composables/useWebSocketClient.js', async () => {
@@ -44,12 +45,7 @@ vi.mock('@/composables/useWebSocketClient.js', async () => {
   }
 })
 
-const sharedActiveTickers = reactive({})
 vi.mock('@/composables/useWidgetBus.js', () => ({
-  useWidgetBus: vi.fn(() => ({
-    activeTickers:   sharedActiveTickers,
-    setActiveTicker: vi.fn(),
-  })),
   setNewsTimestamp: vi.fn(),
 }))
 
@@ -118,7 +114,6 @@ function mountCNWithBody(propsOverrides = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  Object.keys(sharedActiveTickers).forEach(k => delete sharedActiveTickers[k])
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -312,8 +307,9 @@ describe('watch(busTicker)', () => {
     expect(busMock.subscribe).toHaveBeenCalled()
     const subscribeCountAfterManual = busMock.subscribe.mock.calls.length
 
-    // Act — bus fires with a different ticker
-    sharedActiveTickers['blue'] = 'TSLA'
+    // Act — bus fires with a different ticker (via store)
+    const store = useDashboardStore()
+    store.setActiveTicker('blue', 'TSLA')
     await nextTick()
 
     // Assert — manualTicker cleared → activeTicker switches to TSLA → resubscribe
@@ -1353,10 +1349,11 @@ describe('busTicker watcher with null value', () => {
     await nextTick()
 
     // Act — set busTicker to a value then clear it (triggers watch with null)
-    sharedActiveTickers['blue'] = 'TSLA'
+    const store = useDashboardStore()
+    store.setActiveTicker('blue', 'TSLA')
     await nextTick()
     // Now clear → busTicker becomes null → if(t) FALSE path
-    delete sharedActiveTickers['blue']
+    store.setActiveTicker('blue', null)
     await nextTick()
 
     // Assert — manualTicker was cleared when bus fired (TRUE path)

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV3.spec.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
 
 // Stub ResizeObserver — jsdom does not implement it.
 global.ResizeObserver = class ResizeObserver {
@@ -157,6 +158,7 @@ function mockMassiveFetch({ ticker = MASSIVE_TICKER_RESPONSE, si = MASSIVE_SI_RE
 }
 
 beforeEach(() => {
+  setActivePinia(createPinia())
   vi.clearAllMocks()
   // Default: all Massive endpoints return empty results
   global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) })

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV3Coverage.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV3Coverage.spec.js
@@ -26,6 +26,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
 
 // ── Same global setup as existing spec ────────────────────────────────────────
 global.ResizeObserver = class ResizeObserver {
@@ -105,6 +106,7 @@ const SAMPLE_QUOTE = {
 }
 
 beforeEach(() => {
+  setActivePinia(createPinia())
   vi.clearAllMocks()
   global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) })
 })

--- a/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
+++ b/client/src/components/widgets/__tests__/EnhancedQuoteV4.spec.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
 import EQV4CardPicker from '../EQV4CardPicker.vue'
 
 // ── Global stubs ─────────────────────────────────────────────────────────────
@@ -76,6 +77,7 @@ function mockMassiveFetch() {
 }
 
 beforeEach(() => {
+  setActivePinia(createPinia())
   vi.clearAllMocks()
   global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) })
 })

--- a/client/src/components/widgets/__tests__/GenericScannerTable.spec.js
+++ b/client/src/components/widgets/__tests__/GenericScannerTable.spec.js
@@ -13,7 +13,6 @@ import { createPinia, setActivePinia } from 'pinia'
 vi.mock('@/composables/useWidgetBus.js', async () => {
   const { reactive } = await import('vue')
   return {
-    useWidgetBus:     vi.fn(() => ({ activeTickers: reactive({}), setActiveTicker: vi.fn() })),
     getFlameVariant:  vi.fn(() => null),
     getFlameTooltip:  vi.fn(() => ''),
     newsTimestamps:   reactive({}),

--- a/client/src/components/widgets/__tests__/GenericScannerTableCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/GenericScannerTableCoverage.spec.js
@@ -23,7 +23,6 @@ import { createPinia, setActivePinia } from 'pinia'
 vi.mock('@/composables/useWidgetBus.js', async () => {
   const { reactive } = await import('vue')
   return {
-    useWidgetBus:     vi.fn(() => ({ activeTickers: reactive({}), setActiveTicker: vi.fn() })),
     getFlameVariant:  vi.fn(() => null),
     getFlameTooltip:  vi.fn(() => ''),
     newsTimestamps:   reactive({}),

--- a/client/src/components/widgets/__tests__/NewsFeed.spec.js
+++ b/client/src/components/widgets/__tests__/NewsFeed.spec.js
@@ -2,6 +2,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 
 // ── Mock useWebSocketClient ───────────────────────────────────────────────────
 vi.mock('@/composables/useWebSocketClient.js', async () => {
@@ -33,13 +34,8 @@ vi.mock('@/composables/useConfig.js', async () => {
 
 // ── Mock useWidgetBus ─────────────────────────────────────────────────────────
 vi.mock('@/composables/useWidgetBus.js', async () => {
-  const { reactive, ref } = await import('vue')
-  const activeTickers = reactive({})
   return {
-    useWidgetBus:       vi.fn(() => ({ setActiveTicker: vi.fn(), activeTickers })),
     setNewsTimestamp:   vi.fn(),
-    activeTickers,
-    setActiveTicker:    vi.fn(),
   }
 })
 
@@ -53,7 +49,7 @@ vi.mock('vue-virtual-scroller', () => ({
 }))
 
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
-import { useWidgetBus, setActiveTicker, activeTickers } from '@/composables/useWidgetBus.js'
+
 import { useConfig } from '@/composables/useConfig.js'
 import NewsFeed from '../NewsFeed.vue'
 
@@ -64,10 +60,7 @@ const triggerData = (data) => {
   lastCall[0].onData(data)
 }
 
-// Reset shared activeTickers reactive object between tests to prevent state leakage
-beforeEach(() => {
-  Object.keys(activeTickers).forEach(k => delete activeTickers[k])
-})
+
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const defaultProps = {
@@ -209,10 +202,7 @@ describe('Filter mode — ticker tag click', () => {
   })
 
   test('filter mode: ticker tag click broadcasts via setActiveTicker', async () => {
-    const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
-    const mockSet = vi.fn()
-    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
-
+    const store = useDashboardStore()
     const wrapper = mountFeed({ linkColor: 'blue' })
     triggerData([makeArticle()])
     await nextTick()
@@ -220,7 +210,7 @@ describe('Filter mode — ticker tag click', () => {
     await wrapper.findAll('.ticker-tag')[0].trigger('click')
     await nextTick()
 
-    expect(mockSet).toHaveBeenCalledWith('blue', 'AAPL')
+    expect(store.activeTickers['blue']).toBe('AAPL')
   })
 })
 
@@ -228,10 +218,7 @@ describe('Filter mode — ticker tag click', () => {
 
 describe('Select mode — ticker tag click', () => {
   test('clicking a ticker tag broadcasts to linked widgets', async () => {
-    const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
-    const mockSet = vi.fn()
-    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
-
+    const store = useDashboardStore()
     const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
     triggerData([makeArticle()])
     await nextTick()
@@ -239,7 +226,7 @@ describe('Select mode — ticker tag click', () => {
     await wrapper.findAll('.ticker-tag')[0].trigger('click')
     await nextTick()
 
-    expect(mockSet).toHaveBeenCalledWith('blue', 'AAPL')
+    expect(store.activeTickers['blue']).toBe('AAPL')
   })
 
   test('select mode: ticker tag click does not set active-ticker-pill', async () => {
@@ -268,10 +255,7 @@ describe('Select mode — ticker tag click', () => {
   })
 
   test('select mode: clicking same ticker twice broadcasts null to clear linked widgets', async () => {
-    const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
-    const mockSet = vi.fn()
-    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
-
+    const store = useDashboardStore()
     const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
     triggerData([makeArticle()])
     await nextTick()
@@ -281,14 +265,11 @@ describe('Select mode — ticker tag click', () => {
     await tag.trigger('click')  // second click → broadcasts null (deselect)
     await nextTick()
 
-    expect(mockSet).toHaveBeenLastCalledWith('blue', null)
+    expect(store.activeTickers['blue']).toBeNull()
   })
 
   test('select mode: no linkColor — ticker tag click has no observable effect', async () => {
-    const { useWidgetBus: busMock } = await import('@/composables/useWidgetBus.js')
-    const mockSet = vi.fn()
-    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: mockSet, activeTickers: {} })
-
+    const store = useDashboardStore()
     const wrapper = mountFeed({ linkColor: null, settings: { tickerClickMode: 'select' } })
     triggerData([makeArticle()])
     await nextTick()
@@ -297,7 +278,8 @@ describe('Select mode — ticker tag click', () => {
     await nextTick()
 
     expect(wrapper.find('.active-ticker-pill').exists()).toBe(false)
-    expect(mockSet).not.toHaveBeenCalled()
+    // No color → store not updated
+    expect(Object.values(store.activeTickers).every(v => v === null)).toBe(true)
   })
 })
 
@@ -305,28 +287,24 @@ describe('Select mode — ticker tag click', () => {
 
 describe('Bus sync', () => {
   test('filter mode: external activeTicker change shows active-ticker-pill', async () => {
-    const { useWidgetBus: busMock, activeTickers } = await import('@/composables/useWidgetBus.js')
-    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: vi.fn(), activeTickers })
-
+    const store = useDashboardStore()
     const wrapper = mountFeed({ linkColor: 'blue' })
     triggerData([makeArticle()])
     await nextTick()
 
-    activeTickers['blue'] = 'AAPL'
+    store.setActiveTicker('blue', 'AAPL')
     await nextTick()
 
     expect(wrapper.find('.active-ticker-pill').exists()).toBe(true)
   })
 
   test('select mode: external activeTicker change does not show active-ticker-pill', async () => {
-    const { useWidgetBus: busMock, activeTickers } = await import('@/composables/useWidgetBus.js')
-    vi.mocked(busMock).mockReturnValueOnce({ setActiveTicker: vi.fn(), activeTickers })
-
+    const store = useDashboardStore()
     const wrapper = mountFeed({ linkColor: 'blue', settings: { tickerClickMode: 'select' } })
     triggerData([makeArticle()])
     await nextTick()
 
-    activeTickers['blue'] = 'AAPL'
+    store.setActiveTicker('blue', 'AAPL')
     await nextTick()
 
     expect(wrapper.find('.active-ticker-pill').exists()).toBe(false)

--- a/client/src/components/widgets/__tests__/NewsFeedCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/NewsFeedCoverage.spec.js
@@ -48,13 +48,8 @@ vi.mock('@/composables/useConfig.js', async () => {
 })
 
 vi.mock('@/composables/useWidgetBus.js', async () => {
-  const { reactive } = await import('vue')
-  const activeTickers = reactive({})
   return {
-    useWidgetBus:     vi.fn(() => ({ setActiveTicker: vi.fn(), activeTickers })),
     setNewsTimestamp: vi.fn(),
-    activeTickers,
-    setActiveTicker:  vi.fn(),
   }
 })
 
@@ -67,7 +62,7 @@ vi.mock('vue-virtual-scroller', () => ({
 }))
 
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
-import { setNewsTimestamp, activeTickers } from '@/composables/useWidgetBus.js'
+import { setNewsTimestamp } from '@/composables/useWidgetBus.js'
 import NewsFeed from '../NewsFeed.vue'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -123,7 +118,6 @@ function triggerData(data) {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  Object.keys(activeTickers).forEach(k => delete activeTickers[k])
   localStorage.clear()
 })
 

--- a/client/src/components/widgets/__tests__/Quote.spec.js
+++ b/client/src/components/widgets/__tests__/Quote.spec.js
@@ -2,6 +2,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 
 // ── Mock useWebSocketClient ───────────────────────────────────────────────────
 vi.mock('@/composables/useWebSocketClient.js', async () => {
@@ -29,7 +30,6 @@ vi.mock('@/composables/useWebSocketClient.js', async () => {
 vi.mock('@/composables/useWidgetBus.js', async () => {
   const { reactive } = await import('vue')
   return {
-    useWidgetBus:    vi.fn(() => ({ activeTickers: reactive({}), setActiveTicker: vi.fn() })),
     getFlameVariant: vi.fn(() => null),
     getFlameTooltip: vi.fn(() => ''),
     newsTimestamps:  reactive({}),
@@ -206,12 +206,7 @@ describe('applyInput', () => {
 
   test('with linkColor and input expect setActiveTicker called', async () => {
     // Arrange
-    const { useWidgetBus: mockWidgetBus } = await import('@/composables/useWidgetBus.js')
-    const setActiveTickerMock = vi.fn()
-    vi.mocked(mockWidgetBus).mockReturnValue({
-      activeTickers: {},
-      setActiveTicker: setActiveTickerMock,
-    })
+    const store = useDashboardStore()
     const wrapper = mount(Quote, { props: { ...defaultProps, linkColor: 'red' } })
 
     // Act
@@ -220,7 +215,7 @@ describe('applyInput', () => {
     await wrapper.vm.$nextTick()
 
     // Assert
-    expect(setActiveTickerMock).toHaveBeenCalledWith('red', 'SPY')
+    expect(store.activeTickers['red']).toBe('SPY')
     wrapper.unmount()
   })
 

--- a/client/src/components/widgets/__tests__/QuoteCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/QuoteCoverage.spec.js
@@ -43,7 +43,6 @@ vi.mock('@/composables/useWebSocketClient.js', async () => {
 vi.mock('@/composables/useWidgetBus.js', async () => {
   const { reactive } = await import('vue')
   return {
-    useWidgetBus:    vi.fn(() => ({ activeTickers: reactive({}), setActiveTicker: vi.fn() })),
     getFlameVariant: vi.fn(() => null),
     getFlameTooltip: vi.fn(() => ''),
     newsTimestamps:  reactive({}),
@@ -63,6 +62,7 @@ vi.mock('@/composables/useConfig.js', async () => {
 
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { getFlameVariant, getFlameTooltip } from '@/composables/useWidgetBus.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import Quote from '../Quote.vue'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -409,9 +409,6 @@ describe('activeTicker watch: not connected path', () => {
 describe('busTicker watcher fires with non-null ticker', () => {
   test('with linkColor set and bus ticker set expect manualTicker cleared', async () => {
     // Arrange — mount with linkColor so bus ticker tracking works
-    const { useWidgetBus } = await import('@/composables/useWidgetBus.js')
-    const { setActiveTicker } = vi.mocked(useWidgetBus).mock.results[0]?.value || useWidgetBus()
-    
     const wrapper = mountQuote({ linkColor: 'blue', settings: {} })
     await nextTick()
     
@@ -515,16 +512,8 @@ describe('isConnected watcher with no current feed', () => {
 
 describe('busTicker watcher clears manualTicker', () => {
   test('with busTicker becoming truthy expect manualTicker cleared (TRUE branch)', async () => {
-    // Arrange — capture activeTickers reactive object
-    const { reactive: rv } = await import('vue')
-    let capturedTickers = null
-    const { useWidgetBus } = await import('@/composables/useWidgetBus.js')
-    vi.mocked(useWidgetBus).mockImplementationOnce(() => {
-      capturedTickers = rv({})
-      return { activeTickers: capturedTickers, setActiveTicker: vi.fn() }
-    })
+    // Arrange — use store to simulate bus ticker change
     vi.mocked(useWebSocketClient).mockReturnValueOnce(makeWsMock())
-
     const wrapper = mountQuote({ linkColor: 'red' })
     await nextTick()
 
@@ -533,12 +522,11 @@ describe('busTicker watcher clears manualTicker', () => {
     await wrapper.find('.quote-go-btn').trigger('click')
     await nextTick()
 
-    // Act — bus fires for 'red' color with ticker 'AAPL' → busTicker = 'AAPL'
-    if (capturedTickers) {
-      capturedTickers['red'] = 'AAPL'  // triggers busTicker watcher with t='AAPL'
-      await nextTick()
-      await nextTick()
-    }
+    // Act — store fires for 'red' color with ticker 'AAPL' → busTicker = 'AAPL'
+    const store = useDashboardStore()
+    store.setActiveTicker('red', 'AAPL')  // triggers busTicker watcher with t='AAPL'
+    await nextTick()
+    await nextTick()
 
     // Assert — TRUE path: manualTicker cleared when bus fires
     expect(wrapper.exists()).toBe(true)
@@ -547,24 +535,17 @@ describe('busTicker watcher clears manualTicker', () => {
 
   test('with busTicker becoming null expect watcher fires FALSE branch (no clear)', async () => {
     // Arrange — bus fires with null (busTicker null → t=null → if(t) = false)
-    const { reactive: rv } = await import('vue')
-    let capturedTickers = null
-    const { useWidgetBus } = await import('@/composables/useWidgetBus.js')
-    vi.mocked(useWidgetBus).mockImplementationOnce(() => {
-      capturedTickers = rv({ red: 'AAPL' })  // start with AAPL
-      return { activeTickers: capturedTickers, setActiveTicker: vi.fn() }
-    })
     vi.mocked(useWebSocketClient).mockReturnValueOnce(makeWsMock())
+    const store = useDashboardStore()
+    store.setActiveTicker('red', 'AAPL')  // start with AAPL
 
     const wrapper = mountQuote({ linkColor: 'red' })
     await nextTick()
 
     // Act — clear the bus ticker → busTicker = null → watcher fires with t=null
-    if (capturedTickers) {
-      capturedTickers['red'] = null  // busTicker becomes null → FALSE path
-      await nextTick()
-      await nextTick()
-    }
+    store.setActiveTicker('red', null)  // busTicker becomes null → FALSE path
+    await nextTick()
+    await nextTick()
 
     // Assert — FALSE path executed without crash
     expect(wrapper.exists()).toBe(true)

--- a/client/src/components/widgets/__tests__/TVLiteChartCoverage2.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChartCoverage2.spec.js
@@ -67,7 +67,6 @@ vi.mock('@/composables/useWebSocketClient.js', async () => {
 })
 
 vi.mock('@/composables/useWidgetBus.js', () => ({
-  useWidgetBus: vi.fn(() => ({ activeTickers: {}, setActiveTicker: vi.fn() })),
 }))
 
 vi.mock('@/utils/chartIndicators.js', async () => {

--- a/client/src/components/widgets/__tests__/TopGainersCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/TopGainersCoverage.spec.js
@@ -20,7 +20,7 @@ vi.mock('@/composables/useScannerLink.js', async () => {
 })
 vi.mock('@/composables/useWidgetBus.js', async () => {
   const { reactive } = await import('vue')
-  return { useWidgetBus: vi.fn(() => ({ activeTickers: reactive({}), setActiveTicker: vi.fn() })), getFlameVariant: vi.fn(() => null), getFlameTooltip: vi.fn(() => ''), newsTimestamps: reactive({}) }
+  return { getFlameVariant: vi.fn(() => null), getFlameTooltip: vi.fn(() => ''), newsTimestamps: reactive({}) }
 })
 vi.mock('@/composables/useConfig.js', async () => {
   const { ref } = await import('vue')

--- a/client/src/components/widgets/__tests__/TopGappersCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/TopGappersCoverage.spec.js
@@ -46,7 +46,6 @@ vi.mock('@/composables/useScannerLink.js', async () => {
 vi.mock('@/composables/useWidgetBus.js', async () => {
   const { reactive } = await import('vue')
   return {
-    useWidgetBus: vi.fn(() => ({ activeTickers: reactive({}), setActiveTicker: vi.fn() })),
     getFlameVariant: vi.fn(() => null),
     getFlameTooltip: vi.fn(() => ''),
     newsTimestamps: reactive({}),

--- a/client/src/components/widgets/__tests__/TopVolumeCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/TopVolumeCoverage.spec.js
@@ -37,7 +37,6 @@ vi.mock('@/composables/useScannerLink.js', async () => {
 vi.mock('@/composables/useWidgetBus.js', async () => {
   const { reactive } = await import('vue')
   return {
-    useWidgetBus: vi.fn(() => ({ activeTickers: reactive({}), setActiveTicker: vi.fn() })),
     getFlameVariant: vi.fn(() => null),
     getFlameTooltip: vi.fn(() => ''),
     newsTimestamps: reactive({}),

--- a/client/src/composables/__tests__/useScannerLink.spec.js
+++ b/client/src/composables/__tests__/useScannerLink.spec.js
@@ -1,100 +1,95 @@
 /**
  * Tests for useScannerLink composable.
  *
- * useScannerLink wraps useWidgetBus — test via onRowClick and verify
- * activeTickers state. Reset bus between tests via clearActiveTicker.
+ * useScannerLink wraps useDashboardStore — test via onRowClick and verify
+ * store state. Reset store between tests via createPinia().
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ref } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
 import { useScannerLink } from '../useScannerLink.js'
-import { useWidgetBus, LINK_COLORS } from '../useWidgetBus.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
+import { LINK_COLORS } from '@/constants/linkColors.js'
 
-function resetBus() {
-  const { clearActiveTicker } = useWidgetBus()
-  LINK_COLORS.forEach(c => clearActiveTicker(c.name))
-}
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
 
 describe('useScannerLink', () => {
-  beforeEach(() => {
-    resetBus()
-  })
-
   // ------------------------------------------------------------------
   // onRowClick
   // ------------------------------------------------------------------
 
-  it('test_useScannerLink_with_color_and_ticker_expect_bus_updated', () => {
+  it('test_useScannerLink_with_color_and_ticker_expect_store_updated', () => {
     const linkColor = ref('blue')
     const { onRowClick } = useScannerLink(linkColor)
-    const { activeTickers } = useWidgetBus()
+    const store = useDashboardStore()
 
     onRowClick({ symbol: 'AAPL' })
 
-    expect(activeTickers['blue']).toBe('AAPL')
+    expect(store.activeTickers['blue']).toBe('AAPL')
   })
 
-  it('test_useScannerLink_with_no_color_expect_no_bus_update', () => {
+  it('test_useScannerLink_with_no_color_expect_no_store_update', () => {
     const linkColor = ref(null)
     const { onRowClick } = useScannerLink(linkColor)
-    const { activeTickers } = useWidgetBus()
+    const store = useDashboardStore()
 
     onRowClick({ symbol: 'AAPL' })
 
     LINK_COLORS.forEach(({ name }) => {
-      expect(activeTickers[name]).toBeNull()
+      expect(store.activeTickers[name]).toBeNull()
     })
   })
 
-  it('test_useScannerLink_with_ticker_field_expect_bus_updated', () => {
-    // Some rows use 'ticker' instead of 'symbol'
+  it('test_useScannerLink_with_ticker_field_expect_store_updated', () => {
     const linkColor = ref('red')
     const { onRowClick } = useScannerLink(linkColor)
-    const { activeTickers } = useWidgetBus()
+    const store = useDashboardStore()
 
     onRowClick({ ticker: 'MSFT' })
 
-    expect(activeTickers['red']).toBe('MSFT')
+    expect(store.activeTickers['red']).toBe('MSFT')
   })
 
-  it('test_useScannerLink_with_no_symbol_or_ticker_expect_no_bus_update', () => {
+  it('test_useScannerLink_with_no_symbol_or_ticker_expect_no_store_update', () => {
     const linkColor = ref('green')
     const { onRowClick } = useScannerLink(linkColor)
-    const { activeTickers } = useWidgetBus()
+    const store = useDashboardStore()
 
     onRowClick({})
 
-    expect(activeTickers['green']).toBeNull()
+    expect(store.activeTickers['green']).toBeNull()
   })
 
   it('test_useScannerLink_clicking_active_ticker_again_expect_clears', () => {
-    // Toggle behavior: clicking the same ticker clears it
     const linkColor = ref('orange')
     const { onRowClick } = useScannerLink(linkColor)
-    const { activeTickers } = useWidgetBus()
+    const store = useDashboardStore()
 
     onRowClick({ symbol: 'NVDA' })
-    expect(activeTickers['orange']).toBe('NVDA')
+    expect(store.activeTickers['orange']).toBe('NVDA')
 
     onRowClick({ symbol: 'NVDA' })
-    expect(activeTickers['orange']).toBeNull()
+    expect(store.activeTickers['orange']).toBeNull()
   })
 
   it('test_useScannerLink_clicking_different_ticker_expect_updates', () => {
     const linkColor = ref('cyan')
     const { onRowClick } = useScannerLink(linkColor)
-    const { activeTickers } = useWidgetBus()
+    const store = useDashboardStore()
 
     onRowClick({ symbol: 'AMD' })
     onRowClick({ symbol: 'NVDA' })
 
-    expect(activeTickers['cyan']).toBe('NVDA')
+    expect(store.activeTickers['cyan']).toBe('NVDA')
   })
 
   // ------------------------------------------------------------------
   // activeTicker computed
   // ------------------------------------------------------------------
 
-  it('test_useScannerLink_activeTicker_reflects_bus_state', () => {
+  it('test_useScannerLink_activeTicker_reflects_store_state', () => {
     const linkColor = ref('violet')
     const { activeTicker, onRowClick } = useScannerLink(linkColor)
 
@@ -118,7 +113,6 @@ describe('useScannerLink', () => {
     onRowClick({ symbol: 'QQQ' })
     expect(activeTicker.value).toBe('QQQ')
 
-    // Switch to a color with no active ticker
     linkColor.value = 'white'
     expect(activeTicker.value).toBeNull()
   })

--- a/client/src/composables/__tests__/useWidgetBus.spec.js
+++ b/client/src/composables/__tests__/useWidgetBus.spec.js
@@ -281,7 +281,6 @@ describe('getFlameTooltip', () => {
 describe('getFlameVariant: dark fallback when very old', () => {
   test('with very old news timestamp expect dark variant', () => {
     // Arrange — set a very old timestamp (days ago, exceeds all thresholds)
-    const { setNewsTimestamp, getFlameVariant } = require('../useWidgetBus.js')
     // Set timestamp to 1 week ago (well beyond any threshold)
     setNewsTimestamp('OLD', Date.now() - 7 * 24 * 3600_000)
 

--- a/client/src/composables/useScannerLink.js
+++ b/client/src/composables/useScannerLink.js
@@ -8,14 +8,14 @@
  * @param {import('vue').Ref<string|null>} linkColorRef  - reactive linkColor prop
  */
 import { computed } from 'vue'
-import { useWidgetBus } from './useWidgetBus.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 
 export function useScannerLink(linkColorRef) {
-  const { setActiveTicker, activeTickers } = useWidgetBus()
+  const store = useDashboardStore()
 
   const activeTicker = computed(() => {
     const color = linkColorRef.value
-    return color ? activeTickers[color] : null
+    return color ? store.activeTickers[color] : null
   })
 
   const onRowClick = (row) => {
@@ -24,8 +24,8 @@ export function useScannerLink(linkColorRef) {
     const symbol = row.symbol || row.ticker || null
     if (!symbol) return
     // Toggle: clicking the active ticker clears it
-    const current = activeTickers[color]
-    setActiveTicker(color, current === symbol ? null : symbol)
+    const current = store.activeTickers[color]
+    store.setActiveTicker(color, current === symbol ? null : symbol)
   }
 
   return { activeTicker, onRowClick }

--- a/client/src/composables/useWidgetBus.js
+++ b/client/src/composables/useWidgetBus.js
@@ -13,20 +13,9 @@
  */
 import { reactive } from 'vue'
 
-// 9-color palette — high contrast, distinct at a glance
-export const LINK_COLORS = [
-  { name: 'red',    hex: '#ef4444' },
-  { name: 'orange', hex: '#f97316' },
-  { name: 'yellow', hex: '#eab308' },
-  { name: 'green',  hex: '#22c55e' },
-  { name: 'blue',   hex: '#3b82f6' },
-  { name: 'violet', hex: '#8b5cf6' },
-  { name: 'pink',   hex: '#ec4899' },
-  { name: 'cyan',   hex: '#06b6d4' },
-  { name: 'white',  hex: '#e5e7eb' },
-]
-
-export const LINK_COLOR_MAP = Object.fromEntries(LINK_COLORS.map(c => [c.name, c.hex]))
+// Re-exported from shared constants for backwards compatibility
+import { LINK_COLORS, LINK_COLOR_MAP } from '@/constants/linkColors.js'
+export { LINK_COLORS, LINK_COLOR_MAP }
 
 // ── News freshness state ─────────────────────────────────────────────────────
 // Map of ticker → timestamp (ms) of most recent article mentioning that ticker.

--- a/client/src/constants/linkColors.js
+++ b/client/src/constants/linkColors.js
@@ -1,0 +1,20 @@
+/**
+ * linkColors — shared color palette for widget bus link groups.
+ *
+ * Extracted from useWidgetBus so both useWidgetBus and useDashboardStore
+ * can import from a single source of truth.
+ */
+
+export const LINK_COLORS = [
+  { name: 'red',    hex: '#ef4444' },
+  { name: 'orange', hex: '#f97316' },
+  { name: 'yellow', hex: '#eab308' },
+  { name: 'green',  hex: '#22c55e' },
+  { name: 'blue',   hex: '#3b82f6' },
+  { name: 'violet', hex: '#8b5cf6' },
+  { name: 'pink',   hex: '#ec4899' },
+  { name: 'cyan',   hex: '#06b6d4' },
+  { name: 'white',  hex: '#e5e7eb' },
+]
+
+export const LINK_COLOR_MAP = Object.fromEntries(LINK_COLORS.map(c => [c.name, c.hex]))

--- a/client/src/stores/useDashboardStore.js
+++ b/client/src/stores/useDashboardStore.js
@@ -6,7 +6,7 @@
  */
 import { defineStore } from 'pinia'
 import { reactive, ref } from 'vue'
-import { LINK_COLORS } from '@/composables/useWidgetBus.js'
+import { LINK_COLORS } from '@/constants/linkColors.js'
 
 export const useDashboardStore = defineStore('dashboard', () => {
   // Active ticker per link color — null means no ticker selected for that color


### PR DESCRIPTION
## Summary

Migrates active ticker state from `useWidgetBus` to `useDashboardStore` across the widget layer.

### Constants extraction
- New `src/constants/linkColors.js` — single source of truth for `LINK_COLORS`/`LINK_COLOR_MAP`
- `useWidgetBus.js` re-exports from constants for backwards compatibility

### Store migration
- `useScannerLink.js` → `useDashboardStore` instead of `useWidgetBus`
- `Quote.vue`, `EnhancedQuoteV3.vue`, `EnhancedQuoteV4.vue`, `CompanyNews.vue`, `NewsFeed.vue` → `store.activeTickers[color]` / `store.setActiveTicker()`
- `WidgetWrapper.vue` → imports `LINK_COLORS`/`LINK_COLOR_MAP` from constants

### Tests
- `useScannerLink.spec.js` rewritten to assert against Pinia store state
- 13 test files updated: removed `useWidgetBus: vi.fn(...)` mock entries, replaced `setActiveTickerMock` assertions with store state assertions
- All 1438 tests pass

refs #281