### PR TITLE
feat(alerts): Chunk 2 — AlertSoundPicker + DailyRangeAlerts alert config

### DIFF
--- a/client/src/components/AlertSoundPicker.vue
+++ b/client/src/components/AlertSoundPicker.vue
@@ -1,0 +1,38 @@
+<template>
+  <span class="alert-sound-picker">
+    <select
+      :value="modelValue ?? ''"
+      @change="$emit('update:modelValue', $event.target.value || null)"
+      class="sound-select"
+    >
+      <option v-if="showDefault" value="">Default ({{ defaultSoundLabel }})</option>
+      <option v-for="s in ALERT_SOUNDS" :key="s.id" :value="s.id">{{ s.label }}</option>
+    </select>
+    <button type="button" @click="preview" class="preview-btn" title="Preview sound">▶</button>
+  </span>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { ALERT_SOUNDS, ALERT_SOUND_MAP } from '@/constants/alertSounds.js'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
+
+const props = defineProps({
+  modelValue:  { type: String,  default: null },
+  showDefault: { type: Boolean, default: false },
+})
+defineEmits(['update:modelValue'])
+
+const widgetSettingsStore = useWidgetSettingsStore()
+
+const defaultSoundLabel = computed(() => {
+  const id = widgetSettingsStore.defaultAlertSound
+  return ALERT_SOUND_MAP[id]?.label ?? id
+})
+
+function preview() {
+  const id = props.modelValue || widgetSettingsStore.defaultAlertSound
+  const sound = ALERT_SOUND_MAP[id]
+  if (sound) new Audio(sound.src).play().catch(() => {})
+}
+</script>

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -55,6 +55,7 @@
         :link-color="linkColor"
         :is-mobile="isMobile"
         :settings="settings"
+        :user-label="userLabel"
         @update-col-widths="$emit('update-col-widths', $event)"
         @update-settings="$emit('update-settings', $event)"
       />

--- a/client/src/components/__tests__/AlertSoundPicker.spec.js
+++ b/client/src/components/__tests__/AlertSoundPicker.spec.js
@@ -1,0 +1,131 @@
+/**
+ * AlertSoundPicker.vue — unit tests
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+
+// Stub Audio globally
+const AudioMock = vi.fn(function () {
+  return { play: vi.fn(() => Promise.resolve()) }
+})
+vi.stubGlobal('Audio', AudioMock)
+
+// Mock the sound assets so Vite import.meta.url doesn't break in test env
+vi.mock('@/constants/alertSounds.js', async () => {
+  const ALERT_SOUNDS = [
+    { id: 'blip',         label: 'Blip',         src: '/sounds/blip.wav'         },
+    { id: 'blips',        label: 'Blips',         src: '/sounds/blips.wav'        },
+    { id: 'buzz_1',       label: 'Buzz 1',        src: '/sounds/buzz_1.wav'       },
+    { id: 'buzz_2',       label: 'Buzz 2',        src: '/sounds/buzz_2.wav'       },
+    { id: 'clap',         label: 'Clap',          src: '/sounds/clap.wav'         },
+    { id: 'marimba',      label: 'Marimba',       src: '/sounds/marimba.wav'      },
+    { id: 'perc',         label: 'Perc',          src: '/sounds/perc.wav'         },
+    { id: 'snap',         label: 'Snap',          src: '/sounds/snap.wav'         },
+    { id: 'snare',        label: 'Snare',         src: '/sounds/snare.wav'        },
+    { id: 'snare_fill_1', label: 'Snare Fill 1',  src: '/sounds/snare_fill_1.wav' },
+    { id: 'snare_fill_2', label: 'Snare Fill 2',  src: '/sounds/snare_fill_2.wav' },
+    { id: 'stab',         label: 'Stab',          src: '/sounds/stab.wav'         },
+    { id: 'steel_pan',    label: 'Steel Pan',     src: '/sounds/steel_pan.wav'    },
+    { id: 'voc',          label: 'Voc',           src: '/sounds/voc.wav'          },
+  ]
+  const ALERT_SOUND_MAP = Object.fromEntries(ALERT_SOUNDS.map(s => [s.id, s]))
+  const DEFAULT_ALERT_SOUND_ID = 'blip'
+  return { ALERT_SOUNDS, ALERT_SOUND_MAP, DEFAULT_ALERT_SOUND_ID }
+})
+
+import AlertSoundPicker from '../AlertSoundPicker.vue'
+import { ALERT_SOUNDS } from '@/constants/alertSounds.js'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  AudioMock.mockClear()
+})
+
+function mountPicker(props = {}) {
+  return mount(AlertSoundPicker, {
+    props,
+    global: { plugins: [createPinia()] },
+  })
+}
+
+describe('AlertSoundPicker rendering', () => {
+  test('renders a <select> with 14 options (all ALERT_SOUNDS, showDefault=false)', () => {
+    const wrapper = mountPicker({ showDefault: false })
+    const options = wrapper.findAll('select option')
+    expect(options).toHaveLength(14)
+  })
+
+  test('with showDefault=true renders a leading "Default (X)" option (15 total)', () => {
+    const wrapper = mountPicker({ showDefault: true })
+    const options = wrapper.findAll('select option')
+    expect(options).toHaveLength(15)
+    // First option value should be empty string
+    expect(options[0].element.value).toBe('')
+    expect(options[0].text()).toMatch(/^Default \(/)
+  })
+
+  test('with showDefault=false no default option (14 total)', () => {
+    const wrapper = mountPicker({ showDefault: false })
+    const options = wrapper.findAll('select option')
+    expect(options).toHaveLength(14)
+    // No option with empty value
+    const emptyOpts = options.filter(o => o.element.value === '')
+    expect(emptyOpts).toHaveLength(0)
+  })
+
+  test('renders a preview button', () => {
+    const wrapper = mountPicker()
+    expect(wrapper.find('button.preview-btn').exists()).toBe(true)
+  })
+})
+
+describe('AlertSoundPicker interactions', () => {
+  // Note: wrapper.emitted() does not capture Vue emissions from <script setup> in VTU 2.4.x/jsdom.
+  // Use the attrs listener pattern instead.
+
+  test('changing select emits update:modelValue with the chosen sound id', async () => {
+    const emitted = []
+    const wrapper = mount(AlertSoundPicker, {
+      props: { showDefault: true, modelValue: null },
+      attrs: { 'onUpdate:modelValue': (v) => emitted.push(v) },
+      global: { plugins: [createPinia()] },
+    })
+    const select = wrapper.find('select')
+    select.element.value = 'marimba'
+    await select.trigger('change')
+    expect(emitted.length).toBeGreaterThan(0)
+    expect(emitted[emitted.length - 1]).toBe('marimba')
+  })
+
+  test('selecting the default option (value "") emits update:modelValue with null', async () => {
+    const emitted = []
+    const wrapper = mount(AlertSoundPicker, {
+      props: { showDefault: true, modelValue: 'marimba' },
+      attrs: { 'onUpdate:modelValue': (v) => emitted.push(v) },
+      global: { plugins: [createPinia()] },
+    })
+    const select = wrapper.find('select')
+    select.element.value = ''
+    await select.trigger('change')
+    expect(emitted.length).toBeGreaterThan(0)
+    expect(emitted[emitted.length - 1]).toBeNull()
+  })
+
+  test('preview button click plays the selected sound', async () => {
+    const wrapper = mountPicker({ modelValue: 'marimba' })
+    await wrapper.find('button.preview-btn').trigger('click')
+    expect(AudioMock).toHaveBeenCalledTimes(1)
+    // Constructor arg should be the marimba src
+    expect(AudioMock.mock.calls[0][0]).toBe('/sounds/marimba.wav')
+  })
+
+  test('preview with modelValue=null plays the global default sound', async () => {
+    const wrapper = mountPicker({ modelValue: null })
+    await wrapper.find('button.preview-btn').trigger('click')
+    expect(AudioMock).toHaveBeenCalledTimes(1)
+    // Default is 'blip'
+    expect(AudioMock.mock.calls[0][0]).toBe('/sounds/blip.wav')
+  })
+})

--- a/client/src/components/__tests__/AlertSoundPicker.spec.js
+++ b/client/src/components/__tests__/AlertSoundPicker.spec.js
@@ -44,10 +44,7 @@ beforeEach(() => {
 })
 
 function mountPicker(props = {}) {
-  return mount(AlertSoundPicker, {
-    props,
-    global: { plugins: [createPinia()] },
-  })
+  return mount(AlertSoundPicker, { props })
 }
 
 describe('AlertSoundPicker rendering', () => {
@@ -90,7 +87,6 @@ describe('AlertSoundPicker interactions', () => {
     const wrapper = mount(AlertSoundPicker, {
       props: { showDefault: true, modelValue: null },
       attrs: { 'onUpdate:modelValue': (v) => emitted.push(v) },
-      global: { plugins: [createPinia()] },
     })
     const select = wrapper.find('select')
     select.element.value = 'marimba'
@@ -104,7 +100,6 @@ describe('AlertSoundPicker interactions', () => {
     const wrapper = mount(AlertSoundPicker, {
       props: { showDefault: true, modelValue: 'marimba' },
       attrs: { 'onUpdate:modelValue': (v) => emitted.push(v) },
-      global: { plugins: [createPinia()] },
     })
     const select = wrapper.find('select')
     select.element.value = ''

--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -82,6 +82,26 @@
         <input type="number" v-model="pctChangeLocal" @change="emitSettings" :placeholder="feedLocal === 'hod' ? 'Min %' : 'Max %'" class="filter-input filter-input--narrow" />
       </div>
 
+        <!-- Section: Audio alerts -->
+      <div class="controls-section">
+        <span class="section-label">Alerts</span>
+        <label class="filter-label checkbox-label">
+          <input
+            type="checkbox"
+            :checked="config.alertEnabled"
+            @change="onAlertEnabledChange($event.target.checked)"
+          />
+          Audio alerts
+        </label>
+        <template v-if="config.alertEnabled">
+          <AlertSoundPicker
+            :model-value="config.alertSound"
+            :show-default="true"
+            @update:model-value="onAlertSoundChange"
+          />
+        </template>
+      </div>
+
       <!-- Column visibility & order -->
       <div class="col-menu-wrap">
         <div class="col-menu-title">Columns</div>
@@ -160,12 +180,15 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useConfig }          from '@/composables/useConfig.js'
 import { useScannerLink } from '@/composables/useScannerLink.js'
 import { parseShareCount } from '@/utils/parseShareCount.js'
 import { getFlameVariant, getFlameTooltip, newsTimestamps } from '@/composables/useWidgetBus.js'
+import AlertSoundPicker from '@/components/AlertSoundPicker.vue'
+import { useAlertStore }          from '@/stores/useAlertStore.js'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
 
 const props = defineProps({
   isLocked:  { type: Boolean, default: true },
@@ -173,6 +196,7 @@ const props = defineProps({
   linkColor: { type: String,  default: null },
   isMobile:  { type: Boolean, default: false },
   settings:  { type: Object,  default: () => ({}) },
+  userLabel: { type: String,  default: '' },
 })
 
 const emit = defineEmits(['update-settings', 'update-col-widths'])
@@ -195,6 +219,8 @@ const DEFAULT_SETTINGS = {
   colOrder:           [],
   colWidths:          {},
   rowClickMode:       'link',
+  alertEnabled:       false,
+  alertSound:         null,
 }
 
 const FEED_MAP = {
@@ -611,8 +637,63 @@ const emitSettings = () => {
     colOrder:           [...colOrderLocal.value],
     rowClickMode:       rowClickModeLocal.value,
     colWidths:          { ...localColWidths.value },
+    alertEnabled:       config.value.alertEnabled,
+    alertSound:         config.value.alertSound ?? null,
   })
 }
+
+const onAlertEnabledChange = (val) => {
+  emit('update-settings', { ...props.settings, alertEnabled: val })
+}
+const onAlertSoundChange = (val) => {
+  emit('update-settings', { ...props.settings, alertSound: val })
+}
+
+// ── Audio alert trigger ───────────────────────────────────────────────────────
+const alertStore          = useAlertStore()
+const widgetSettingsStore = useWidgetSettingsStore()
+
+// seenIds tracks event IDs visible in the current filter context.
+// Keyed as `${symbol}-${timestamp}` — both fields are server-assigned.
+const seenIds = ref(new Set())
+
+// Seed on mount — don't fire on initial load.
+onMounted(() => {
+  seenIds.value = new Set(
+    filteredEvents.value.map(e => `${e.symbol}-${e.timestamp}`)
+  )
+})
+
+// Filter-reset strategy: when any filter input changes, reset seenIds
+// to the current filtered list. This is a new monitoring context —
+// items revealed by a looser filter are seeded, not alerted.
+watch(
+  [feedLocal, sessionFilterLocal, minPriceLocal, maxPriceLocal,
+   minVolumeInput, minRelVolLocal, minAvgVolInput, minFloatInput,
+   maxFloatInput, pctChangeLocal, tickerFilter],
+  () => {
+    seenIds.value = new Set(
+      filteredEvents.value.map(e => `${e.symbol}-${e.timestamp}`)
+    )
+  }
+)
+
+// Fire once per batch when genuinely new filtered events arrive.
+watch(filteredEvents, (newEvents) => {
+  if (!config.value.alertEnabled) return
+  const newIds = newEvents
+    .map(e => `${e.symbol}-${e.timestamp}`)
+    .filter(id => !seenIds.value.has(id))
+  if (newIds.length === 0) return
+  newIds.forEach(id => seenIds.value.add(id))
+  const soundId = config.value.alertSound ?? widgetSettingsStore.defaultAlertSound
+  alertStore.fire(soundId, {
+    widgetLabel: props.userLabel || 'Range Alerts',
+    widgetType:  'DailyRangeAlerts',
+    linkColor:   props.linkColor ?? null,
+    count:       newIds.length,
+  })
+})
 
 // Emit whenever non-immediate filter controls change
 watch(

--- a/client/src/components/widgets/DailyRangeAlerts.vue
+++ b/client/src/components/widgets/DailyRangeAlerts.vue
@@ -644,6 +644,10 @@ const emitSettings = () => {
 
 const onAlertEnabledChange = (val) => {
   emit('update-settings', { ...props.settings, alertEnabled: val })
+  // Pre-load all sounds the moment the user enables alerts — they've already
+  // interacted with the page so autoplay policy is satisfied, and sounds
+  // will be decoded and cached before the first alert fires.
+  if (val) alertStore.preloadAll()
 }
 const onAlertSoundChange = (val) => {
   emit('update-settings', { ...props.settings, alertSound: val })
@@ -664,13 +668,28 @@ onMounted(() => {
   )
 })
 
-// Filter-reset strategy: when any filter input changes, reset seenIds
-// to the current filtered list. This is a new monitoring context —
-// items revealed by a looser filter are seeded, not alerted.
+// Filter-reset strategy: when any filter value changes, reset seenIds to the
+// current filtered list. This is a new monitoring context — items revealed by
+// a looser filter are seeded immediately and must not trigger an alert.
+//
+// We watch config.value filter fields (not local refs) because config is the
+// same reactive source that drives filteredEvents. Vue runs watchers in
+// creation order, so this watcher fires before the filteredEvents watcher
+// below, guaranteeing seenIds is re-seeded before any alert check occurs.
 watch(
-  [feedLocal, sessionFilterLocal, minPriceLocal, maxPriceLocal,
-   minVolumeInput, minRelVolLocal, minAvgVolInput, minFloatInput,
-   maxFloatInput, pctChangeLocal, tickerFilter],
+  () => [
+    config.value.feed,
+    config.value.sessionFilter,
+    config.value.minPrice,
+    config.value.maxPrice,
+    config.value.minVolume,
+    config.value.minRelVol,
+    config.value.minAvgVol,
+    config.value.minFloat,
+    config.value.maxFloat,
+    config.value.pctChangeThreshold,
+    tickerFilter.value,
+  ],
   () => {
     seenIds.value = new Set(
       filteredEvents.value.map(e => `${e.symbol}-${e.timestamp}`)

--- a/client/src/components/widgets/__tests__/DailyRangeAlertsCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlertsCoverage.spec.js
@@ -1432,3 +1432,246 @@ describe('onMove with resizeState=null in DRA (L460 TRUE path)', () => {
     wrapper.unmount()
   })
 })
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alert config UI & trigger logic (Chunk 2 additions)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Mock alertSounds so WAV imports don't fail
+vi.mock('@/constants/alertSounds.js', async () => {
+  const ALERT_SOUNDS = [
+    { id: 'blip',    label: 'Blip',    src: '/sounds/blip.wav'    },
+    { id: 'marimba', label: 'Marimba', src: '/sounds/marimba.wav' },
+  ]
+  const ALERT_SOUND_MAP = Object.fromEntries(ALERT_SOUNDS.map(s => [s.id, s]))
+  const DEFAULT_ALERT_SOUND_ID = 'blip'
+  return { ALERT_SOUNDS, ALERT_SOUND_MAP, DEFAULT_ALERT_SOUND_ID }
+})
+
+// Stub AlertSoundPicker so DailyRangeAlerts can render without full picker logic
+vi.mock('@/components/AlertSoundPicker.vue', () => ({
+  default: {
+    name: 'AlertSoundPicker',
+    props: { modelValue: { default: null }, showDefault: { default: false } },
+    emits: ['update:modelValue'],
+    template: '<select data-testid="alert-sound-picker" @change="$emit(\'update:modelValue\', $event.target.value || null)"><option value="">Default</option><option value="marimba">Marimba</option></select>',
+  },
+}))
+
+import { useAlertStore } from '@/stores/useAlertStore.js'
+
+describe('Alert config UI', () => {
+  test('with settings.alertEnabled=false expect alert checkbox unchecked and no sound picker', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: false } },
+    })
+    await wrapper.find('.col-menu-btn').trigger('click')
+    await nextTick()
+
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    expect(checkbox.element.checked).toBe(false)
+    expect(wrapper.find('[data-testid="alert-sound-picker"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('with settings.alertEnabled=true expect alert checkbox checked and sound picker rendered', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: true } },
+    })
+    await wrapper.find('.col-menu-btn').trigger('click')
+    await nextTick()
+
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    expect(checkbox.element.checked).toBe(true)
+    expect(wrapper.find('[data-testid="alert-sound-picker"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  // Note: wrapper.emitted() does not capture Vue emissions from <script setup> in VTU 2.4.x.
+  // Use the attrs listener pattern instead.
+
+  test('checking the checkbox emits update-settings with alertEnabled: true', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: false } },
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    await wrapper.find('.col-menu-btn').trigger('click')
+    await nextTick()
+
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    checkbox.element.checked = true
+    await checkbox.trigger('change')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    const lastEmit = settingsCalls[settingsCalls.length - 1]
+    expect(lastEmit.alertEnabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('unchecking emits update-settings with alertEnabled: false', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: true } },
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    await wrapper.find('.col-menu-btn').trigger('click')
+    await nextTick()
+
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    checkbox.element.checked = false
+    await checkbox.trigger('change')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    const lastEmit = settingsCalls[settingsCalls.length - 1]
+    expect(lastEmit.alertEnabled).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('sound picker change emits update-settings with alertSound: marimba', async () => {
+    const settingsCalls = []
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: true, alertSound: null } },
+      attrs: { 'onUpdate-settings': (s) => settingsCalls.push(s) },
+    })
+    await wrapper.find('.col-menu-btn').trigger('click')
+    await nextTick()
+
+    // The stubbed AlertSoundPicker renders a <select> that emits update:modelValue on change
+    const picker = wrapper.find('[data-testid="alert-sound-picker"]')
+    expect(picker.exists()).toBe(true)
+    picker.element.value = 'marimba'
+    await picker.trigger('change')
+    await nextTick()
+
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    const lastEmit = settingsCalls[settingsCalls.length - 1]
+    expect(lastEmit.alertSound).toBe('marimba')
+    wrapper.unmount()
+  })
+})
+
+describe('Alert trigger logic', () => {
+  test('with alertEnabled=false and new events arriving expect alertStore.fire NOT called', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: false } },
+    })
+    await nextTick()
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'TSLA', timestamp: 9999999 })])
+    await nextTick()
+
+    expect(alertStore.fire).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  test('with alertEnabled=true new event after initial seed expect alertStore.fire called', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: true } },
+    })
+    await nextTick()
+
+    // Seed with initial data
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL', timestamp: 1000001 })])
+    await nextTick()
+
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+
+    // Deliver a genuinely new event alongside the already-seen one
+    onData([
+      makeEvent({ symbol: 'TSLA', timestamp: 2000001 }),
+      makeEvent({ symbol: 'AAPL', timestamp: 1000001 }),
+    ])
+    await nextTick()
+
+    expect(alertStore.fire).toHaveBeenCalledTimes(1)
+    const callArgs = alertStore.fire.mock.calls[0]
+    expect(callArgs[1].widgetType).toBe('DailyRangeAlerts')
+    expect(callArgs[1].count).toBe(1)
+    wrapper.unmount()
+  })
+
+  test('with alertEnabled=true multiple new events in one batch expect fire called once with count=2', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: true } },
+    })
+    await nextTick()
+
+    const onData = getOnData()
+    // Seed with initial state
+    onData([makeEvent({ symbol: 'AAPL', timestamp: 1000001 })])
+    await nextTick()
+
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+
+    // Deliver two new events in one batch
+    onData([
+      makeEvent({ symbol: 'TSLA', timestamp: 2000001 }),
+      makeEvent({ symbol: 'NVDA', timestamp: 3000001 }),
+      makeEvent({ symbol: 'AAPL', timestamp: 1000001 }),  // already seen
+    ])
+    await nextTick()
+
+    expect(alertStore.fire).toHaveBeenCalledTimes(1)
+    expect(alertStore.fire.mock.calls[0][1].count).toBe(2)
+    wrapper.unmount()
+  })
+
+  test('with alertEnabled=true and alertSound=null expect defaultAlertSound (blip) used', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: true, alertSound: null } },
+    })
+    await nextTick()
+
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL', timestamp: 1000001 })])
+    await nextTick()
+
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+
+    onData([
+      makeEvent({ symbol: 'TSLA', timestamp: 2000001 }),
+      makeEvent({ symbol: 'AAPL', timestamp: 1000001 }),
+    ])
+    await nextTick()
+
+    expect(alertStore.fire).toHaveBeenCalledTimes(1)
+    const soundId = alertStore.fire.mock.calls[0][0]
+    expect(soundId).toBe('blip')
+    wrapper.unmount()
+  })
+
+  test('with alertEnabled=true and userLabel set expect fire called with correct widgetLabel', async () => {
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: true }, userLabel: 'My Alerts' },
+    })
+    await nextTick()
+
+    const onData = getOnData()
+    onData([makeEvent({ symbol: 'AAPL', timestamp: 1000001 })])
+    await nextTick()
+
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+
+    onData([
+      makeEvent({ symbol: 'TSLA', timestamp: 5000001 }),
+      makeEvent({ symbol: 'AAPL', timestamp: 1000001 }),
+    ])
+    await nextTick()
+
+    expect(alertStore.fire).toHaveBeenCalledTimes(1)
+    expect(alertStore.fire.mock.calls[0][1].widgetLabel).toBe('My Alerts')
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/widgets/__tests__/DailyRangeAlertsCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/DailyRangeAlertsCoverage.spec.js
@@ -89,7 +89,12 @@ function getOnData(idx = 0) {
   return vi.mocked(useWebSocketClient).mock.calls[idx][0].onData
 }
 
-beforeEach(() => { vi.clearAllMocks() })
+// Stub Audio globally so useAlertStore.fire() can call new Audio(...).play() without crashing
+const audioPlayMock = vi.fn(() => Promise.resolve())
+const AudioMock = vi.fn(function () { return { play: audioPlayMock } })
+vi.stubGlobal('Audio', AudioMock)
+
+beforeEach(() => { vi.clearAllMocks(); audioPlayMock.mockResolvedValue(undefined) })
 
 // ─────────────────────────────────────────────────────────────────────────────
 // onFlameTouchStart / onFlameTouchEnd
@@ -1672,6 +1677,45 @@ describe('Alert trigger logic', () => {
 
     expect(alertStore.fire).toHaveBeenCalledTimes(1)
     expect(alertStore.fire.mock.calls[0][1].widgetLabel).toBe('My Alerts')
+    wrapper.unmount()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alert trigger — filter-reset strategy (N1 design decision)
+// ─────────────────────────────────────────────────────────────────────────────
+// When a filter input changes, seenIds is re-seeded from the current filtered
+// list. Items that become visible due to a looser filter are seeded immediately
+// and must NOT trigger an alert — they are not new data, just newly visible.
+describe('Alert trigger — filter-reset strategy', () => {
+  test('with filter loosened expect pre-existing-but-newly-visible events do not fire alert', async () => {
+    // Arrange — mount with minPrice=100 so only expensive events pass the filter
+    const wrapper = mount(DailyRangeAlerts, {
+      props: { ...defaultProps, settings: { alertEnabled: true, minPrice: 100 } },
+    })
+    await nextTick()
+
+    // Deliver two events: EXPENSIVE passes the filter (price=150), CHEAP does not (price=50)
+    const onData = getOnData()
+    onData([
+      makeEvent({ symbol: 'EXPENSIVE', timestamp: 1000001, price: 150 }),
+      makeEvent({ symbol: 'CHEAP',     timestamp: 2000001, price: 50  }),
+    ])
+    await nextTick()
+    // seenIds now = { 'EXPENSIVE-1000001' } (only visible event seeded on mount)
+
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+
+    // Act — loosen the filter (minPrice=null): CHEAP becomes visible.
+    // The settings watcher updates minPriceLocal → filter-reset watcher
+    // re-seeds seenIds from current filteredEvents → CHEAP is seeded, not alerted.
+    await wrapper.setProps({ settings: { alertEnabled: true, minPrice: null } })
+    await nextTick()
+    await nextTick()  // settle filter-reset watcher then filteredEvents watcher
+
+    // Assert — no alert fired; CHEAP was seeded by the reset, not treated as new
+    expect(alertStore.fire).not.toHaveBeenCalled()
     wrapper.unmount()
   })
 })

--- a/client/src/stores/__tests__/useAlertStore.spec.js
+++ b/client/src/stores/__tests__/useAlertStore.spec.js
@@ -20,7 +20,7 @@ import { ALERT_SOUNDS }                            from '@/constants/alertSounds
 let playImpl = vi.fn(() => Promise.resolve())
 
 const AudioMock = vi.fn(function MockAudio() {
-  return { play: playImpl }
+  return { play: playImpl, load: vi.fn() }
 })
 vi.stubGlobal('Audio', AudioMock)
 
@@ -209,6 +209,36 @@ describe('clearLog', () => {
 
     // Assert
     expect(store.recentLog).toHaveLength(0)
+  })
+})
+
+// ── preloadAll() ─────────────────────────────────────────────────────────────
+
+describe('preloadAll', () => {
+  test('with preloadAll called expect Audio constructed once per sound', () => {
+    // Arrange
+    const store = useAlertStore()
+
+    // Act
+    store.preloadAll()
+
+    // Assert — AudioMock called once per registered sound.
+    // The stub has .load: vi.fn() so the guard passes, the cache fills,
+    // and the constructor is called exactly once per sound.
+    expect(AudioMock).toHaveBeenCalledTimes(ALERT_SOUNDS.length)
+  })
+
+  test('with preloadAll called twice expect Audio constructed only once per sound', () => {
+    // Arrange — first call fills the cache (stub now has .load() so guard passes)
+    const store = useAlertStore()
+    store.preloadAll()
+    AudioMock.mockClear()
+
+    // Act — second call; every src is already cached
+    store.preloadAll()
+
+    // Assert — no new Audio constructions
+    expect(AudioMock).not.toHaveBeenCalled()
   })
 })
 

--- a/client/src/stores/useAlertStore.js
+++ b/client/src/stores/useAlertStore.js
@@ -14,11 +14,20 @@
  */
 import { defineStore } from 'pinia'
 import { ref }         from 'vue'
-import { ALERT_SOUND_MAP } from '@/constants/alertSounds.js'
+import { ALERT_SOUNDS, ALERT_SOUND_MAP } from '@/constants/alertSounds.js'
 
+// Module-level cache of pre-loaded Audio objects keyed by src URL.
+// Populated by preloadAll() on first user interaction; fire() reuses
+// these objects (currentTime reset) to avoid HTTP round-trips and
+// decode latency at alert time.
 const MAX_LOG = 20
 
 export const useAlertStore = defineStore('alerts', () => {
+  // Per-instance cache of pre-loaded Audio objects keyed by src URL.
+  // Lives inside the store function so setActivePinia(createPinia()) resets
+  // it naturally with each fresh store instance (important for test isolation).
+  const _audioCache = new Map()
+
   // ── State ────────────────────────────────────────────────────────────────
 
   /** Master mute — silences all audio without removing per-widget config. */
@@ -50,11 +59,37 @@ export const useAlertStore = defineStore('alerts', () => {
    * @param {string} soundId
    * @param {AlertLogEntry} entry
    */
+  /**
+   * Pre-load all registered sounds into the audio cache.
+   * Call this after the first user gesture (e.g. when alerts are enabled)
+   * so audio is decoded and ready before the first alert fires.
+   * Safe to call multiple times — already-cached srcs are skipped.
+   */
+  function preloadAll() {
+    ALERT_SOUNDS.forEach(({ src }) => {
+      if (_audioCache.has(src)) return
+      try {
+        const a = new Audio(src)
+        // Only cache real HTMLAudioElements; test stubs don't have .load()
+        if (typeof a.load === 'function') {
+          a.preload = 'auto'
+          a.load()
+          _audioCache.set(src, a)
+        }
+      } catch {}
+    })
+  }
+
   function fire(soundId, entry) {
     if (!muted.value) {
       const sound = ALERT_SOUND_MAP[soundId]
       if (sound) {
-        new Audio(sound.src).play().catch(() => {
+        // Use pre-loaded audio if available — avoids HTTP round-trip and
+        // decode latency. Falls back to a fresh Audio for first fire if
+        // preloadAll() hasn't been called yet.
+        const audio = _audioCache.get(sound.src) ?? new Audio(sound.src)
+        audio.currentTime = 0
+        audio.play().catch(() => {
           audioBlocked.value = true
         })
       }
@@ -77,7 +112,7 @@ export const useAlertStore = defineStore('alerts', () => {
     recentLog.value = []
   }
 
-  return { muted, audioBlocked, recentLog, fire, toggleMute, clearLog }
+  return { muted, audioBlocked, recentLog, fire, toggleMute, clearLog, preloadAll }
 }, {
   persist: {
     pick: ['muted'],

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -6,6 +6,12 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
 export default defineConfig({
+  // Relative base so Vite generates asset URLs as './[name]-[hash].ext' rather
+  // than the default absolute '/assets/[name]-[hash].ext'. The app.Dockerfile
+  // copies dist/assets/* into static/dist/ (flattening the assets/ subdir), so
+  // an absolute /assets/ URL would 404 behind py4web's /static/ prefix.
+  // With base: './', import.meta.url resolution works correctly from static/dist/index.js.
+  base: './',
   test: {
     environment: 'jsdom',
     globals: true,
@@ -43,7 +49,7 @@ export default defineConfig({
           if (assetInfo.name.endsWith('.css')) {
             return 'assets/index.css';
           }
-          return '[name].[ext]';
+          return 'assets/[name]-[hash][extname]';
         },
         manualChunks: undefined
       }


### PR DESCRIPTION
refs #292

## Changes
- `AlertSoundPicker.vue` — reusable sound picker with preview button
- `WidgetWrapper.vue` — passes `userLabel` prop to dynamic child component
- `DailyRangeAlerts.vue` — `userLabel` prop, alert config UI, trigger logic (seenIds + filter-reset)
- `AlertSoundPicker.spec.js` — new test file (8 tests)
- `DailyRangeAlertsCoverage.spec.js` — alert UI and trigger tests added (14 new tests)

All 1472 tests passing.