### PR TITLE
feat(alerts): Chunk 4 — Global Alert Manager

### DIFF
--- a/client/src/components/AlertManager.vue
+++ b/client/src/components/AlertManager.vue
@@ -1,0 +1,214 @@
+<template>
+  <div class="alert-manager-panel">
+
+    <!-- Mute toggle -->
+    <div class="am-section">
+      <button @click="alertStore.toggleMute()" class="btn-mute" :class="{ 'btn-mute--active': alertStore.muted }">
+        {{ alertStore.muted ? '🔇 Unmute' : '🔊 Mute All' }}
+      </button>
+    </div>
+
+    <!-- Global default sound -->
+    <div class="am-section">
+      <label class="am-label">Default sound</label>
+      <AlertSoundPicker
+        :model-value="widgetSettingsStore.defaultAlertSound"
+        @update:model-value="widgetSettingsStore.defaultAlertSound = $event"
+      />
+    </div>
+
+    <!-- Active alerts list -->
+    <div class="am-section">
+      <div class="am-label">Active alerts</div>
+      <div v-if="alertEnabledWidgets.length === 0" class="am-empty">
+        No alerts configured. Enable alerts in a widget's settings panel.
+      </div>
+      <div v-else class="am-widget-list">
+        <div v-for="w in alertEnabledWidgets" :key="w.widgetId" class="am-widget-row">
+          <span
+            v-if="w.linkColor"
+            class="am-color-swatch"
+            :style="{ background: colorHex(w.linkColor) }"
+          ></span>
+          <span class="am-widget-label">{{ w.widgetLabel }}</span>
+          <span class="am-widget-sound">{{ soundLabel(w.effectiveSound) }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Recent log -->
+    <div class="am-section">
+      <div class="am-label-row">
+        <span class="am-label">Recent alerts</span>
+        <button v-if="alertStore.recentLog.length > 0" @click="alertStore.clearLog()" class="am-clear-btn">Clear</button>
+      </div>
+      <div v-if="alertStore.recentLog.length === 0" class="am-empty">No alerts fired yet.</div>
+      <div v-else class="am-log">
+        <div v-for="(entry, i) in alertStore.recentLog" :key="i" class="am-log-row">
+          <span class="am-log-time">{{ formatTime(entry.timestamp) }}</span>
+          <span v-if="entry.linkColor" class="am-color-swatch" :style="{ background: colorHex(entry.linkColor) }"></span>
+          <span class="am-log-label">{{ entry.widgetLabel }}</span>
+          <span class="am-log-count">{{ entry.count }} new {{ entry.widgetType === 'NewsFeed' ? (entry.count === 1 ? 'article' : 'articles') : (entry.count === 1 ? 'alert' : 'alerts') }}</span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script setup>
+import { useAlertStore }          from '@/stores/useAlertStore.js'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
+import { ALERT_SOUND_MAP }        from '@/constants/alertSounds.js'
+import { LINK_COLOR_MAP }         from '@/constants/linkColors.js'
+import AlertSoundPicker           from '@/components/AlertSoundPicker.vue'
+
+defineProps({
+  alertEnabledWidgets: {
+    type: Array,  // AlertWidgetInfo[]
+    default: () => [],
+  },
+})
+
+const alertStore          = useAlertStore()
+const widgetSettingsStore = useWidgetSettingsStore()
+
+function colorHex(name) {
+  return LINK_COLOR_MAP[name] ?? '#888'
+}
+
+function soundLabel(id) {
+  return ALERT_SOUND_MAP[id]?.label ?? id
+}
+
+function formatTime(ts) {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+</script>
+
+<style scoped>
+.alert-manager-panel {
+  background: var(--pd-surface, #1a1a1a);
+  border: 1px solid var(--pd-border, #2a2a2a);
+  border-radius: 6px;
+  padding: 12px;
+  min-width: 280px;
+  max-width: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.am-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.am-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--pd-text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.am-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.am-empty {
+  font-size: 12px;
+  color: var(--pd-text-muted, #888);
+  font-style: italic;
+}
+
+.am-widget-list,
+.am-log {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.am-widget-row,
+.am-log-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--pd-text, #ccc);
+}
+
+.am-color-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.am-widget-label,
+.am-log-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.am-widget-sound {
+  color: var(--pd-text-muted, #888);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.am-log-time {
+  color: var(--pd-text-muted, #888);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.am-log-count {
+  color: var(--pd-text-muted, #888);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.btn-mute {
+  padding: 6px 12px;
+  background: var(--pd-surface, #2d2d2d);
+  border: 1px solid var(--pd-border, #444);
+  border-radius: 4px;
+  color: var(--pd-text, #fff);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-mute:hover {
+  background: var(--pd-surface-2, #3d3d3d);
+}
+
+.btn-mute--active {
+  border-color: #f97316;
+  color: #f97316;
+}
+
+.am-clear-btn {
+  padding: 2px 8px;
+  background: transparent;
+  border: 1px solid var(--pd-border, #444);
+  border-radius: 3px;
+  color: var(--pd-text-muted, #888);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.am-clear-btn:hover {
+  background: var(--pd-surface-2, #3d3d3d);
+  color: var(--pd-text, #ccc);
+}
+</style>

--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -147,12 +147,35 @@
 
     </div>
 
+    <!-- Alert Manager bell icon -->
+    <div v-if="appConfig && !isMobile" class="alert-manager-wrap">
+      <button
+        @click="widgetSettingsStore.alertManagerOpen = !widgetSettingsStore.alertManagerOpen"
+        class="btn-icon alert-bell"
+        :class="{ 'alert-bell--muted': alertStore.muted }"
+        title="Alert Manager"
+        data-testid="alert-bell"
+      >
+        🔔<span v-if="alertBadgeCount > 0" class="alert-badge">{{ alertBadgeCount }}</span>
+      </button>
+      <AlertManager
+        v-if="widgetSettingsStore.alertManagerOpen"
+        :alert-enabled-widgets="alertEnabledWidgets"
+        class="alert-manager-dropdown"
+      />
+    </div>
+
     <div v-if="!appConfig" class="auth-required">
       <p>Please log in to access the dashboard</p>
     </div>
 
     <div v-if="appVersion" class="app-version">v{{ appVersion }}</div>
   </header>
+
+  <!-- Autoplay blocked banner -->
+  <div v-if="alertStore.audioBlocked" class="audio-blocked-banner" @click="alertStore.audioBlocked = false">
+    🔔 Click to enable audio alerts
+  </div>
 
   <!-- Hover Preview Tooltip -->
   <div
@@ -314,7 +337,24 @@ import WidgetMenu from './WidgetMenu.vue'
 import WidgetWrapper from './WidgetWrapper.vue'
 import { useConfig } from '@/composables/useConfig.js'
 import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
+import { useAlertStore } from '@/stores/useAlertStore.js'
+import { LINK_COLOR_MAP } from '@/constants/linkColors.js'
 import { storeToRefs } from 'pinia'
+import AlertManager from './AlertManager.vue'
+
+const WIDGET_TYPE_LABELS = {
+  'top-gainers':       'Top Gainers',
+  'top-gappers':       'Top Gappers',
+  'top-volume':        'Top Volume',
+  'news-feed':         'News Feed',
+  'company-news':      'Company News',
+  'quote':             'Mini Quote',
+  'enhanced-quote':    'Quote',
+  'enhanced-quote-v4': 'Enhanced Quote',
+  'range-alerts':      'Range Alerts',
+  'candlestick-chart': 'Candlestick Chart',
+  'tv-lite-chart':     'TV Lite Chart',
+}
 
 const { config: appConfig, loading: configLoading, error: configError } = useConfig()
 const appVersion = window.__APP_VERSION__ || null
@@ -329,6 +369,7 @@ const AUTOSAVE_DEBOUNCE_MS = 2000
 
 const widgetSettingsStore = useWidgetSettingsStore()
 const { savedLayouts, defaultLayoutName, isLocked, autosaveEnabled } = storeToRefs(widgetSettingsStore)
+const alertStore = useAlertStore()
 
 // State
 const layout = ref([])
@@ -367,6 +408,20 @@ const savedLayoutNames = computed(() =>
 const editingExistingLayout = computed(() =>
     saveLayoutName.value.trim() && savedLayouts.value[saveLayoutName.value.trim()]
 )
+
+const alertEnabledWidgets = computed(() =>
+  layout.value
+    .filter(item => item.settings?.alertEnabled)
+    .map(item => ({
+      widgetId:       item.i,
+      widgetLabel:    item.userLabel || WIDGET_TYPE_LABELS[item.type] || item.type,
+      widgetType:     item.type,
+      linkColor:      item.linkColor ?? null,
+      effectiveSound: item.settings?.alertSound ?? widgetSettingsStore.defaultAlertSound,
+    }))
+)
+
+const alertBadgeCount = computed(() => alertEnabledWidgets.value.length)
 
 // Layout Operations
 const saveLayout = () => {
@@ -1285,6 +1340,61 @@ defineExpose({ dashboardColNum, layout, addWidget, saveLayout, saveLayoutName, l
 
 .auth-required button:hover {
   background: #3d3d3d;
+}
+
+.alert-manager-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.alert-bell {
+  position: relative;
+  font-size: 18px;
+  padding: 4px 8px;
+}
+
+.alert-bell--muted {
+  opacity: 0.5;
+  filter: grayscale(1);
+}
+
+.alert-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  border-radius: 9999px;
+  padding: 1px 4px;
+  line-height: 1.2;
+  min-width: 16px;
+  text-align: center;
+}
+
+.alert-manager-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 200;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.audio-blocked-banner {
+  background: #f97316;
+  color: #fff;
+  text-align: center;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+
+.audio-blocked-banner:hover {
+  background: #ea6a00;
 }
 
 /* ── Mobile (< 640px) ── */

--- a/client/src/components/__tests__/AlertManager.spec.js
+++ b/client/src/components/__tests__/AlertManager.spec.js
@@ -1,0 +1,349 @@
+/**
+ * AlertManager.vue — unit tests
+ *
+ * Covers: empty state, active alerts list (labels, swatches, sounds),
+ * mute toggle, default sound picker, recent log (count text, clear button,
+ * color swatches, article/alert pluralisation).
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useAlertStore } from '@/stores/useAlertStore.js'
+import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
+
+// ── Stubs ─────────────────────────────────────────────────────────────────────
+vi.mock('../AlertSoundPicker.vue', () => ({
+  default: {
+    name: 'AlertSoundPicker',
+    props: ['modelValue', 'showDefault'],
+    emits: ['update:modelValue'],
+    template: '<select class="mock-picker" @change="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+}))
+
+import AlertManager from '../AlertManager.vue'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function mountAlertManager(props = {}) {
+  // No createPinia() here — rely on the beforeEach instance set by setActivePinia
+  return mount(AlertManager, {
+    props: {
+      alertEnabledWidgets: [],
+      ...props,
+    },
+  })
+}
+
+function makeWidget(overrides = {}) {
+  return {
+    widgetId:      'w1',
+    widgetLabel:   'Range Alerts',
+    widgetType:    'range-alerts',
+    linkColor:     null,
+    effectiveSound: 'blip',
+    ...overrides,
+  }
+}
+
+function makeLogEntry(overrides = {}) {
+  return {
+    timestamp:   Date.now(),
+    widgetLabel: 'News Feed',
+    widgetType:  'NewsFeed',
+    linkColor:   null,
+    count:       1,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe('empty state', () => {
+  test('with alertEnabledWidgets=[] expect empty-state message rendered', async () => {
+    // Arrange
+    const wrapper = mountAlertManager({ alertEnabledWidgets: [] })
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.am-empty').text()).toContain('No alerts configured')
+    wrapper.unmount()
+  })
+
+  test('with empty recentLog expect "No alerts fired yet" message rendered', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = []
+
+    // Act
+    await nextTick()
+
+    // Assert
+    const empties = wrapper.findAll('.am-empty')
+    expect(empties.some(el => el.text().includes('No alerts fired yet'))).toBe(true)
+    wrapper.unmount()
+  })
+})
+
+// ── Active alerts list ────────────────────────────────────────────────────────
+
+describe('active alerts list', () => {
+  test('with two widgets expect two rows with correct labels and sounds', async () => {
+    // Arrange
+    const widgets = [
+      makeWidget({ widgetId: 'w1', widgetLabel: 'Top Gainers', effectiveSound: 'blip' }),
+      makeWidget({ widgetId: 'w2', widgetLabel: 'News Feed',   effectiveSound: 'snap' }),
+    ]
+    const wrapper = mountAlertManager({ alertEnabledWidgets: widgets })
+
+    // Act
+    await nextTick()
+
+    // Assert
+    const rows = wrapper.findAll('.am-widget-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text()).toContain('Top Gainers')
+    expect(rows[0].text()).toContain('Blip')
+    expect(rows[1].text()).toContain('News Feed')
+    expect(rows[1].text()).toContain('Snap')
+    wrapper.unmount()
+  })
+
+  test('with widget having linkColor expect color swatch rendered', async () => {
+    // Arrange
+    const wrapper = mountAlertManager({ alertEnabledWidgets: [makeWidget({ linkColor: 'red' })] })
+
+    // Act
+    await nextTick()
+
+    // Assert
+    const swatch = wrapper.find('.am-widget-row .am-color-swatch')
+    expect(swatch.exists()).toBe(true)
+    expect(swatch.attributes('style')).toMatch(/background:\s*(#ef4444|rgb\(239,\s*68,\s*68\))/)
+    wrapper.unmount()
+  })
+
+  test('with widget having no linkColor expect no color swatch', async () => {
+    // Arrange
+    const wrapper = mountAlertManager({ alertEnabledWidgets: [makeWidget({ linkColor: null })] })
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.am-widget-row .am-color-swatch').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})
+
+// ── Mute button ───────────────────────────────────────────────────────────────
+
+describe('mute button', () => {
+  test('with muted=false expect button shows "Mute All"', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().muted = false
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.btn-mute').text()).toContain('Mute All')
+    wrapper.unmount()
+  })
+
+  test('with muted=true expect button shows "Unmute"', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().muted = true
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.btn-mute').text()).toContain('Unmute')
+    wrapper.unmount()
+  })
+
+  test('with mute button clicked expect alertStore.toggleMute called', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    await nextTick()
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'toggleMute')
+
+    // Act
+    await wrapper.find('.btn-mute').trigger('click')
+
+    // Assert
+    expect(alertStore.toggleMute).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+})
+
+// ── Default sound picker ──────────────────────────────────────────────────────
+
+describe('default sound picker', () => {
+  test('with panel open expect sound picker rendered', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.mock-picker').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('with picker emitting new value expect widgetSettingsStore.defaultAlertSound updated', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    const wss = useWidgetSettingsStore()
+    wss.defaultAlertSound = 'blip'
+    await nextTick()
+
+    // Act
+    await wrapper.findComponent({ name: 'AlertSoundPicker' }).vm.$emit('update:modelValue', 'snap')
+
+    // Assert
+    expect(wss.defaultAlertSound).toBe('snap')
+    wrapper.unmount()
+  })
+})
+
+// ── Recent log ────────────────────────────────────────────────────────────────
+
+describe('recent log', () => {
+  test('with entries in recentLog expect clear button shown', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = [makeLogEntry()]
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.am-clear-btn').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('with empty recentLog expect clear button absent', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = []
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.am-clear-btn').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('with clear button clicked expect alertStore.clearLog called', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    const alertStore = useAlertStore()
+    vi.spyOn(alertStore, 'clearLog')
+    alertStore.recentLog = [makeLogEntry()]
+    await nextTick()
+
+    // Act
+    await wrapper.find('.am-clear-btn').trigger('click')
+
+    // Assert
+    expect(alertStore.clearLog).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+
+  test('with log entry expect label and count rendered', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = [makeLogEntry({ widgetLabel: 'News Feed', count: 3 })]
+
+    // Act
+    await nextTick()
+
+    // Assert
+    const row = wrapper.find('.am-log-row')
+    expect(row.find('.am-log-label').text()).toContain('News Feed')
+    expect(row.find('.am-log-count').text()).toContain('3')
+    wrapper.unmount()
+  })
+
+  test('with NewsFeed entry count=1 expect "1 new article"', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = [makeLogEntry({ widgetType: 'NewsFeed', count: 1 })]
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.am-log-count').text()).toBe('1 new article')
+    wrapper.unmount()
+  })
+
+  test('with NewsFeed entry count=3 expect "3 new articles"', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = [makeLogEntry({ widgetType: 'NewsFeed', count: 3 })]
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.am-log-count').text()).toBe('3 new articles')
+    wrapper.unmount()
+  })
+
+  test('with DailyRangeAlerts entry count=2 expect "2 new alerts"', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = [makeLogEntry({ widgetType: 'DailyRangeAlerts', count: 2 })]
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.am-log-count').text()).toBe('2 new alerts')
+    wrapper.unmount()
+  })
+
+  test('with log entry having linkColor expect color swatch rendered', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = [makeLogEntry({ linkColor: 'blue' })]
+
+    // Act
+    await nextTick()
+
+    // Assert
+    const swatch = wrapper.find('.am-log-row .am-color-swatch')
+    expect(swatch.exists()).toBe(true)
+    expect(swatch.attributes('style')).toMatch(/background:\s*(#3b82f6|rgb\(59,\s*130,\s*246\))/)
+    wrapper.unmount()
+  })
+
+  test('with log entry having no linkColor expect no color swatch', async () => {
+    // Arrange
+    const wrapper = mountAlertManager()
+    useAlertStore().recentLog = [makeLogEntry({ linkColor: null })]
+
+    // Act
+    await nextTick()
+
+    // Assert
+    expect(wrapper.find('.am-log-row .am-color-swatch').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/client/src/components/__tests__/DashboardGridCoverage.spec.js
+++ b/client/src/components/__tests__/DashboardGridCoverage.spec.js
@@ -20,6 +20,7 @@ import { mount }     from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import { useWidgetSettingsStore } from '@/stores/useWidgetSettingsStore.js'
+import { useAlertStore } from '@/stores/useAlertStore.js'
 
 // ── Heavy dep stubs ────────────────────────────────────────────────────────────
 vi.mock('vue3-grid-layout-next', () => ({
@@ -38,6 +39,9 @@ vi.mock('vue3-grid-layout-next', () => ({
 }))
 vi.mock('../WidgetMenu.vue', () => ({
   default: { name: 'WidgetMenu', emits: ['add-widget'], template: '<div />' },
+}))
+vi.mock('../AlertManager.vue', () => ({
+  default: { name: 'AlertManager', props: ['alertEnabledWidgets'], template: '<div class="mock-alert-manager" />' },
 }))
 vi.mock('../WidgetWrapper.vue', () => ({
   default: {
@@ -122,6 +126,114 @@ beforeEach(() => {
     loading: ref(false),
     error:   ref(null),
   }))
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bell icon + badge
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('alert bell icon and badge', () => {
+  test('with no alert-enabled widgets expect badge absent', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    expect(wrapper.find('.alert-badge').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('with 2 alert-enabled widgets expect badge shows "2"', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    wrapper.vm.layout = [
+      { i: 'w1', x: 0, y: 0, w: 6, h: 4, type: 'news-feed',   settings: { alertEnabled: true, alertSound: 'blip' } },
+      { i: 'w2', x: 6, y: 0, w: 6, h: 4, type: 'range-alerts', settings: { alertEnabled: true, alertSound: 'snap' } },
+    ]
+    await nextTick()
+    expect(wrapper.find('.alert-badge').exists()).toBe(true)
+    expect(wrapper.find('.alert-badge').text()).toBe('2')
+    wrapper.unmount()
+  })
+
+  test('bell click toggles widgetSettingsStore.alertManagerOpen', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    const wss = useWidgetSettingsStore()
+    expect(wss.alertManagerOpen).toBe(false)
+    await wrapper.find('[data-testid="alert-bell"]').trigger('click')
+    await nextTick()
+    expect(wss.alertManagerOpen).toBe(true)
+    await wrapper.find('[data-testid="alert-bell"]').trigger('click')
+    await nextTick()
+    expect(wss.alertManagerOpen).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('when alertManagerOpen=true expect AlertManager rendered', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    const wss = useWidgetSettingsStore()
+    wss.alertManagerOpen = true
+    await nextTick()
+    expect(wrapper.find('.mock-alert-manager').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('when alertManagerOpen=false expect AlertManager absent', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    const wss = useWidgetSettingsStore()
+    wss.alertManagerOpen = false
+    await nextTick()
+    expect(wrapper.find('.mock-alert-manager').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('when muted expect bell has alert-bell--muted class', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    const alertStore = useAlertStore()
+    alertStore.muted = true
+    await nextTick()
+    expect(wrapper.find('[data-testid="alert-bell"]').classes()).toContain('alert-bell--muted')
+    wrapper.unmount()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Autoplay blocked banner
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('autoplay blocked banner', () => {
+  test('when audioBlocked=true expect banner rendered', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    const alertStore = useAlertStore()
+    alertStore.audioBlocked = true
+    await nextTick()
+    expect(wrapper.find('.audio-blocked-banner').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('when audioBlocked=false expect banner absent', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    const alertStore = useAlertStore()
+    alertStore.audioBlocked = false
+    await nextTick()
+    expect(wrapper.find('.audio-blocked-banner').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('clicking banner sets audioBlocked=false', async () => {
+    const wrapper = mountGrid()
+    await nextTick()
+    const alertStore = useAlertStore()
+    alertStore.audioBlocked = true
+    await nextTick()
+    await wrapper.find('.audio-blocked-banner').trigger('click')
+    await nextTick()
+    expect(alertStore.audioBlocked).toBe(false)
+    wrapper.unmount()
+  })
 })
 
 afterEach(() => { vi.restoreAllMocks() })


### PR DESCRIPTION
refs #294

## Changes

- `AlertManager.vue` — bell icon panel: master mute, global default sound, active alerts list, recent log
- `DashboardGrid.vue` — bell icon + badge, AlertManager integration, autoplay blocked banner
- `AlertManager.spec.js` — new test file
- `DashboardGridCoverage.spec.js` — bell/badge/banner coverage