### PR TITLE
feat(alerts): Chunk 3 — NewsFeed alert config

### DIFF
--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -47,6 +47,22 @@
       <select v-model.number="maxArticles" class="max-articles-select" title="Max articles loaded">
         <option v-for="n in MAX_ARTICLES_OPTIONS" :key="n" :value="n">{{ n }}</option>
       </select>
+
+      <!-- Audio alert toggle -->
+      <button
+        :class="['filter-btn', config_alertEnabled ? 'filter-btn--active' : '']"
+        :title="config_alertEnabled ? 'Audio alerts ON \u2014 click to disable' : 'Audio alerts OFF \u2014 click to enable'"
+        @click="onAlertEnabledChange(!config_alertEnabled)"
+        data-testid="alert-toggle"
+      >&#x1F514;</button>
+
+      <!-- Sound picker (shown when alerts enabled) -->
+      <AlertSoundPicker
+        v-if="config_alertEnabled"
+        :model-value="config_alertSound"
+        :show-default="true"
+        @update:model-value="onAlertSoundChange"
+      />
     </div>
 
     <!-- Mobile: card list -->
@@ -191,13 +207,15 @@
  * @emits ticker-click        - US ticker badge clicked, payload: symbol string
  * @emits update-col-widths   - Column widths changed, payload: { time, title, source, tickers }
  */
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { setNewsTimestamp } from '@/composables/useWidgetBus.js'
 import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
+import { useAlertStore }          from '@/stores/useAlertStore.js'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import { useWebSocketClient } from '@/composables/useWebSocketClient.js'
 import { useConfig }          from '@/composables/useConfig.js'
+import AlertSoundPicker from '@/components/AlertSoundPicker.vue'
 
 const props = defineProps({
   feedName:  { type: String,  default: 'news:feed:latest' },
@@ -206,6 +224,7 @@ const props = defineProps({
   linkColor: { type: String,  default: null },
   isMobile:  { type: Boolean, default: false },
   settings:  { type: Object,  default: () => ({}) },
+  userLabel: { type: String,  default: '' },
 })
 const emit = defineEmits(['ticker-click', 'update-col-widths', 'update-settings'])
 
@@ -436,6 +455,64 @@ const filteredNews = computed(() => {
   })
 
   return items
+})
+
+// ── Alert config — derived from settings prop ────────────────────────────────
+const config_alertEnabled = computed(() => props.settings.alertEnabled ?? false)
+const config_alertSound   = computed(() => props.settings.alertSound   ?? null)
+
+const onAlertEnabledChange = (val) => {
+  emit('update-settings', { ...props.settings, alertEnabled: val })
+}
+const onAlertSoundChange = (val) => {
+  emit('update-settings', { ...props.settings, alertSound: val })
+}
+
+// ── Audio alert trigger ───────────────────────────────────────────────────────
+const alertStore = useAlertStore()
+
+// seenIds tracks article links visible in the current filter context.
+// `link` is the stable server-assigned article identifier.
+const seenIds = ref(new Set())
+
+// alertReady: false until the initial cache tick has settled. Prevents the
+// initial cache load from being treated as "new" articles.
+const alertReady = ref(false)
+
+// Filter-reset strategy: when any filter input changes, this is a new
+// monitoring context — reset seenIds to avoid false positives from
+// items revealed by a looser filter.
+watch(
+  [hasTickersOnly, activeTicker, searchQuery],
+  () => {
+    seenIds.value = new Set(filteredNews.value.map(a => a.link))
+  }
+)
+
+// Fire once per batch when genuinely new filtered articles arrive.
+watch(filteredNews, (newItems) => {
+  if (!alertReady.value || !config_alertEnabled.value) return
+  const newIds = newItems
+    .map(a => a.link)
+    .filter(id => !seenIds.value.has(id))
+  if (newIds.length === 0) return
+  newIds.forEach(id => seenIds.value.add(id))
+  const soundId = config_alertSound.value ?? widgetSettingsStore.defaultAlertSound
+  alertStore.fire(soundId, {
+    widgetLabel: props.userLabel || 'News Feed',
+    widgetType:  'NewsFeed',
+    linkColor:   props.linkColor ?? null,
+    count:       newIds.length,
+  })
+})
+
+// Seed seenIds after the initial cache tick so the first batch of articles
+// is treated as "already seen" rather than firing an alert on page load.
+onMounted(() => {
+  nextTick(() => {
+    seenIds.value = new Set(filteredNews.value.map(a => a.link))
+    alertReady.value = true
+  })
 })
 </script>
 

--- a/client/src/components/widgets/NewsFeed.vue
+++ b/client/src/components/widgets/NewsFeed.vue
@@ -50,16 +50,16 @@
 
       <!-- Audio alert toggle -->
       <button
-        :class="['filter-btn', config_alertEnabled ? 'filter-btn--active' : '']"
-        :title="config_alertEnabled ? 'Audio alerts ON \u2014 click to disable' : 'Audio alerts OFF \u2014 click to enable'"
-        @click="onAlertEnabledChange(!config_alertEnabled)"
+        :class="['filter-btn', configAlertEnabled ? 'filter-btn--active' : '']"
+        :title="configAlertEnabled ? 'Audio alerts ON \u2014 click to disable' : 'Audio alerts OFF \u2014 click to enable'"
+        @click="onAlertEnabledChange(!configAlertEnabled)"
         data-testid="alert-toggle"
       >&#x1F514;</button>
 
       <!-- Sound picker (shown when alerts enabled) -->
       <AlertSoundPicker
-        v-if="config_alertEnabled"
-        :model-value="config_alertSound"
+        v-if="configAlertEnabled"
+        :model-value="configAlertSound"
         :show-default="true"
         @update:model-value="onAlertSoundChange"
       />
@@ -458,11 +458,12 @@ const filteredNews = computed(() => {
 })
 
 // ── Alert config — derived from settings prop ────────────────────────────────
-const config_alertEnabled = computed(() => props.settings.alertEnabled ?? false)
-const config_alertSound   = computed(() => props.settings.alertSound   ?? null)
+const configAlertEnabled = computed(() => props.settings.alertEnabled ?? false)
+const configAlertSound   = computed(() => props.settings.alertSound   ?? null)
 
 const onAlertEnabledChange = (val) => {
   emit('update-settings', { ...props.settings, alertEnabled: val })
+  if (val) alertStore.preloadAll()
 }
 const onAlertSoundChange = (val) => {
   emit('update-settings', { ...props.settings, alertSound: val })
@@ -491,13 +492,13 @@ watch(
 
 // Fire once per batch when genuinely new filtered articles arrive.
 watch(filteredNews, (newItems) => {
-  if (!alertReady.value || !config_alertEnabled.value) return
+  if (!alertReady.value || !configAlertEnabled.value) return
   const newIds = newItems
     .map(a => a.link)
     .filter(id => !seenIds.value.has(id))
   if (newIds.length === 0) return
   newIds.forEach(id => seenIds.value.add(id))
-  const soundId = config_alertSound.value ?? widgetSettingsStore.defaultAlertSound
+  const soundId = configAlertSound.value ?? widgetSettingsStore.defaultAlertSound
   alertStore.fire(soundId, {
     widgetLabel: props.userLabel || 'News Feed',
     widgetType:  'NewsFeed',

--- a/client/src/components/widgets/__tests__/NewsFeedCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/NewsFeedCoverage.spec.js
@@ -1761,3 +1761,182 @@ describe('sort fallback when sortKey is unknown', () => {
     wrapper.unmount()
   })
 })
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alert config UI (Chunk 3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { useAlertStore } from '@/stores/useAlertStore.js'
+
+describe('alert config UI', () => {
+  test('with alertEnabled not set expect 🔔 button rendered with inactive class', async () => {
+    const wrapper = mountFeed()
+    await nextTick()
+    const btn = wrapper.find('[data-testid="alert-toggle"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.classes()).not.toContain('filter-btn--active')
+    wrapper.unmount()
+  })
+
+  test('with alertEnabled=true expect 🔔 button has active class and sound picker rendered', async () => {
+    const wrapper = mountFeed({ settings: { alertEnabled: true } })
+    await nextTick()
+    const btn = wrapper.find('[data-testid="alert-toggle"]')
+    expect(btn.classes()).toContain('filter-btn--active')
+    // AlertSoundPicker renders a select with class sound-select
+    expect(wrapper.find('.sound-select').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('clicking 🔔 button when disabled emits update-settings with alertEnabled: true', async () => {
+    const calls = []
+    const wrapper = mount(NewsFeed, {
+      props: { ...defaultProps, settings: { alertEnabled: false } },
+      attrs: { 'onUpdate-settings': (s) => calls.push(s) },
+      global: { stubs: { Teleport: true } },
+    })
+    await nextTick()
+    await wrapper.find('[data-testid="alert-toggle"]').trigger('click')
+    await nextTick()
+    expect(calls.length).toBeGreaterThan(0)
+    expect(calls[calls.length - 1].alertEnabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('clicking 🔔 button when enabled emits update-settings with alertEnabled: false', async () => {
+    const calls = []
+    const wrapper = mount(NewsFeed, {
+      props: { ...defaultProps, settings: { alertEnabled: true } },
+      attrs: { 'onUpdate-settings': (s) => calls.push(s) },
+      global: { stubs: { Teleport: true } },
+    })
+    await nextTick()
+    await wrapper.find('[data-testid="alert-toggle"]').trigger('click')
+    await nextTick()
+    expect(calls.length).toBeGreaterThan(0)
+    expect(calls[calls.length - 1].alertEnabled).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('sound picker change emits update-settings with alertSound: "snap"', async () => {
+    const calls = []
+    const wrapper = mount(NewsFeed, {
+      props: { ...defaultProps, settings: { alertEnabled: true } },
+      attrs: { 'onUpdate-settings': (s) => calls.push(s) },
+      global: { stubs: { Teleport: true } },
+    })
+    await nextTick()
+    // AlertSoundPicker emits update:modelValue which calls onAlertSoundChange
+    const select = wrapper.find('.sound-select')
+    expect(select.exists()).toBe(true)
+    await select.setValue('snap')
+    await nextTick()
+    expect(calls.length).toBeGreaterThan(0)
+    expect(calls[calls.length - 1].alertSound).toBe('snap')
+    wrapper.unmount()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alert trigger logic (Chunk 3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('alert trigger logic', () => {
+  test('with alertEnabled=false and new articles arriving expect alertStore.fire NOT called', async () => {
+    const wrapper = mountFeed({ settings: { alertEnabled: false } })
+    await nextTick()
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+    triggerData([makeArticle({ link: 'https://a.com/new1' })])
+    await nextTick()
+    expect(alertStore.fire).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  test('with alertEnabled=true and initial data load (mount) expect alertStore.fire NOT called', async () => {
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+    const wrapper = mountFeed({ settings: { alertEnabled: true } })
+    // Deliver data as part of "initial" load — seenIds seeds on nextTick after mount
+    triggerData([makeArticle({ link: 'https://a.com/seed1' })])
+    await nextTick()
+    // onMounted nextTick callback runs, seeding seenIds and setting alertReady
+    await nextTick()
+    // fire should not have been called since seenIds was seeded with these items
+    expect(alertStore.fire).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  test('with alertEnabled=true and new article arriving after mount expect alertStore.fire called', async () => {
+    const wrapper = mountFeed({ settings: { alertEnabled: true } })
+    // Seed initial data
+    triggerData([makeArticle({ link: 'https://a.com/existing' })])
+    await nextTick()
+    await nextTick() // allow onMounted nextTick seeding
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+    // Now deliver a new article
+    triggerData([makeArticle({ link: 'https://a.com/brand-new', title: 'Breaking News' })])
+    await nextTick()
+    expect(alertStore.fire).toHaveBeenCalledOnce()
+    const [soundId, entry] = alertStore.fire.mock.calls[0]
+    expect(entry.widgetType).toBe('NewsFeed')
+    expect(entry.count).toBe(1)
+    wrapper.unmount()
+  })
+
+  test('with alertEnabled=true and 3 new articles in one batch expect fire called once with count: 3', async () => {
+    const wrapper = mountFeed({ settings: { alertEnabled: true } })
+    await nextTick()
+    await nextTick() // allow onMounted nextTick seeding
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+    triggerData([
+      makeArticle({ link: 'https://a.com/b1', title: 'Batch 1' }),
+      makeArticle({ link: 'https://a.com/b2', title: 'Batch 2' }),
+      makeArticle({ link: 'https://a.com/b3', title: 'Batch 3' }),
+    ])
+    await nextTick()
+    expect(alertStore.fire).toHaveBeenCalledOnce()
+    expect(alertStore.fire.mock.calls[0][1].count).toBe(3)
+    wrapper.unmount()
+  })
+
+  test('with filter change then new articles expect fire NOT called for already-seen articles', async () => {
+    const wrapper = mountFeed({ settings: { alertEnabled: true } })
+    // Deliver initial articles
+    triggerData([
+      makeArticle({ link: 'https://a.com/a1', title: 'Apple news', companies: [{ ticker: 'AAPL', name: 'Apple', primaryListing: { exchangeCode: 'XNAS' } }] }),
+      makeArticle({ link: 'https://a.com/a2', title: 'Other news', companies: [] }),
+    ])
+    await nextTick()
+    await nextTick() // allow onMounted nextTick seeding
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+
+    // Toggle hasTickersOnly — filter changes, seenIds reseeds
+    await wrapper.find('button[title="Show only articles with tickers"]').trigger('click')
+    await nextTick()
+
+    // The AAPL article is still in filteredNews — was already seen
+    expect(alertStore.fire).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  test('with settings.alertSound=null expect widgetSettingsStore.defaultAlertSound used', async () => {
+    const wrapper = mountFeed({ settings: { alertEnabled: true, alertSound: null } })
+    await nextTick()
+    await nextTick()
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'fire')
+    const widgetSettingsStore = useWidgetSettingsStore()
+    const expectedSound = widgetSettingsStore.defaultAlertSound
+
+    triggerData([makeArticle({ link: 'https://a.com/sound-test' })])
+    await nextTick()
+    expect(alertStore.fire).toHaveBeenCalledOnce()
+    expect(alertStore.fire.mock.calls[0][0]).toBe(expectedSound)
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/widgets/__tests__/NewsFeedCoverage.spec.js
+++ b/client/src/components/widgets/__tests__/NewsFeedCoverage.spec.js
@@ -117,8 +117,14 @@ function triggerData(data) {
   lastCall[0].onData(data)
 }
 
+// Stub Audio globally so useAlertStore.fire() can call new Audio(...).play() without crashing
+const audioPlayMock = vi.fn(() => Promise.resolve())
+const AudioMock = vi.fn(function () { return { play: audioPlayMock } })
+vi.stubGlobal('Audio', AudioMock)
+
 beforeEach(() => {
   vi.clearAllMocks()
+  audioPlayMock.mockResolvedValue(undefined)
   localStorage.clear()
 })
 


### PR DESCRIPTION
refs #293

## Changes
- `AlertSoundPicker.vue` — reusable sound picker with preview (also in Chunk 2; identical spec)
- `WidgetWrapper.vue` — passes `userLabel` prop to dynamic child component
- `NewsFeed.vue` — `userLabel` prop, alert toggle + sound picker in controls bar, trigger logic (seenIds + filter-reset)
- `NewsFeedCoverage.spec.js` — alert UI and trigger tests added