### PR TITLE
fix(mobile): give widget-content explicit pixel height so charts render on iOS Safari

### DIFF
--- a/client/src/components/WidgetWrapper.vue
+++ b/client/src/components/WidgetWrapper.vue
@@ -281,14 +281,29 @@ const freshnessIcon = computed(() => {
   overflow: auto;
 }
 
-/* Mobile: fixed height so flex children (charts) have a concrete size to fill */
+/* Mobile: fixed heights so chart widgets get a definite pixel height.
+
+   iOS Safari does not resolve height:100% against a flex-grown parent
+   (flex:1 without an explicit pixel height is not a "definite" height
+   in the CSS spec). Chart widgets call clientHeight at mount and get 0,
+   rendering invisible. The fix: give every element in the chain a
+   concrete pixel height so percentage resolution is unambiguous.
+
+   widget-wrapper--mobile : 420px  (set here)
+   widget-content         : 388px  (420 - 32px header)
+   chart widget           : height:100% resolves to 388px  ✓
+   chart-container        : flex:1 resolves within 388px   ✓
+*/
 .widget-wrapper--mobile {
   height: 420px;
+  min-height: 420px;  /* belt-and-suspenders: prevent flex shrink from parent */
+  flex-shrink: 0;
 }
 
 .widget-wrapper--mobile .widget-content {
-  flex: 1;
+  height: 388px;      /* explicit px — percentage resolution works on all browsers */
   min-height: 0;
-  overflow: hidden;
+  overflow: auto;
+  flex: none;         /* don't let flex override the explicit height */
 }
 </style>


### PR DESCRIPTION
## Problem

iOS Safari does not resolve `height: 100%` against a flex-grown parent. `flex: 1` with no explicit pixel height is not a "definite" height per the CSS spec, so child elements that use `height: 100%` get 0.

Both `TVLiteChart` and `CandlestickChart` call `clientHeight` on their chart container at mount time to size the canvas. When that returns 0, the chart creates a 0px canvas and renders invisible. The `ResizeObserver` does eventually fire, but by then lightweight-charts has already committed to a zero-size layout.

## Fix

Replace `flex: 1` on `.widget-wrapper--mobile .widget-content` with an explicit `height: 388px` (420px wrapper − 32px header). Every element in the chain now has a concrete pixel height:

```
.mobile-widget            → height: auto (wraps content)
  .widget-wrapper--mobile → height: 420px  ← was already set
    .widget-header        → height: ~32px  (flex-shrink: 0)
    .widget-content       → height: 388px  ← this is the fix
      chart widget        → height: 100% resolves to 388px ✓
        .chart-container  → flex: 1 resolves within 388px  ✓
```

Also adds `flex-shrink: 0` and `min-height: 420px` to `.widget-wrapper--mobile` so a flex parent cannot shrink the wrapper below its intended height.

## Scope

One file, two CSS rules changed. 1526/1526 tests pass.