### PR TITLE
fix(mobile): rework header layout and fix chart height chain

### DIFF
--- a/client/src/components/DashboardGrid.vue
+++ b/client/src/components/DashboardGrid.vue
@@ -1,10 +1,11 @@
 <template>
   <header class="dashboard-header">
+    <!-- Title + connection status (always visible) -->
     <h1 class="dashboard-title">Stock Scanner Dashboard</h1>
     <div v-if="appConfig" class="status success">Connected</div>
     <div v-else class="status error">Error</div>
 
-    <!-- Mobile toolbar: layout selector + lock + widget add -->
+    <!-- Mobile toolbar: layout selector + all controls -->
     <div v-if="appConfig && isMobile" class="layout-controls layout-controls--mobile">
       <!-- Layout load dropdown -->
       <div class="custom-select custom-select--mobile" ref="selectContainerMobile">
@@ -1407,19 +1408,49 @@ defineExpose({ dashboardColNum, layout, addWidget, saveLayout, saveLayoutName, l
 
 /* ── Mobile (< 640px) ── */
 @media (max-width: 639px) {
-  .dashboard-title { font-size: 15px; }
+  /* Header: allow content to wrap so toolbar drops to its own row */
+  .dashboard-header {
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    padding: 4px 6px;
+    overflow: visible;
+  }
 
+  .dashboard-header h1 {
+    font-size: 14px;
+    white-space: nowrap;
+  }
+
+  /* Version: shrink font, don't force a full-width line */
+  .app-version {
+    font-size: 11px;
+    margin-left: auto;
+    white-space: nowrap;
+  }
+
+  /* Toolbar: always on its own full-width row below title */
   .layout-controls--mobile {
     display: flex;
     align-items: center;
-    gap: 4px;
-    flex-wrap: wrap;
+    gap: 6px;
+    flex-wrap: nowrap;    /* buttons stay on one row, scroll if needed */
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: visible;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;  /* hide scrollbar on Firefox */
+    padding-bottom: 2px;    /* breathing room for scrollbar on iOS */
+  }
+
+  .layout-controls--mobile::-webkit-scrollbar {
+    display: none;          /* hide scrollbar on WebKit */
   }
 
   .custom-select--mobile {
     min-width: 110px;
     max-width: 150px;
     position: relative;
+    flex-shrink: 0;
   }
 
   .custom-select--mobile .select-trigger {
@@ -1432,6 +1463,18 @@ defineExpose({ dashboardColNum, layout, addWidget, saveLayout, saveLayoutName, l
     z-index: 9999;
   }
 
+  /* Buttons: Apple HIG 44pt minimum touch target */
+  .btn-icon {
+    padding: 0;
+    min-width: 44px;
+    min-height: 44px;
+    font-size: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
   .mobile-stack {
     display: flex;
     flex-direction: column;
@@ -1441,7 +1484,6 @@ defineExpose({ dashboardColNum, layout, addWidget, saveLayout, saveLayoutName, l
 
   .mobile-widget {
     width: 100%;
-    /* Fixed heights per widget type handled by inner widget */
   }
 
   .mobile-widget .widget-wrapper {

--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -281,14 +281,23 @@ const freshnessIcon = computed(() => {
   overflow: auto;
 }
 
-/* Mobile: fixed height so flex children (charts) have a concrete size to fill */
+/* Mobile: fixed height so flex children (charts) have a concrete size to fill.
+   The widget-header is ~32px; leave the rest for widget-content. */
 .widget-wrapper--mobile {
   height: 420px;
+  min-height: 420px;
 }
 
 .widget-wrapper--mobile .widget-content {
-  flex: 1;
+  /* Explicit pixel height = wrapper height minus header height.
+     Charts (TVLiteChart, CandlestickChart) call clientHeight on their
+     container at mount time. If that resolves to 0 — which happens when
+     overflow:hidden collapses the flex chain before layout paint —
+     they render invisible. Explicit height + overflow:auto ensures the
+     container has a real, non-zero size before the chart initialises. */
+  height: 388px;   /* 420px wrapper − 32px header − ~0px borders */
   min-height: 0;
-  overflow: hidden;
+  overflow: auto;
+  flex: none;      /* don't let flex override the explicit height */
 }
 </style>


### PR DESCRIPTION
## Mobile fixes — three issues addressed

### 1. Charts not rendering on mobile (root cause fixed)

`widget-content` had `overflow: hidden` on mobile. This collapsed the flex chain before browser layout paint, so chart widgets called `clientHeight` at mount time and got `0`. Both TVLiteChart and CandlestickChart rendered invisibly — TVLiteChart's `|| 300` fallback from the previous commit only covered the `createChart()` call, not the container's actual painted height.

**Fix:** Replace `overflow: hidden` + `flex: 1` with `height: 388px` (420px wrapper − 32px header) + `overflow: auto` + `flex: none`. Both chart widgets use `height: 100%` → `flex: 1; min-height: 0` → chart container internally, which now resolves against a real non-zero pixel height.

### 2. Mobile header: all controls visible, version not clipped

The header is a flat `flex` row with no `flex-wrap`. On a phone (375–430px wide), title + status badge + mobile toolbar + version badge all fight for one row. Controls wrap but overflow invisibly; version hangs off-screen.

**Fix:** Enable `flex-wrap` on `.dashboard-header` for mobile. The toolbar (`.layout-controls--mobile`) becomes a full-width second row via `width: 100%`. It's `overflow-x: auto` with hidden scrollbar, so all buttons (layout dropdown, 💾, 🔄/⏸, 🔒, add widget) are reachable by horizontal swipe. Version badge stays in the top row via `margin-left: auto`.

### 3. Resize handle (Bishop's blocking comment, already merged)

Wrapped `.vue-resizable-handle` override in `@media (hover: none) and (pointer: coarse)` so the 44×44px touch target applies only on touchscreens.

### 4. Button touch targets

All `.btn-icon` on mobile get `min-width: 44px; min-height: 44px` (Apple HIG minimum).

---

All 1526 tests pass.
