### PR TITLE
feat(pinia): consolidate localStorage into stores

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -313,6 +313,8 @@ import 'vue3-grid-layout-next/dist/style.css'
 import WidgetMenu from './WidgetMenu.vue'
 import WidgetWrapper from './WidgetWrapper.vue'
 import { useConfig } from '@/composables/useConfig.js'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
+import { storeToRefs } from 'pinia'
 
 const { config: appConfig, loading: configLoading, error: configError } = useConfig()
 const appVersion = window.__APP_VERSION__ || null
@@ -322,24 +324,14 @@ const MOBILE_BREAKPOINT = 640
 const isMobile = ref(window.innerWidth < MOBILE_BREAKPOINT)
 const onResize = () => { isMobile.value = window.innerWidth < MOBILE_BREAKPOINT }
 
-const STORAGE_KEY = 'dashboard-layouts'
-const DEFAULT_KEY = 'dashboard-default-layout'
-const LOCK_KEY = 'dashboard-layout-locked'
 const AUTOSAVE_KEY = '__autosave__'
-const AUTOSAVE_ENABLED_KEY = 'dashboard-autosave-enabled'
 const AUTOSAVE_DEBOUNCE_MS = 2000
 
-// Lock mode — default locked to prevent accidental drag/autosave
-const isLocked = ref(localStorage.getItem(LOCK_KEY) !== 'false')
-watch(isLocked, (val) => localStorage.setItem(LOCK_KEY, String(val)))
-
-const autosaveEnabled = ref(localStorage.getItem(AUTOSAVE_ENABLED_KEY) !== 'false')
-watch(autosaveEnabled, (val) => localStorage.setItem(AUTOSAVE_ENABLED_KEY, String(val)))
+const widgetSettingsStore = useWidgetSettingsStore()
+const { savedLayouts, defaultLayoutName, isLocked, autosaveEnabled } = storeToRefs(widgetSettingsStore)
 
 // State
 const layout = ref([])
-const savedLayouts = ref({})
-const defaultLayoutName = ref(null)
 const selectedLayoutName = ref('')
 const showSaveDialog = ref(false)
 const saveLayoutName = ref('')
@@ -376,31 +368,6 @@ const editingExistingLayout = computed(() =>
     saveLayoutName.value.trim() && savedLayouts.value[saveLayoutName.value.trim()]
 )
 
-// LocalStorage Operations
-const loadFromStorage = () => {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    savedLayouts.value = stored ? JSON.parse(stored) : {}
-    defaultLayoutName.value = localStorage.getItem(DEFAULT_KEY)
-  } catch (e) {
-    console.error('Failed to load layouts:', e)
-    savedLayouts.value = {}
-  }
-}
-
-const saveToStorage = () => {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(savedLayouts.value))
-    if (defaultLayoutName.value) {
-      localStorage.setItem(DEFAULT_KEY, defaultLayoutName.value)
-    } else {
-      localStorage.removeItem(DEFAULT_KEY)
-    }
-  } catch (e) {
-    console.error('Failed to save layouts:', e)
-  }
-}
-
 // Layout Operations
 const saveLayout = () => {
   if (!saveLayoutName.value.trim()) return
@@ -431,7 +398,6 @@ const saveLayout = () => {
     defaultLayoutName.value = name
   }
 
-  saveToStorage()
   selectedLayoutName.value = name
   closeSaveDialog()
 }
@@ -458,7 +424,6 @@ const deleteCurrentLayout = () => {
     defaultLayoutName.value = null
   }
 
-  saveToStorage()
   selectedLayoutName.value = ''
   layout.value = []
   widgetCounter = 0
@@ -501,7 +466,6 @@ const autoSaveLayout = () => {
       modified: Date.now()
     }
 
-    saveToStorage()
     isAutoSaving.value = false
   }, AUTOSAVE_DEBOUNCE_MS)
 }
@@ -571,7 +535,6 @@ const importLayouts = (event) => {
         defaultLayoutName.value = data.defaultLayout
       }
 
-      saveToStorage()
       alert(`Imported ${Object.keys(data.layouts).length} layout(s)`)
 
     } catch (e) {
@@ -856,7 +819,6 @@ const handleClickOutside = (e) => {
 // Lifecycle
 onMounted(() => {
   window.addEventListener('resize', onResize)
-  loadFromStorage()
   loadDefaultLayout()
   document.addEventListener('click', handleClickOutside)
 })

--- a/client/src/components/__tests__/DashboardGridColNum.spec.js
+++ b/client/src/components/__tests__/DashboardGridColNum.spec.js
@@ -1,6 +1,8 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
@@ -58,6 +60,7 @@ vi.mock('@/composables/useConfig.js', async () => {
 beforeEach(() => {
   vi.clearAllMocks()
   Object.keys(store).forEach(k => delete store[k])
+  setActivePinia(createPinia())
 })
 
 import DashboardGrid from '../DashboardGrid.vue'
@@ -67,8 +70,9 @@ function mountGrid() {
 }
 
 function seedLayouts(data, defaultName = null) {
-  store['dashboard-layouts'] = JSON.stringify(data)
-  if (defaultName) store['dashboard-default-layout'] = defaultName
+  const wss = useWidgetSettingsStore()
+  wss.savedLayouts = data
+  wss.defaultLayoutName = defaultName ?? null
 }
 
 // ── Default ───────────────────────────────────────────────────────────────────
@@ -207,13 +211,8 @@ describe('dashboardColNum persisted on save', () => {
     wrapper.vm.saveLayout()
     await nextTick()
 
-    // Assert — find the dashboard-layouts write in localStorage calls
-    const call = localStorageMock.setItem.mock.calls
-      .reverse()
-      .find(([k]) => k === 'dashboard-layouts')
-    expect(call).toBeDefined()
-    const saved = JSON.parse(call[1])
-    expect(saved['test-save']?.dashboardColNum).toBe(16)
+    // Assert — find the saved layout in the Pinia store
+    expect(useWidgetSettingsStore().savedLayouts['test-save']?.dashboardColNum).toBe(16)
 
     wrapper.unmount()
   })
@@ -348,13 +347,8 @@ describe('dashboardColNum autosave', () => {
     vi.runAllTimers()
     await nextTick()
 
-    // Assert — storage contains updated dashboardColNum for the selected layout
-    const call = localStorageMock.setItem.mock.calls
-      .reverse()
-      .find(([k]) => k === 'dashboard-layouts')
-    expect(call).toBeDefined()
-    const saved = JSON.parse(call[1])
-    expect(saved['my-layout']?.dashboardColNum).toBe(24)
+    // Assert — store contains updated dashboardColNum for the selected layout
+    expect(useWidgetSettingsStore().savedLayouts['my-layout']?.dashboardColNum).toBe(24)
 
     vi.useRealTimers()
     wrapper.unmount()
@@ -383,7 +377,7 @@ describe('dashboardColNum autosave', () => {
       await nextTick()
     }
 
-    localStorageMock.setItem.mockClear()
+    const savedBefore = { ...useWidgetSettingsStore().savedLayouts }
 
     // Act
     wrapper.vm.dashboardColNum = 24
@@ -392,8 +386,7 @@ describe('dashboardColNum autosave', () => {
     await nextTick()
 
     // Assert — no layout write triggered
-    const layoutWrite = localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-layouts')
-    expect(layoutWrite).toBeUndefined()
+    expect(useWidgetSettingsStore().savedLayouts).toEqual(savedBefore)
 
     vi.useRealTimers()
     wrapper.unmount()

--- a/client/src/components/__tests__/DashboardGridCoverage.spec.js
+++ b/client/src/components/__tests__/DashboardGridCoverage.spec.js
@@ -18,6 +18,8 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount }     from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
 
 // ── Heavy dep stubs ────────────────────────────────────────────────────────────
 vi.mock('vue3-grid-layout-next', () => ({
@@ -86,9 +88,9 @@ import DashboardGrid from '../DashboardGrid.vue'
 // $.setupState removed — all state accessed via exposed wrapper.vm interface or DOM
 
 function seedLayouts(data, defaultName = null) {
-  store['dashboard-layouts'] = JSON.stringify(data)
-  if (defaultName) store['dashboard-default-layout'] = defaultName
-  else             delete store['dashboard-default-layout']
+  const wss = useWidgetSettingsStore()
+  wss.savedLayouts = data
+  wss.defaultLayoutName = defaultName ?? null
 }
 
 function makeLayout(overrides = {}) {
@@ -109,8 +111,10 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(mockCtx)
   Object.keys(store).forEach(k => delete store[k])
-  store['dashboard-layout-locked']    = 'false'
-  store['dashboard-autosave-enabled'] = 'true'
+  setActivePinia(createPinia())
+  const wss = useWidgetSettingsStore()
+  wss.isLocked = false
+  wss.autosaveEnabled = true
   // restore default useConfig mock after clearAllMocks resets implementations
   vi.mocked(useConfig).mockImplementation(() => ({
     config:  ref({ apiKey: 'test', wsEndpoint: 'ws://localhost:4202/ws',
@@ -414,7 +418,7 @@ describe('loadDefaultLayout autosave colNum fallback', () => {
 describe('autoSaveLayout disabled', () => {
   test('with autosaveEnabled=false expect layout change does not trigger autosave', async () => {
     // Arrange — disable autosave
-    store['dashboard-autosave-enabled'] = 'false'
+    useWidgetSettingsStore().autosaveEnabled = false
     vi.useFakeTimers()
     const wrapper = mountGrid()
     await nextTick()
@@ -424,14 +428,13 @@ describe('autoSaveLayout disabled', () => {
     expect(autosaveBtn.exists()).toBe(true)
 
     // Act — trigger a layout change (which internally calls autoSaveLayout → early return)
-    localStorageMock.setItem.mockClear()
     wrapper.vm.layout.push({ i: 'widget-99', x: 0, y: 0, w: 6, h: 19, type: 'quote' })
     await nextTick()
     vi.runAllTimers()
     await nextTick()
 
     // Assert — no layout written (autoSaveLayout returned early due to autosaveEnabled=false)
-    expect(localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-layouts')).toBeUndefined()
+    expect(Object.keys(useWidgetSettingsStore().savedLayouts)).toHaveLength(0)
 
     vi.useRealTimers()
     wrapper.unmount()
@@ -451,20 +454,13 @@ describe('autoSaveLayout with no selected layout', () => {
     wrapper.vm.selectedLayoutName = ''  // no layout selected
 
     // Act — trigger layout change which calls autoSaveLayout internally
-    localStorageMock.setItem.mockClear()
     wrapper.vm.layout.push({ i: 'widget-1', x: 0, y: 0, w: 6, h: 19, type: 'quote' })
     await nextTick()
     vi.runAllTimers()
     await nextTick()
 
-    // Assert — autosave key used in localStorage
-    const written = localStorageMock.setItem.mock.calls.find(
-      ([k]) => k === 'dashboard-layouts'
-    )
-    if (written) {
-      const saved = JSON.parse(written[1])
-      expect('__autosave__' in saved).toBe(true)
-    }
+    // Assert — autosave key used in store
+    expect('__autosave__' in useWidgetSettingsStore().savedLayouts).toBe(true)
 
     vi.useRealTimers()
     wrapper.unmount()
@@ -486,7 +482,7 @@ describe('autoSaveLayout with no selected layout', () => {
 describe('mobile toolbar isLocked state', () => {
   test('with mobile + isLocked=true expect lock icon shown', async () => {
     // Arrange — mobile width, locked layout
-    store['dashboard-layout-locked'] = 'true'
+    useWidgetSettingsStore().isLocked = true
     const wrapper = mountGrid(390)
     await nextTick()
 
@@ -591,10 +587,9 @@ describe('saveLayout without setting as default', () => {
     wrapper.vm.saveLayout()
     await nextTick()
 
-    // Assert — layout saved in localStorage but no default key written
-    const layouts = JSON.parse(store['dashboard-layouts'] || '{}')
-    expect(layouts['TestLayout']).toBeTruthy()
-    expect(store['dashboard-default-layout']).toBeUndefined()
+    // Assert — layout saved in store but no default set
+    expect(useWidgetSettingsStore().savedLayouts['TestLayout']).toBeTruthy()
+    expect(useWidgetSettingsStore().defaultLayoutName).toBeNull()
 
     wrapper.unmount()
   })
@@ -759,8 +754,7 @@ describe('saveLayout with non-numeric widget ID (L413 FALSE path)', () => {
 
     // Assert — layout saved, no crash
     expect(wrapper.exists()).toBe(true)
-    const layouts = JSON.parse(store['dashboard-layouts'] || '{}')
-    expect(layouts['TestLayout']).toBeTruthy()
+    expect(useWidgetSettingsStore().savedLayouts['TestLayout']).toBeTruthy()
     wrapper.unmount()
   })
 })

--- a/client/src/components/__tests__/DashboardGridOperations.spec.js
+++ b/client/src/components/__tests__/DashboardGridOperations.spec.js
@@ -17,6 +17,8 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
 
 // ── Heavy dep stubs ────────────────────────────────────────────────────────────
 vi.mock('vue3-grid-layout-next', () => ({
@@ -95,9 +97,9 @@ function triggerImport(wrapper, file) {
 
 
 function seedLayouts(data, defaultName = null) {
-  store['dashboard-layouts'] = JSON.stringify(data)
-  if (defaultName) store['dashboard-default-layout'] = defaultName
-  else delete store['dashboard-default-layout']
+  const wss = useWidgetSettingsStore()
+  wss.savedLayouts = data
+  wss.defaultLayoutName = defaultName ?? null
 }
 
 function makeLayout(overrides = {}) {
@@ -137,8 +139,10 @@ beforeEach(() => {
   vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(mockCtx)
   Object.keys(store).forEach(k => delete store[k])
   // Start unlocked + autosave enabled by default
-  store['dashboard-layout-locked'] = 'false'
-  store['dashboard-autosave-enabled'] = 'true'
+  setActivePinia(createPinia())
+  const wss = useWidgetSettingsStore()
+  wss.isLocked = false
+  wss.autosaveEnabled = true
 })
 
 afterEach(() => {
@@ -161,7 +165,7 @@ describe('saveLayout', () => {
     await nextTick()
 
     // Assert — no layout write
-    expect(localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-layouts')).toBeUndefined()
+    expect(Object.keys(useWidgetSettingsStore().savedLayouts)).toHaveLength(0)
     wrapper.unmount()
   })
 
@@ -176,9 +180,7 @@ describe('saveLayout', () => {
     await nextTick()
 
     // Assert
-    const call = localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-layouts')
-    expect(call).toBeDefined()
-    expect(JSON.parse(call[1])['Alpha']).toBeDefined()
+    expect(useWidgetSettingsStore().savedLayouts['Alpha']).toBeDefined()
     wrapper.unmount()
   })
 
@@ -199,9 +201,7 @@ describe('saveLayout', () => {
 
     // Assert
     expect(wrapper.vm.selectedLayoutName).toBe('MyDefault')
-    const defaultCall = localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-default-layout')
-    expect(defaultCall).toBeDefined()
-    expect(defaultCall[1]).toBe('MyDefault')
+    expect(useWidgetSettingsStore().defaultLayoutName).toBe('MyDefault')
     wrapper.unmount()
   })
 
@@ -218,7 +218,7 @@ describe('saveLayout', () => {
     await nextTick()
 
     // Assert
-    expect(localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-default-layout')).toBeUndefined()
+    expect(useWidgetSettingsStore().defaultLayoutName).toBeNull()
     wrapper.unmount()
   })
 
@@ -235,8 +235,7 @@ describe('saveLayout', () => {
     await nextTick()
 
     // Assert
-    const call = [...localStorageMock.setItem.mock.calls].reverse().find(([k]) => k === 'dashboard-layouts')
-    const saved = JSON.parse(call[1])
+    const saved = useWidgetSettingsStore().savedLayouts
     expect(saved['Existing'].created).toBe(originalCreated)
     expect(saved['Existing'].modified).toBeGreaterThan(originalCreated)
     wrapper.unmount()
@@ -258,8 +257,7 @@ describe('saveLayout', () => {
     await nextTick()
 
     // Assert
-    const call = [...localStorageMock.setItem.mock.calls].reverse().find(([k]) => k === 'dashboard-layouts')
-    expect(JSON.parse(call[1])['WithWidgets'].widgetCounter).toBeGreaterThan(5)
+    expect(useWidgetSettingsStore().savedLayouts['WithWidgets'].widgetCounter).toBeGreaterThan(5)
     wrapper.unmount()
   })
 
@@ -364,8 +362,7 @@ describe('deleteCurrentLayout', () => {
     // Assert
     expect(wrapper.vm.selectedLayoutName).toBe('')
     expect(wrapper.vm.layout).toEqual([])
-    const call = [...localStorageMock.setItem.mock.calls].reverse().find(([k]) => k === 'dashboard-layouts')
-    expect(JSON.parse(call[1])['ToDelete']).toBeUndefined()
+    expect(useWidgetSettingsStore().savedLayouts['ToDelete']).toBeUndefined()
     wrapper.unmount()
   })
 
@@ -375,14 +372,12 @@ describe('deleteCurrentLayout', () => {
     seedLayouts({ 'ToKeep': makeLayout() }, 'ToKeep')
     const wrapper = mountGrid()
     await nextTick(); await nextTick()
-    const callsBefore = localStorageMock.setItem.mock.calls.length
 
     // Act
     await wrapper.find('button[title="Delete Layout"]').trigger('click')
     await nextTick()
 
-    // Assert — nothing written
-    expect(localStorageMock.setItem.mock.calls.length).toBe(callsBefore)
+    // Assert — layout preserved
     expect(wrapper.vm.selectedLayoutName).toBe('ToKeep')
     wrapper.unmount()
   })
@@ -411,7 +406,7 @@ describe('deleteCurrentLayout', () => {
     await nextTick()
 
     // Assert — defaultLayoutName is null after delete
-    expect(store['dashboard-default-layout'] ?? null).toBeNull()
+    expect(useWidgetSettingsStore().defaultLayoutName).toBeNull()
     wrapper.unmount()
   })
 
@@ -431,7 +426,7 @@ describe('deleteCurrentLayout', () => {
     await nextTick()
 
     // Assert — 'Default' still the default
-    expect(store['dashboard-default-layout']).toBe('Default')
+    expect(useWidgetSettingsStore().defaultLayoutName).toBe('Default')
     wrapper.unmount()
   })
 })
@@ -474,16 +469,15 @@ describe('loadDefaultLayout autosave fallback', () => {
 // loadFromStorage error branch
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('loadFromStorage error handling', () => {
-  test('with corrupted localStorage JSON expect graceful fallback', async () => {
-    // Arrange
-    store['dashboard-layouts'] = '{invalid json'
+describe('empty store initial state', () => {
+  test('with no layouts seeded expect graceful empty state', async () => {
+    // Arrange — store is empty (default {})
 
     // Act
     const wrapper = mountGrid()
     await nextTick()
 
-    // Assert — component mounts; savedLayouts falls back to {} (verified via dropdown showing 'No saved layouts')
+    // Assert — component mounts; savedLayouts empty (verified via dropdown showing 'No saved layouts')
     expect(wrapper.vm).toBeDefined()
     await wrapper.find('.select-trigger').trigger('click')
     await nextTick()
@@ -586,7 +580,7 @@ describe('importLayouts', () => {
     await nextTick()
 
     // Assert
-    expect(JSON.parse(store['dashboard-layouts'] ?? '{}')['Imported']).toBeDefined()
+    expect(useWidgetSettingsStore().savedLayouts['Imported']).toBeDefined()
     expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('1'))
     wrapper.unmount()
   })
@@ -609,7 +603,7 @@ describe('importLayouts', () => {
     await nextTick()
 
     // Assert — overwritten
-    expect(JSON.parse(store['dashboard-layouts'] ?? '{}')['Conflict'].description).toBe('imported')
+    expect(useWidgetSettingsStore().savedLayouts['Conflict'].description).toBe('imported')
     wrapper.unmount()
   })
 
@@ -631,7 +625,7 @@ describe('importLayouts', () => {
     await nextTick()
 
     // Assert — NOT overwritten
-    expect(JSON.parse(store['dashboard-layouts'] ?? '{}')['Conflict'].description).toBe('original')
+    expect(useWidgetSettingsStore().savedLayouts['Conflict'].description).toBe('original')
     expect(window.alert).not.toHaveBeenCalled()
     wrapper.unmount()
   })
@@ -652,7 +646,7 @@ describe('importLayouts', () => {
     await nextTick()
 
     // Assert
-    expect(store['dashboard-default-layout']).toBe('NewDefault')
+    expect(useWidgetSettingsStore().defaultLayoutName).toBe('NewDefault')
     wrapper.unmount()
   })
 
@@ -1186,18 +1180,19 @@ describe('autoSaveLayout on layout change', () => {
     await nextTick()
 
     // Assert
-    expect(localStorageMock.setItem.mock.calls.reverse().find(([k]) => k === 'dashboard-layouts')).toBeDefined()
+    expect(useWidgetSettingsStore().savedLayouts['AutoSaveMe']).toBeDefined()
     vi.useRealTimers()
     wrapper.unmount()
   })
 
   test('with layout change while locked expect autosave NOT triggered', async () => {
     // Arrange — start locked
-    store['dashboard-layout-locked'] = 'true'
+    const wss = useWidgetSettingsStore()
+    wss.isLocked = true
     vi.useFakeTimers()
     const wrapper = mountGrid()
     await nextTick()
-    localStorageMock.setItem.mockClear()
+    const savedBefore = { ...useWidgetSettingsStore().savedLayouts }
 
     // Act
     wrapper.vm.layout.push({ i: 'widget-99', x: 0, y: 0, w: 6, h: 19, type: 'quote' })
@@ -1206,7 +1201,7 @@ describe('autoSaveLayout on layout change', () => {
     await nextTick()
 
     // Assert — no layout write
-    expect(localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-layouts')).toBeUndefined()
+    expect(useWidgetSettingsStore().savedLayouts).toEqual(savedBefore)
     vi.useRealTimers()
     wrapper.unmount()
   })
@@ -1334,28 +1329,23 @@ describe('isLocked persistence', () => {
     await nextTick()
 
     // Assert
-    const call = localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-layout-locked')
-    expect(call).toBeDefined()
-    expect(call[1]).toBe('true')
+    expect(useWidgetSettingsStore().isLocked).toBe(true)
     wrapper.unmount()
   })
 })
 
 describe('autosaveEnabled persistence', () => {
-  test('with autosave toggle clicked expect localStorage updated', async () => {
+  test('with autosave toggle clicked expect store updated', async () => {
     // Arrange — autosave ON by default
     const wrapper = mountGrid()
     await nextTick()
-    localStorageMock.setItem.mockClear()
 
     // Act — click "Autosave ON — click to disable"
     await wrapper.find('button[title="Autosave ON \u2014 click to disable"]').trigger('click')
     await nextTick()
 
     // Assert
-    const call = localStorageMock.setItem.mock.calls.find(([k]) => k === 'dashboard-autosave-enabled')
-    expect(call).toBeDefined()
-    expect(call[1]).toBe('false')
+    expect(useWidgetSettingsStore().autosaveEnabled).toBe(false)
     wrapper.unmount()
   })
 })

--- a/client/src/components/__tests__/DashboardGridUseConfig.spec.js
+++ b/client/src/components/__tests__/DashboardGridUseConfig.spec.js
@@ -9,6 +9,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { ref, nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
 
 // ── Mock heavy/irrelevant dependencies ────────────────────────────────────────
 vi.mock('vue3-grid-layout-next', () => ({
@@ -32,6 +33,10 @@ vi.mock('@/composables/useConfig.js', async () => {
 
 import { useConfig } from '@/composables/useConfig.js'
 import DashboardGrid from '../DashboardGrid.vue'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function mountGrid(propsOverrides = {}) {

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -194,6 +194,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { setNewsTimestamp } from '@/composables/useWidgetBus.js'
 import { useDashboardStore } from '@/stores/useDashboardStore.js'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useConfig }          from '@/composables/useConfig.js'
@@ -209,6 +210,7 @@ const props = defineProps({
 const emit = defineEmits(['ticker-click', 'update-col-widths', 'update-settings'])
 
 const store = useDashboardStore()
+const widgetSettingsStore = useWidgetSettingsStore()
 
 // ── Ticker click mode ─────────────────────────────────────────────────────────
 const tickerClickMode = ref(props.settings.tickerClickMode ?? 'filter')
@@ -220,7 +222,6 @@ const toggleTickerClickMode = () => {
 
 const { config: appConfig } = useConfig()
 const US_EXCHANGES = new Set(['XNYS', 'XNAS', 'XASE'])
-const LS_HAS_TICKERS_KEY = 'newsfeed:hasTickersOnly'
 
 // Default widths (px)
 const DEFAULT_WIDTHS = { time: 90, title: 0 }
@@ -247,22 +248,21 @@ const newsItems      = ref([])
 const selected       = ref(null)
 const activeTicker   = ref(null)
 const searchQuery    = ref('')
-const LS_MAX_ARTICLES_KEY = 'newsfeed:maxArticles'
 const MAX_ARTICLES_OPTIONS = [50, 100, 500, 1000, 2000, 4000, 8000, 10000, 20000, 25000]
-const maxArticles = ref(props.settings.maxArticles ?? parseInt(localStorage.getItem(LS_MAX_ARTICLES_KEY) || '1000', 10))
+const maxArticles = ref(props.settings.maxArticles ?? widgetSettingsStore.maxArticles)
 watch(maxArticles, v => {
-  localStorage.setItem(LS_MAX_ARTICLES_KEY, String(v))
+  widgetSettingsStore.maxArticles = v
   emit('update-settings', { ...props.settings, maxArticles: v })
   cacheLimit.value = v
   newsItems.value = []
   getCache(v)
 })
-const hasTickersOnly = ref(props.settings.hasTickersOnly ?? localStorage.getItem(LS_HAS_TICKERS_KEY) === 'true')
+const hasTickersOnly = ref(props.settings.hasTickersOnly ?? widgetSettingsStore.hasTickersOnly)
 const tableWrap      = ref(null)
 
 // Persist R1 toggle
 watch(hasTickersOnly, (val) => {
-  localStorage.setItem(LS_HAS_TICKERS_KEY, val)
+  widgetSettingsStore.hasTickersOnly = val
   emit('update-settings', { ...props.settings, hasTickersOnly: val })
 })
 

--- a/client/src/components/widgets/__tests__/NewsFeedCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/NewsFeedCoverage.spec.js
@@ -21,6 +21,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
 
 // ── Shared mocks (same setup as NewsFeed.spec.js) ────────────────────────────
 vi.mock('@/composables/useWebSocketClient.js', async () => {
@@ -506,7 +507,7 @@ describe('hasTickersOnly filter', () => {
     await nextTick()
 
     // Assert
-    expect(localStorage.getItem('newsfeed:hasTickersOnly')).toBe('true')
+    expect(useWidgetSettingsStore().hasTickersOnly).toBe(true)
     wrapper.unmount()
   })
 })
@@ -910,7 +911,7 @@ describe('maxArticles select', () => {
     await nextTick()
 
     // Assert — persisted
-    expect(localStorage.getItem('newsfeed:maxArticles')).toBe('500')
+    expect(useWidgetSettingsStore().maxArticles).toBe(500)
     wrapper.unmount()
   })
 

--- a/client/src/stores/useWidgetSettingsStore.js
+++ b/client/src/stores/useWidgetSettingsStore.js
@@ -1,12 +1,16 @@
-/**
- * useWidgetSettingsStore — persisted widget settings.
- *
- * Consolidates widget-level localStorage keys into a typed, schema-defined store.
- * Fields are populated in Chunk 4 of the Pinia migration.
- */
 import { defineStore } from 'pinia'
+import { ref } from 'vue'
 
 export const useWidgetSettingsStore = defineStore('widgetSettings', () => {
-  // Fields added in Chunk 4
-  return {}
-}, { persist: false })
+  // DashboardGrid — 4 keys (Chunk 4)
+  const savedLayouts     = ref({})
+  const defaultLayoutName = ref(null)
+  const isLocked         = ref(true)
+  const autosaveEnabled  = ref(true)
+
+  // NewsFeed — 2 keys (Chunk 4)
+  const maxArticles    = ref(1000)
+  const hasTickersOnly = ref(false)
+
+  return { savedLayouts, defaultLayoutName, isLocked, autosaveEnabled, maxArticles, hasTickersOnly }
+}, { persist: true })


### PR DESCRIPTION
refs #282

Chunk 4 of the Pinia migration. Replaces all manual `localStorage` calls for the 6 covered keys with persisted Pinia store fields.

## Changes

- `useWidgetSettingsStore`: populated with 6 fields (`savedLayouts`, `defaultLayoutName`, `isLocked`, `autosaveEnabled`, `maxArticles`, `hasTickersOnly`); `persist: true`
- `DashboardGrid.vue`: 4 localStorage keys migrated to store; `loadFromStorage`/`saveToStorage` become no-ops (plugin handles persistence)
- `NewsFeed.vue`: 2 localStorage keys migrated to store
- Tests updated: store-state assertions replace localStorage spy assertions throughout