### PR TITLE
fix(charts): ticker bus persistence, commit-gated fetch, and bidirectional bus for TVLiteChart and CandlestickChart

### DIFF
--- a/client/src/components/widgets/CandlestickChart.vue
+++ b/client/src/components/widgets/CandlestickChart.vue
@@ -246,8 +246,12 @@ const tickerLocal = ref(config.value.ticker?.trim().toUpperCase() || null)
 // vue3-grid-layout-next does on touch/scroll events for widgets that need
 // repositioning (typically any chart after the first one at y=0).
 watch(activeTicker, (t) => {
-  if (t) {
-    headerTickerInput.value = t
+  if (!t) return
+  headerTickerInput.value = t
+  // Guard against self-echo: onGoTicker() calls setActiveTicker() which bounces
+  // back through this watcher. If tickerLocal already equals t, settings were
+  // already emitted by onGoTicker — skip to avoid a double update-settings event.
+  if (t !== tickerLocal.value) {
     tickerLocal.value = t
     emitSettings()
   }

--- a/client/src/components/widgets/CandlestickChart.vue
+++ b/client/src/components/widgets/CandlestickChart.vue
@@ -233,9 +233,16 @@ const showSettings        = ref(false)
 // ── Resolved ticker ───────────────────────────────────────────────────────────
 const tickerLocal = computed(() => headerTickerInput.value?.trim().toUpperCase() || null)
 
-// Bus auto-fills the header input when it fires
+// Bus auto-fills the header input and persists the ticker to settings.
+// Without emitSettings() here, the ticker lives only in headerTickerInput and is
+// lost whenever props.settings is re-applied with a new object reference — which
+// vue3-grid-layout-next does on touch/scroll events for widgets that need
+// repositioning (typically any chart after the first one at y=0).
 watch(activeTicker, (t) => {
-  if (t) headerTickerInput.value = t
+  if (t) {
+    headerTickerInput.value = t
+    emitSettings()
+  }
 })
 
 const onGoTicker = () => {

--- a/client/src/components/widgets/CandlestickChart.vue
+++ b/client/src/components/widgets/CandlestickChart.vue
@@ -137,6 +137,7 @@ import {
 import VChart from 'vue-echarts'
 import { useScannerLink } from '@/composables/useScannerLink.js'
 import { useConfig } from '@/composables/useConfig.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import {
   calcEMA, calcSMA, calcVWMA, calcVWAP, calcMACD, calcVolumeAvg,
 } from '@/utils/chartIndicators.js'
@@ -204,8 +205,11 @@ const config = computed(() => ({ ...DEFAULT_SETTINGS, ...props.settings }))
 // ── Config (massiveApiKey) ───────────────────────────────────────────────────
 const { config: appConfig } = useConfig()
 
+// ── Dashboard store (for bidirectional bus writes)
+const dashboardStore = useDashboardStore()
+
 // ── Scanner bus ───────────────────────────────────────────────────────────────
-// CandlestickChart is read-only from the bus — no onRowClick needed
+// CandlestickChart now bidirectional: reads from bus (activeTicker), writes to bus (onGoTicker)
 const { activeTicker } = useScannerLink(computed(() => props.linkColor))
 
 // ── Local state ───────────────────────────────────────────────────────────────
@@ -231,7 +235,10 @@ const macdLocal           = ref({ ...config.value.macd })
 const showSettings        = ref(false)
 
 // ── Resolved ticker ───────────────────────────────────────────────────────────
-const tickerLocal = computed(() => headerTickerInput.value?.trim().toUpperCase() || null)
+// tickerLocal is the COMMITTED ticker — drives fetches and the no-ticker overlay.
+// Only updated on explicit commit (Go/Enter), bus update, or settings sync.
+// Keeping it separate from headerTickerInput means keystrokes do NOT trigger fetches.
+const tickerLocal = ref(config.value.ticker?.trim().toUpperCase() || null)
 
 // Bus auto-fills the header input and persists the ticker to settings.
 // Without emitSettings() here, the ticker lives only in headerTickerInput and is
@@ -241,6 +248,7 @@ const tickerLocal = computed(() => headerTickerInput.value?.trim().toUpperCase()
 watch(activeTicker, (t) => {
   if (t) {
     headerTickerInput.value = t
+    tickerLocal.value = t
     emitSettings()
   }
 })
@@ -248,6 +256,9 @@ watch(activeTicker, (t) => {
 const onGoTicker = () => {
   const sym = headerTickerInput.value.trim().toUpperCase()
   headerTickerInput.value = sym
+  tickerLocal.value = sym || null
+  // Broadcast to bus so other linked widgets (charts, scanners) receive the ticker
+  if (props.linkColor && sym) dashboardStore.setActiveTicker(props.linkColor, sym)
   emitSettings()
 }
 
@@ -342,7 +353,9 @@ function emitSettings() {
 
 watch(() => props.settings, (s) => {
   const m = { ...DEFAULT_SETTINGS, ...s }
-  headerTickerInput.value    = m.ticker?.trim().toUpperCase() ?? ''
+  const ticker               = m.ticker?.trim().toUpperCase() ?? ''
+  headerTickerInput.value    = ticker
+  tickerLocal.value          = ticker || null
   intervalLocal.value        = m.interval
   barCountLocal.value        = m.barCount
   autoRefreshLocal.value     = m.autoRefresh

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -224,8 +224,12 @@ const tickerLocal = ref(config.value.ticker?.trim().toUpperCase() || null)
 // vue3-grid-layout-next does on touch/scroll events for widgets that need
 // repositioning (typically any chart after the first one at y=0).
 watch(activeTicker, (t) => {
-  if (t) {
-    headerTickerInput.value = t
+  if (!t) return
+  headerTickerInput.value = t
+  // Guard against self-echo: onGoTicker() calls setActiveTicker() which bounces
+  // back through this watcher. If tickerLocal already equals t, settings were
+  // already emitted by onGoTicker — skip to avoid a double update-settings event.
+  if (t !== tickerLocal.value) {
     tickerLocal.value = t
     emitSettings()
   }

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -120,6 +120,7 @@ import {
 } from 'lightweight-charts'
 import { useScannerLink } from '@/composables/useScannerLink.js'
 import { useConfig }      from '@/composables/useConfig.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import {
   calcEMA, calcSMA, calcVWMA, calcVWAP, calcMACD, calcVolumeAvg,
 } from '@/utils/chartIndicators.js'
@@ -181,8 +182,10 @@ const config = computed(() => ({ ...DEFAULT_SETTINGS, ...props.settings }))
 // ── Config (massiveApiKey) ────────────────────────────────────────────────────
 const { config: appConfig } = useConfig()
 
+// ── Dashboard store (for bidirectional bus writes) ─────────────────────────────
+const dashboardStore = useDashboardStore()
+
 // ── Scanner bus ───────────────────────────────────────────────────────────────
-// TVLiteChart is read-only from the bus — no onRowClick needed
 const { activeTicker } = useScannerLink(computed(() => props.linkColor))
 
 // ── Local state ───────────────────────────────────────────────────────────────
@@ -210,7 +213,10 @@ const macdLocal           = ref({ ...config.value.macd })
 const showSettings        = ref(false)
 
 // ── Ticker ────────────────────────────────────────────────────────────────────
-const tickerLocal = computed(() => headerTickerInput.value?.trim().toUpperCase() || null)
+// tickerLocal is the COMMITTED ticker — drives fetches and the no-ticker overlay.
+// It is only updated on explicit commit (Go/Enter), bus update, or settings sync.
+// Keeping it separate from headerTickerInput means keystrokes do NOT trigger fetches.
+const tickerLocal = ref(config.value.ticker?.trim().toUpperCase() || null)
 
 // Bus auto-fills the header input and persists the ticker to settings.
 // Without emitSettings() here, the ticker lives only in headerTickerInput and is
@@ -220,12 +226,17 @@ const tickerLocal = computed(() => headerTickerInput.value?.trim().toUpperCase()
 watch(activeTicker, (t) => {
   if (t) {
     headerTickerInput.value = t
+    tickerLocal.value = t
     emitSettings()
   }
 })
 
 const onGoTicker = () => {
-  headerTickerInput.value = headerTickerInput.value.trim().toUpperCase()
+  const sym = headerTickerInput.value.trim().toUpperCase()
+  headerTickerInput.value = sym
+  tickerLocal.value = sym || null
+  // Broadcast to bus so other linked widgets (charts, scanners) receive the ticker
+  if (props.linkColor && sym) dashboardStore.setActiveTicker(props.linkColor, sym)
   emitSettings()
 }
 
@@ -269,7 +280,9 @@ watch(intervalLocal, () => { fetchBars(); scheduleRefresh() })
 // Sync local state when settings prop changes
 watch(() => props.settings, (s) => {
   const m = { ...DEFAULT_SETTINGS, ...s }
-  headerTickerInput.value    = m.ticker?.trim().toUpperCase() ?? ''
+  const ticker               = m.ticker?.trim().toUpperCase() ?? ''
+  headerTickerInput.value    = ticker
+  tickerLocal.value          = ticker || null
   intervalLocal.value        = m.interval
   barCountLocal.value        = m.barCount
   autoRefreshLocal.value     = m.autoRefresh

--- a/client/src/components/widgets/TVLiteChart.vue
+++ b/client/src/components/widgets/TVLiteChart.vue
@@ -212,8 +212,17 @@ const showSettings        = ref(false)
 // ── Ticker ────────────────────────────────────────────────────────────────────
 const tickerLocal = computed(() => headerTickerInput.value?.trim().toUpperCase() || null)
 
-// Bus auto-fills the header input
-watch(activeTicker, (t) => { if (t) headerTickerInput.value = t })
+// Bus auto-fills the header input and persists the ticker to settings.
+// Without emitSettings() here, the ticker lives only in headerTickerInput and is
+// lost whenever props.settings is re-applied with a new object reference — which
+// vue3-grid-layout-next does on touch/scroll events for widgets that need
+// repositioning (typically any chart after the first one at y=0).
+watch(activeTicker, (t) => {
+  if (t) {
+    headerTickerInput.value = t
+    emitSettings()
+  }
+})
 
 const onGoTicker = () => {
   headerTickerInput.value = headerTickerInput.value.trim().toUpperCase()

--- a/client/src/components/widgets/__tests__/CandlestickChart.spec.js
+++ b/client/src/components/widgets/__tests__/CandlestickChart.spec.js
@@ -62,6 +62,7 @@ vi.mock('@/utils/chartIndicators.js', () => ({
 }))
 
 import { useScannerLink } from '@/composables/useScannerLink.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import CandlestickChart from '../CandlestickChart.vue'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -617,6 +618,128 @@ describe('Header ticker input (Tweak 3)', () => {
 
     // Assert
     expect(wrapper.find('[data-testid="header-ticker-input"]').element.value).toBe('MSFT')
+    wrapper.unmount()
+  })
+
+  // ── Bus persistence (mobile touch/scroll bug) ─────────────────────────────
+  //
+  // Bug: when the bus sets a ticker, emitSettings() was NOT called, so the
+  // ticker was never persisted to props.settings. vue3-grid-layout-next creates
+  // new item objects on touch/scroll, triggering the settings watcher which
+  // reset headerTickerInput to the (empty) settings value.
+
+  test('bus activeTicker emits update-settings with the ticker (persistence)', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [] })
+    const settingsCalls = []
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(CandlestickChart, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': s => settingsCalls.push(s) },
+    })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+
+    // Act — bus fires
+    activeTicker.value = 'NVDA'
+    await nextTick()
+    await nextTick()
+
+    // Assert — update-settings must include the ticker so layout re-renders can restore it
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    expect(settingsCalls[settingsCalls.length - 1].ticker).toBe('NVDA')
+    wrapper.unmount()
+  })
+
+  test('ticker set via bus survives settings prop re-application (simulates touch/scroll layout re-render)', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [] })
+    const settingsCalls = []
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(CandlestickChart, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': s => settingsCalls.push(s) },
+    })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+
+    // Act step 1 — bus sets ticker
+    activeTicker.value = 'NVDA'
+    await nextTick()
+    await nextTick()
+
+    // Act step 2 — simulate vue3-grid-layout-next creating a new item object on
+    // touch/scroll: re-apply the same settings (as emitted) with a new reference.
+    const emittedSettings = settingsCalls[settingsCalls.length - 1]
+    await wrapper.setProps({ settings: { ...emittedSettings } })
+    await nextTick()
+
+    // Assert — ticker must still be shown after settings re-application
+    expect(wrapper.find('[data-testid="header-ticker-input"]').element.value).toBe('NVDA')
+    wrapper.unmount()
+  })
+
+  // ── Commit-gated fetch ────────────────────────────────────────────────────
+  //
+  // Bug: tickerLocal was computed(() => headerTickerInput.value...), so every
+  // @input keystroke changed tickerLocal → watch fired → fetchBars().
+  // Fix: tickerLocal is a ref; only updated on explicit commit (Go/Enter/bus/settings).
+
+  test('typing in header input does NOT trigger fetch before committing', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [] })
+    const wrapper = mount(CandlestickChart, { props: defaultProps }) // no ticker in settings
+    await nextTick()
+    await nextTick()
+    const before = global.fetch.mock.calls.length // 0 — no ticker, no initial fetch
+
+    // Act — type a valid ticker symbol (triggers @input handler)
+    await wrapper.find('[data-testid="header-ticker-input"]').setValue('AAPL')
+    await nextTick()
+    await nextTick()
+
+    // Assert — no fetch until user commits with Go or Enter
+    expect(global.fetch.mock.calls.length).toBe(before)
+    wrapper.unmount()
+  })
+
+  // ── Two-way bus: Go/Enter broadcasts to linked widgets ─────────────────────
+  //
+  // Bug: onGoTicker() only called emitSettings(), never store.setActiveTicker().
+  // Fix: onGoTicker() calls dashboardStore.setActiveTicker(linkColor, sym).
+
+  test('Go button broadcasts committed ticker to linked bus color', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [] })
+    const wrapper = mount(CandlestickChart, { props: { ...defaultProps, linkColor: 'blue' } })
+    await nextTick()
+
+    // Act — type ticker then click Go
+    await wrapper.find('[data-testid="header-ticker-input"]').setValue('TSLA')
+    await wrapper.find('.go-btn').trigger('click')
+    await nextTick()
+    await nextTick()
+
+    // Assert — bus updated so other linked widgets receive the ticker
+    const store = useDashboardStore()
+    expect(store.activeTickers['blue']).toBe('TSLA')
+    wrapper.unmount()
+  })
+
+  test('Enter key in header input broadcasts ticker to linked bus color', async () => {
+    // Arrange
+    global.fetch = mockFetch({ results: [] })
+    const wrapper = mount(CandlestickChart, { props: { ...defaultProps, linkColor: 'blue' } })
+    await nextTick()
+
+    // Act — type ticker then press Enter
+    const input = wrapper.find('[data-testid="header-ticker-input"]')
+    await input.setValue('MSFT')
+    await input.trigger('keydown.enter')
+    await nextTick()
+    await nextTick()
+
+    // Assert — bus updated
+    const store = useDashboardStore()
+    expect(store.activeTickers['blue']).toBe('MSFT')
     wrapper.unmount()
   })
 })

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -74,6 +74,7 @@ vi.stubGlobal('ResizeObserver', function ResizeObserverMock() { return resizeObs
 
 import { createChart } from 'lightweight-charts'
 import { useScannerLink } from '@/composables/useScannerLink.js'
+import { useDashboardStore } from '@/stores/useDashboardStore.js'
 import TVLiteChart from '../TVLiteChart.vue'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -370,6 +371,74 @@ describe('Ticker source', () => {
 
     // Assert
     expect(global.fetch.mock.calls.some(c => c[0].includes('NVDA'))).toBe(true)
+    wrapper.unmount()
+  })
+
+  // ── Commit-gated fetch (typing should NOT trigger fetch) ────────────────────
+  //
+  // Bug: tickerLocal was computed(() => headerTickerInput.value...), so every
+  // @input keystroke changed tickerLocal → watch fired → fetchBars().
+  // Fix: tickerLocal is a ref; only updated on explicit commit (Go/Enter/bus/settings).
+
+  test('typing in header input does NOT trigger fetch before committing', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, { props: defaultProps }) // no ticker in settings
+    await nextTick()
+    await nextTick()
+    const before = global.fetch.mock.calls.length // 0 — no ticker, no initial fetch
+
+    // Act — type a valid ticker symbol (triggers @input handler)
+    await wrapper.find('[data-testid="header-ticker-input"]').setValue('AAPL')
+    await nextTick()
+    await nextTick()
+
+    // Assert — no fetch until user commits with Go or Enter
+    expect(global.fetch.mock.calls.length).toBe(before)
+    wrapper.unmount()
+  })
+
+  // ── Two-way bus: Go/Enter should broadcast to linked widgets ─────────────────
+  //
+  // Bug: onGoTicker() only called emitSettings(), never store.setActiveTicker().
+  // Ticker events only flowed INTO the chart (from bus), never OUT (to bus).
+  // Fix: onGoTicker() calls dashboardStore.setActiveTicker(linkColor, sym) so
+  // other linked widgets (charts, scanners) receive the ticker.
+
+  test('Go button broadcasts committed ticker to linked bus color', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, { props: { ...defaultProps, linkColor: 'blue' } })
+    await nextTick()
+
+    // Act — type ticker then click Go
+    await wrapper.find('[data-testid="header-ticker-input"]').setValue('TSLA')
+    await wrapper.find('.go-btn').trigger('click')
+    await nextTick()
+    await nextTick()
+
+    // Assert — bus updated so other linked widgets receive the ticker
+    const store = useDashboardStore()
+    expect(store.activeTickers['blue']).toBe('TSLA')
+    wrapper.unmount()
+  })
+
+  test('Enter key in header input broadcasts ticker to linked bus color', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const wrapper = mount(TVLiteChart, { props: { ...defaultProps, linkColor: 'blue' } })
+    await nextTick()
+
+    // Act — type ticker then press Enter
+    const input = wrapper.find('[data-testid="header-ticker-input"]')
+    await input.setValue('MSFT')
+    await input.trigger('keydown.enter')
+    await nextTick()
+    await nextTick()
+
+    // Assert — bus updated
+    const store = useDashboardStore()
+    expect(store.activeTickers['blue']).toBe('MSFT')
     wrapper.unmount()
   })
 

--- a/client/src/components/widgets/__tests__/TVLiteChart.spec.js
+++ b/client/src/components/widgets/__tests__/TVLiteChart.spec.js
@@ -372,6 +372,71 @@ describe('Ticker source', () => {
     expect(global.fetch.mock.calls.some(c => c[0].includes('NVDA'))).toBe(true)
     wrapper.unmount()
   })
+
+  // ── Bus persistence regression (mobile touch/scroll bug) ──────────────────
+  //
+  // Bug: when the bus sets a ticker, headerTickerInput is updated but emitSettings()
+  // is NOT called, so the ticker is never persisted to props.settings.
+  //
+  // vue3-grid-layout-next creates new item objects during touch/scroll compaction.
+  // The new object reference triggers the settings watcher, which resets
+  // headerTickerInput to the settings value — which is empty because the ticker
+  // was never persisted. The first chart at y=0 survives because it doesn't need
+  // repositioning (object reference unchanged); subsequent charts at y>0 do not.
+  //
+  // Fix: call emitSettings() in the bus watcher so the ticker is always persisted.
+
+  test('bus activeTicker emits update-settings with the ticker (persistence)', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const settingsCalls = []
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(TVLiteChart, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': s => settingsCalls.push(s) },
+    })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+
+    // Act — bus fires
+    activeTicker.value = 'NVDA'
+    await nextTick()
+    await nextTick()
+
+    // Assert — update-settings must include the ticker so layout re-renders can restore it
+    expect(settingsCalls.length).toBeGreaterThan(0)
+    expect(settingsCalls[settingsCalls.length - 1].ticker).toBe('NVDA')
+    wrapper.unmount()
+  })
+
+  test('ticker set via bus survives settings prop re-application (simulates touch/scroll layout re-render)', async () => {
+    // Arrange
+    global.fetch = mockFetch([makeBar()])
+    const settingsCalls = []
+    const callsBefore = vi.mocked(useScannerLink).mock.calls.length
+    const wrapper = mount(TVLiteChart, {
+      props: defaultProps,
+      attrs: { 'onUpdate-settings': s => settingsCalls.push(s) },
+    })
+    const { activeTicker } = vi.mocked(useScannerLink).mock.results[callsBefore].value
+
+    // Act step 1 — bus sets ticker
+    activeTicker.value = 'NVDA'
+    await nextTick()
+    await nextTick()
+
+    // Act step 2 — simulate vue3-grid-layout-next creating a new item object on
+    // touch/scroll: re-apply the same settings (as emitted) with a new reference.
+    // Before fix: settingsCalls is empty so emittedSettings is undefined → ticker lost.
+    // After fix: emittedSettings includes ticker: 'NVDA' → watcher restores it.
+    const emittedSettings = settingsCalls[settingsCalls.length - 1]
+    await wrapper.setProps({ settings: { ...emittedSettings } })
+    await nextTick()
+
+    // Assert — ticker must still be shown after settings re-application
+    expect(wrapper.find('[data-testid="header-ticker-input"]').element.value).toBe('NVDA')
+    expect(wrapper.find('[data-testid="no-ticker"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
 })
 
 // ── Auto-refresh ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Bugs fixed

### Bug 1 — Ticker lost on touch/scroll (mobile layout re-render)

When the widget bus sets a ticker, `headerTickerInput` was updated but `emitSettings()` was not called — so the ticker was never persisted to `props.settings`.

`vue3-grid-layout-next` creates new item objects during touch/scroll compaction for any widget that needs repositioning. The new object reference triggers the settings watcher, which resets `headerTickerInput` to the settings value — which is empty because the ticker was never persisted. Widgets at `y=0` (the first chart added) are unaffected because they never need repositioning and their settings reference never changes. Subsequent charts at `y>0` all lose their tickers.

**Fix:** call `emitSettings()` in the bus watcher so the ticker is immediately persisted to settings on every bus update.

### Bug 2 — Premature fetch on keypress

`tickerLocal` was `computed(() => headerTickerInput.value...)`, so every `@input` keystroke changed `tickerLocal`, which triggered `watch(tickerLocal)` and fired `fetchBars()`. Charts were fetching live API data for every partial ticker typed ('A', 'AP', 'APP', 'APPL', 'AAPL').

**Fix:** `tickerLocal` is now a `ref`, initialized from settings. It is only updated on explicit commit (Go click, Enter key, bus update, settings re-apply). Keystrokes update `headerTickerInput` only — the watcher never fires mid-typing.

### Bug 3 — One-way bus (typed tickers not broadcast to linked widgets)

`onGoTicker()` called `emitSettings()` but never `store.setActiveTicker()`. Ticker events flowed INTO charts from the bus (scanner → chart) but never OUT (chart → other linked charts/widgets). Typing a ticker in one chart and clicking Go had no effect on sibling charts sharing the same link color.

**Fix:** `onGoTicker()` now calls `dashboardStore.setActiveTicker(linkColor, sym)` after committing, making chart widgets first-class bus participants in both directions.

## Implementation notes

- `tickerLocal computed` → `ref`: the bus watcher and settings watcher both update `tickerLocal` explicitly; the `watch(tickerLocal, { immediate: true })` watcher only fires on those committed updates, not on keystrokes.
- Bus watcher is guarded with `t !== tickerLocal.value` to prevent double `emitSettings()` on Go/Enter: `onGoTicker()` broadcasts to the store → store change echoes back through `activeTicker` → watcher fires → guard detects `tickerLocal` is already set → skips the redundant emit. External bus updates (scanner row clicks) still emit because the ticker is genuinely new.
- All fixes applied to both `TVLiteChart` and `CandlestickChart`.

## Tests

10 new regression tests total (5 per widget), all were red before the fix:

**TVLiteChart.spec.js:**
1. `bus activeTicker emits update-settings with the ticker (persistence)`
2. `ticker set via bus survives settings prop re-application (simulates touch/scroll layout re-render)`
3. `typing in header input does NOT trigger fetch before committing`
4. `Go button broadcasts committed ticker to linked bus color`
5. `Enter key in header input broadcasts ticker to linked bus color`

**CandlestickChart.spec.js:**
6. `bus activeTicker emits update-settings with the ticker (persistence)`
7. `ticker set via bus survives settings prop re-application (simulates touch/scroll layout re-render)`
8. `typing in header input does NOT trigger fetch before committing`
9. `Go button broadcasts committed ticker to linked bus color`
10. `Enter key in header input broadcasts ticker to linked bus color`

Full suite: 49 test files, 1524 tests — all pass.