### PR TITLE
docs: add Development section covering Vue DevTools and Pinia state inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,76 @@ The platform consists of four main packages:
 - **Frontend Application** ([kuhl-haus-mdp-app](https://github.com/kuhl-haus/kuhl-haus-mdp-app)) — Web-based user interface and API *(this repo)*
 - **Deployment Automation** ([kuhl-haus-mdp-deployment](https://github.com/kuhl-haus/kuhl-haus-mdp-deployment)) — Docker Compose, Ansible playbooks and Kubernetes manifests for environment provisioning
 
+## Development
+
+### Pinia State Inspection with Vue DevTools
+
+Install the [Vue DevTools browser extension](https://devtools.vuejs.org/) (Chrome/Edge/Firefox).
+DevTools hooks are only active in dev builds — they are compiled out of production bundles entirely.
+
+**Start the dev server** (devtools enabled automatically):
+
+```bash
+npm run dev
+```
+
+To produce a built artifact with devtools intact (e.g. for staging):
+
+```bash
+vite build --mode development
+```
+
+#### How Vue knows it's in production
+
+Vite replaces the global `__DEV__` flag at build time — `true` in development, `false` in production.
+The bundler then tree-shakes all `if (__DEV__)` branches from the production bundle, so devtools
+hooks and Pinia's `mutation.events` don't exist in production at all.
+
+#### Observing mutation history in the Timeline tab
+
+DevTools → **Timeline** is the Pinia mutation log. Every state change emits a `Pinia 🍍` event
+showing the store id, the action that triggered it, a timestamp, and a before/after state diff.
+You can scrub back through events to see exactly what changed and when.
+
+#### Programmatic observation with `$subscribe`
+
+```js
+const store = useWidgetSettingsStore()
+
+store.$subscribe((mutation, state) => {
+  console.log(mutation.type)    // 'direct' | 'patch object' | 'patch function'
+  console.log(mutation.storeId) // store name
+  console.log(mutation.events)  // before/after values — dev mode only
+  console.log(state)            // full state snapshot after mutation
+})
+```
+
+> `mutation.events` is only populated in dev mode. It is compiled out of production builds at
+> the Pinia source level and cannot be re-enabled at runtime.
+
+#### Tracing which action caused a state change
+
+```js
+store.$onAction(({ name, args, after, onError }) => {
+  console.log(`action: ${name}`, args)
+  after((result) => console.log('completed', result))
+  onError((error) => console.error('failed', error))
+})
+```
+
+#### Verifying devtools are active
+
+```js
+// In the browser console — defined and populated means devtools are active:
+window.__VUE_DEVTOOLS_GLOBAL_HOOK__
+```
+
+#### `pinia-plugin-persistedstate` tip
+
+State changes that trigger a `localStorage` write show up in the Timeline as a `patch object`
+mutation. Use this to confirm persistence is firing without digging through Application →
+Local Storage.
+
 ## Documentation
 
 For architecture details, component descriptions, and API reference, see the

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ hooks and Pinia's `mutation.events` don't exist in production at all.
 #### Observing mutation history in the Timeline tab
 
 DevTools → **Timeline** is the Pinia mutation log. Every state change emits a `Pinia 🍍` event
-showing the store id, the action that triggered it, a timestamp, and a before/after state diff.
+showing the store id, the action that triggered it (if applicable), a timestamp, and a before/after state diff.
 You can scrub back through events to see exactly what changed and when.
 
 #### Programmatic observation with `$subscribe`
@@ -133,9 +133,10 @@ window.__VUE_DEVTOOLS_GLOBAL_HOOK__
 
 #### `pinia-plugin-persistedstate` tip
 
-State changes that trigger a `localStorage` write show up in the Timeline as a `patch object`
-mutation. Use this to confirm persistence is firing without digging through Application →
-Local Storage.
+`pinia-plugin-persistedstate` subscribes to all mutations via `$subscribe` and writes to
+`localStorage` after every mutation regardless of type. In the Timeline, you'll see a
+`Pinia 🍍` event for each mutation; to confirm the write actually landed, check
+Application → Local Storage for the `widgetSettings` key after triggering an action.
 
 ## Documentation
 


### PR DESCRIPTION
Adds a **Development** section to the README covering Vue DevTools setup and Pinia state inspection.

## What's included

- How to enable devtools (`npm run dev` vs `vite build --mode development`)
- How Vue/Vite detects production (`__DEV__` flag + tree-shaking)
- Observing mutation history in the DevTools Timeline tab
- Programmatic observation with `$subscribe` (including the dev-only `mutation.events` caveat)
- Tracing which action caused a state change with `$onAction`
- Verifying devtools are active in the browser console
- `pinia-plugin-persistedstate` tip for confirming localStorage writes

refs #278